### PR TITLE
Add account-aware Responses WebSocket modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,16 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -260,11 +269,13 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "libc",
  "rand",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "toml_edit",
@@ -296,11 +307,46 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -395,9 +441,20 @@ checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1033,6 +1090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1195,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1259,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1313,6 +1413,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,6 +1448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1464,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,14 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-rustls = { version = "0.27", features = ["http1", "http2", "webpki-roots"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "server", "tokio"] }
+libc = "0.2"
 rand = "0.9"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
+tokio-tungstenite = { version = "0.28", default-features = false, features = ["handshake"] }
 toml = "0.9"
 toml_edit = "0.23"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Workers of all accounts, unite.
 
-Comradex is a small Rust relay that gives the native Codex App/CLI a sticky, quota-aware collective of ChatGPT accounts without rewriting Codex sessions, rollouts, Responses payloads, SSE events, or WebSocket frames.
+Comradex is a small Rust relay that gives the native Codex App/CLI a sticky, quota-aware collective of ChatGPT accounts without rewriting Codex sessions or rollouts. Raw mode preserves Responses WebSocket bytes; the two frame-aware modes intentionally inspect and, where required for safe recovery, reframe Responses traffic.
 
 The current implementation intentionally supports only native Codex traffic. It has no provider translation, request history, GUI, telemetry, or conversation cache.
 
@@ -22,7 +22,19 @@ In another terminal, install the listener into Codex's existing config:
 cargo run -- install --codex-config "$CODEX_HOME/config.toml"
 ```
 
-This changes only the root `openai_base_url`. It never sets `model_provider` and never reads or writes `sessions/` or `rollouts/`. `uninstall` restores the previous value, but refuses if somebody changed it after installation.
+This changes only the root `openai_base_url`. It preserves a symlinked `config.toml` (including dotfiles-managed configurations), never sets `model_provider`, and never reads or writes `sessions/` or `rollouts/`. Reinstalling updates the Comradex URL without losing the original pre-Comradex value. `uninstall` restores that original value, but refuses if somebody changed it after installation.
+
+On macOS, an installed Comradex binary can manage its own LaunchAgent:
+
+```sh
+comradex --config /absolute/path/to/comradex.toml service install
+comradex --config /absolute/path/to/comradex.toml service status
+comradex service uninstall
+```
+
+The service installer records the exact executable and configuration paths, validates the generated plist, starts the daemon at login, and writes logs beneath Comradex's state directory. Installation waits for launchd to report a running PID and verifies every configured listener with a Comradex-specific HTTP probe; a failed replacement restores the previous Comradex plist and loaded job when possible. It manages only `com.nicosuave.comradex`: it does not inspect, stop, or remove OpenCodex or any other relay. Stop OpenCodex first if it owns the same listener port. Codex configuration installation and service installation remain separate reversible operations.
+
+`service status` reports whether launchd currently has a running Comradex process. `SIGTERM` stops the listeners, aborts and joins tracked HTTP/WebSocket connection tasks, clears in-flight counters, and only then writes final affinity, file-owner, and statistics snapshots. Active requests are terminated rather than gracefully completed during shutdown.
 
 The generated configuration contains the special `caller` account. It forwards the Codex App's inbound `Authorization` and `ChatGPT-Account-Id` headers and never stores or refreshes them.
 
@@ -43,13 +55,23 @@ Then authenticate through the official client:
 cargo run -- login personal_2
 ```
 
-That executes `codex login --device-auth` with `CODEX_HOME` set to the isolated directory. The daemon reads its `auth.json` for each request, derives a missing account ID from the ID-token claims, and uses Codex's current OAuth refresh contract when the access token is near expiry or receives a 401. Refreshes are single-flight per isolated account and atomically rotate `auth.json`; inbound caller credentials remain unmanaged.
+That executes `codex login --device-auth` with `CODEX_HOME` set to the isolated directory. Absolute account paths are used unchanged; relative account paths are resolved against the canonical directory containing `comradex.toml`, just like a relative `proxy.state_dir`. The daemon reads its `auth.json` for each request, derives a missing account ID from the ID-token claims, and uses Codex's current OAuth refresh contract when the access token is near expiry or receives a 401. Refreshes are single-flight per isolated account and atomically rotate `auth.json`; inbound caller credentials remain unmanaged.
 
 ## Routing contract
 
 Routing recognizes client turn state, accepted Codex session/conversation headers, parent-thread and turn-metadata IDs, request `client_metadata.thread_id`, `previous_response_id`, and `prompt_cache_key`. Values are persisted only as keyed BLAKE3 hashes. Conflicting hard owners and unknown previous-response/turn-state anchors fail closed instead of crossing accounts.
 
-Existing healthy bindings stay put even after usage crosses `switch_at`. The threshold controls only admission of new threads. A pre-output quota response, genuine connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Successful or ambiguous Live Voice creation is never replayed. A managed-account 401 gets one same-account refresh retry; a 401/403 never crosses accounts, and no response is retried after headers or body bytes have reached the client. `Retry-After` and primary/secondary reset windows bound quota cooldowns.
+Uploaded Codex files are account-owned. Comradex records the creating account from successful `/files` responses, pins `/files/{file_id}/uploaded` finalization and Responses requests containing `file_id` to that account, and fails closed for conflicting or partially-known multi-file ownership. Raw file IDs are hashed in a separate bounded `file-owners.json` snapshot and are never persisted directly; account authentication failures do not erase ownership. HTTP requests and the frame-aware WebSocket modes enforce file ownership found in request bodies; raw WebSocket mode intentionally cannot inspect frame-local file IDs.
+
+Responses WebSocket behavior is selected with `proxy.responses_websocket_mode`:
+
+- `raw` is the default and preserves the original handshake-pinned byte relay. One account owns the socket, and Comradex does not inspect its frames.
+- `http_bridge` accepts downstream WebSocket frames and sends each `response.create` through the account-aware HTTP/SSE pipeline. It supersedes an older in-flight turn when a new create arrives and converts bounded, validated SSE or JSON lifecycle events back into WebSocket text frames.
+- `direct` keeps upstream WebSocket transport while routing and tracking each `response.create` frame independently. It supports multiplexed, out-of-order turns, reconnects only before visible output, refreshes an expired credential on the same account before considering one alternate, and can remove a stale `previous_response_id` only when the request contains a verified self-contained full resend.
+
+Live Voice upgrades are separate from these modes and remain raw, call-bound relays.
+
+Existing healthy bindings stay put even after usage crosses `switch_at`. The threshold controls only admission of new threads. A pre-output quota response, genuine connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Successful or ambiguous Live Voice creation is never replayed. On HTTP, a managed-account 401 gets one same-account refresh retry and a 401/403 never crosses accounts. Direct WebSocket mode uses the explicit refresh-then-alternate sequence described above. No response is retried after visible output. `Retry-After` and primary/secondary/tertiary reset windows bound quota cooldowns.
 
 Requests up to 256 KiB are replayed from memory by default; larger requests use a temporary file and all bodies have a hard cap. Responses and upgraded streams are forwarded with backpressure and are never retained.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,15 @@ fn default_flush_seconds() -> u64 {
     5
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponsesWebsocketMode {
+    #[default]
+    Raw,
+    HttpBridge,
+    Direct,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
@@ -62,6 +71,8 @@ pub struct ProxyConfig {
     pub max_inflight: usize,
     #[serde(default = "default_upgrades")]
     pub max_upgrades: usize,
+    #[serde(default)]
+    pub responses_websocket_mode: ResponsesWebsocketMode,
     #[serde(default = "default_replay_memory")]
     pub replay_memory_bytes: usize,
     #[serde(default = "default_request_limit")]
@@ -91,6 +102,7 @@ impl Default for ProxyConfig {
             switch_at: default_switch(),
             max_inflight: default_inflight(),
             max_upgrades: default_upgrades(),
+            responses_websocket_mode: ResponsesWebsocketMode::Raw,
             replay_memory_bytes: default_replay_memory(),
             max_request_bytes: default_request_limit(),
             max_spool_bytes: default_global_spool(),
@@ -125,12 +137,33 @@ pub enum AccountConfig {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self> {
-        let text = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        let config_path =
+            fs::canonicalize(path).with_context(|| format!("resolve config {}", path.display()))?;
+        let text = fs::read_to_string(&config_path)
+            .with_context(|| format!("read {}", config_path.display()))?;
         let mut value: Self = toml::from_str(&text).context("parse config")?;
-        value.validate()?;
-        if value.proxy.state_dir.is_none() {
-            value.proxy.state_dir = Some(path.parent().unwrap_or(Path::new(".")).join("state"));
+        let config_dir = config_path.parent().unwrap_or(Path::new("."));
+        let state_dir = value
+            .proxy
+            .state_dir
+            .take()
+            .unwrap_or_else(|| PathBuf::from("state"));
+        value.proxy.state_dir = Some(if state_dir.is_absolute() {
+            state_dir
+        } else {
+            config_dir.join(state_dir)
+        });
+        for account in value.accounts.values_mut() {
+            if let AccountConfig::CodexHome { path } = account {
+                if path.as_os_str().is_empty() {
+                    bail!("codex_home account path must not be empty")
+                }
+                if !path.is_absolute() {
+                    *path = config_dir.join(&*path);
+                }
+            }
         }
+        value.validate()?;
         Ok(value)
     }
 
@@ -143,6 +176,22 @@ impl Config {
         }
         if !(1..=100).contains(&self.proxy.switch_at) {
             bail!("proxy.switch_at must be 1..=100")
+        }
+        if self.accounts.len() > 512 {
+            bail!("at most 512 accounts are supported")
+        }
+        for (name, account) in &self.accounts {
+            if name.len() > 256 {
+                bail!("account name exceeds the 256-byte limit")
+            }
+            if let AccountConfig::CodexHome { path } = account {
+                if path.as_os_str().is_empty() {
+                    bail!("account {name} has an empty codex_home path")
+                }
+                if !path.is_absolute() {
+                    bail!("account {name} codex_home path must be absolute after loading")
+                }
+            }
         }
         if self.listeners.is_empty() {
             bail!("at least one listener is required")
@@ -165,5 +214,100 @@ impl Config {
 
     pub fn snapshot_interval(&self) -> Duration {
         Duration::from_secs(self.proxy.snapshot_interval_seconds.max(1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_text(state_dir: Option<&str>) -> String {
+        let state_dir = state_dir
+            .map(|path| format!("state_dir = {path:?}\n"))
+            .unwrap_or_default();
+        format!(
+            r#"[proxy]
+installation_secret = "0123456789abcdef"
+affinity_key = "0123456789abcdef0123456789abcdef"
+{state_dir}
+[listeners.default]
+address = "127.0.0.1:10100"
+pool = "default"
+
+[pools.default]
+members = ["caller"]
+
+[accounts.caller]
+kind = "inbound"
+"#
+        )
+    }
+
+    #[test]
+    fn relative_state_dir_is_resolved_from_config_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = dir.path().join("nested");
+        fs::create_dir_all(&config_dir).unwrap();
+        let path = config_dir.join("comradex.toml");
+        fs::write(&path, config_text(Some("state/custom"))).unwrap();
+
+        let config = Config::load(&path).unwrap();
+        assert_eq!(
+            config.proxy.state_dir.unwrap(),
+            fs::canonicalize(&config_dir).unwrap().join("state/custom")
+        );
+    }
+
+    #[test]
+    fn default_state_dir_is_resolved_from_config_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("comradex.toml");
+        fs::write(&path, config_text(None)).unwrap();
+
+        let config = Config::load(&path).unwrap();
+        assert_eq!(
+            config.proxy.state_dir.unwrap(),
+            fs::canonicalize(dir.path()).unwrap().join("state")
+        );
+    }
+
+    #[test]
+    fn relative_account_home_is_resolved_from_config_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("comradex.toml");
+        let text = config_text(None)
+            .replace("members = [\"caller\"]", "members = [\"managed\"]")
+            .replace(
+                "[accounts.caller]\nkind = \"inbound\"",
+                "[accounts.managed]\nkind = \"codex_home\"\npath = \"accounts/managed\"",
+            );
+        fs::write(&path, text).unwrap();
+
+        let config = Config::load(&path).unwrap();
+        let AccountConfig::CodexHome { path: account_home } = &config.accounts["managed"] else {
+            panic!("managed account kind changed")
+        };
+        assert_eq!(
+            account_home,
+            &fs::canonicalize(dir.path())
+                .unwrap()
+                .join("accounts/managed")
+        );
+    }
+
+    #[test]
+    fn empty_account_home_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("comradex.toml");
+        let text = config_text(None)
+            .replace("members = [\"caller\"]", "members = [\"managed\"]")
+            .replace(
+                "[accounts.caller]\nkind = \"inbound\"",
+                "[accounts.managed]\nkind = \"codex_home\"\npath = \"\"",
+            );
+        fs::write(&path, text).unwrap();
+
+        let error = Config::load(&path).unwrap_err();
+        assert!(error.to_string().contains("must not be empty"));
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -15,42 +15,78 @@ struct InstallRecord {
 }
 
 pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<()> {
-    let original = match fs::read_to_string(codex_config) {
+    let destination = resolve_destination(codex_config)?;
+    let original = match fs::read_to_string(&destination) {
         Ok(v) => v,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => return Err(e).with_context(|| format!("read {}", codex_config.display())),
+        Err(e) => return Err(e).with_context(|| format!("read {}", destination.display())),
     };
     let mut doc = original
         .parse::<DocumentMut>()
         .context("parse Codex config.toml")?;
-    let previous_url = doc
+    let current_url = doc
         .get("openai_base_url")
         .and_then(Item::as_str)
         .map(str::to_owned);
+    let previous_url = match read_install_record(record_path)? {
+        Some(existing) => {
+            if existing.codex_config != destination {
+                bail!(
+                    "install record belongs to {}; uninstall it before installing into {}",
+                    existing.codex_config.display(),
+                    destination.display()
+                )
+            }
+            if current_url.as_deref() != Some(existing.installed_url.as_str()) {
+                bail!(
+                    "openai_base_url changed since the previous Comradex install; refusing to replace its recovery record"
+                )
+            }
+            existing.previous_url
+        }
+        None => current_url,
+    };
     doc["openai_base_url"] = value(url);
-    atomic_write(codex_config, doc.to_string().as_bytes())?;
+    atomic_write(&destination, doc.to_string().as_bytes())?;
     let record = InstallRecord {
-        codex_config: codex_config.to_owned(),
+        codex_config: destination.clone(),
         installed_url: url.to_owned(),
         previous_url,
     };
     if let Err(error) = atomic_write(record_path, &serde_json::to_vec_pretty(&record)?) {
-        atomic_write(codex_config, original.as_bytes())
+        atomic_write(&destination, original.as_bytes())
             .context("roll back Codex config after install-record failure")?;
         return Err(error).context("write install record");
     }
     Ok(())
 }
 
+fn read_install_record(path: &Path) -> Result<Option<InstallRecord>> {
+    match fs::read(path) {
+        Ok(bytes) => {
+            Ok(Some(serde_json::from_slice(&bytes).with_context(|| {
+                format!("parse install record {}", path.display())
+            })?))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
 pub fn uninstall(record_path: &Path) -> Result<()> {
-    let record: InstallRecord = serde_json::from_slice(
-        &fs::read(record_path).with_context(|| format!("read {}", record_path.display()))?,
-    )?;
-    let original = fs::read_to_string(&record.codex_config)?;
+    let Some(record) = read_install_record(record_path)? else {
+        return Ok(());
+    };
+    let destination = recorded_destination(&record.codex_config)?;
+    let original = fs::read_to_string(&destination)?;
     let mut doc = original
         .parse::<DocumentMut>()
         .context("parse Codex config.toml")?;
     let current = doc.get("openai_base_url").and_then(Item::as_str);
+    if current == record.previous_url.as_deref() {
+        fs::remove_file(record_path)?;
+        return Ok(());
+    }
     if current != Some(record.installed_url.as_str()) {
         bail!("openai_base_url changed since install; refusing to overwrite user configuration")
     }
@@ -60,7 +96,7 @@ pub fn uninstall(record_path: &Path) -> Result<()> {
             doc.remove("openai_base_url");
         }
     }
-    atomic_write(&record.codex_config, doc.to_string().as_bytes())?;
+    atomic_write(&destination, doc.to_string().as_bytes())?;
     fs::remove_file(record_path)?;
     Ok(())
 }
@@ -71,9 +107,58 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
     let mut temp = tempfile::NamedTempFile::new_in(parent)?;
     use std::io::Write;
     temp.write_all(bytes)?;
+    if let Ok(metadata) = fs::metadata(path) {
+        temp.as_file().set_permissions(metadata.permissions())?;
+    }
     temp.as_file().sync_all()?;
     temp.persist(path).map_err(|e| e.error)?;
     Ok(())
+}
+
+fn resolve_destination(path: &Path) -> Result<PathBuf> {
+    Ok(match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            fs::canonicalize(path).with_context(|| format!("resolve symlink {}", path.display()))?
+        }
+        Ok(_) => fs::canonicalize(path).with_context(|| format!("resolve {}", path.display()))?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let absolute = if path.is_absolute() {
+                path.to_owned()
+            } else {
+                std::env::current_dir()?.join(path)
+            };
+            let parent = absolute.parent().unwrap_or(Path::new("."));
+            match fs::canonicalize(parent) {
+                Ok(parent) => parent.join(
+                    absolute
+                        .file_name()
+                        .context("configuration destination has no file name")?,
+                ),
+                Err(parent_error) if parent_error.kind() == std::io::ErrorKind::NotFound => {
+                    absolute
+                }
+                Err(parent_error) => {
+                    return Err(parent_error)
+                        .with_context(|| format!("resolve parent {}", parent.display()));
+                }
+            }
+        }
+        Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
+    })
+}
+
+fn recorded_destination(path: &Path) -> Result<PathBuf> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!(
+                "recorded Codex configuration target {} became a symlink; refusing to follow a new target",
+                path.display()
+            )
+        }
+        Ok(_) => Ok(path.to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path.to_owned()),
+        Err(error) => Err(error).with_context(|| format!("inspect {}", path.display())),
+    }
 }
 
 #[cfg(test)]
@@ -96,5 +181,190 @@ mod tests {
         assert!(restored.contains("model = \"gpt-test\""));
         assert!(restored.contains("foo = true"));
         assert!(!restored.contains("openai_base_url"));
+    }
+
+    #[test]
+    fn repeated_install_preserves_original_pre_comradex_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(
+            &config,
+            "model = \"gpt-test\"\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n",
+        )
+        .unwrap();
+
+        install(&config, &record, "http://127.0.0.1:10100/secret-a/v1").unwrap();
+        install(&config, &record, "http://127.0.0.1:10100/secret-b/v1").unwrap();
+        uninstall(&record).unwrap();
+
+        let restored = fs::read_to_string(&config).unwrap();
+        assert!(restored.contains("http://127.0.0.1:10100/v1"));
+        assert!(!restored.contains("secret-a"));
+        assert!(!restored.contains("secret-b"));
+    }
+
+    #[test]
+    fn uninstall_is_idempotent_after_restore_before_record_deletion() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(
+            &config,
+            "openai_base_url = \"http://127.0.0.1:10100/original/v1\"\n",
+        )
+        .unwrap();
+        install(&config, &record, "http://127.0.0.1:10100/comradex/v1").unwrap();
+        fs::write(
+            &config,
+            "openai_base_url = \"http://127.0.0.1:10100/original/v1\"\n",
+        )
+        .unwrap();
+
+        uninstall(&record).unwrap();
+        assert!(!record.exists());
+        uninstall(&record).unwrap();
+    }
+
+    #[test]
+    fn reinstall_refuses_to_overwrite_recovery_after_external_url_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(&config, "model = \"gpt-test\"\n").unwrap();
+        install(&config, &record, "http://127.0.0.1:10100/secret-a/v1").unwrap();
+        fs::write(
+            &config,
+            "model = \"gpt-test\"\nopenai_base_url = \"http://127.0.0.1:9999/manual/v1\"\n",
+        )
+        .unwrap();
+
+        let error = install(&config, &record, "http://127.0.0.1:10100/secret-b/v1").unwrap_err();
+
+        assert!(error.to_string().contains("changed since"));
+        assert!(fs::read_to_string(&config).unwrap().contains("9999/manual"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_preserves_codex_config_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("dotfiles-config.toml");
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(&target, "model = \"gpt-test\"\n").unwrap();
+        symlink(&target, &config).unwrap();
+
+        install(&config, &record, "http://127.0.0.1:1/s/v1").unwrap();
+        assert!(
+            fs::symlink_metadata(&config)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            fs::read_to_string(&target)
+                .unwrap()
+                .contains("openai_base_url")
+        );
+
+        uninstall(&record).unwrap();
+        assert!(
+            fs::symlink_metadata(&config)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            !fs::read_to_string(&target)
+                .unwrap()
+                .contains("openai_base_url")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_uses_recorded_target_after_symlink_is_retargeted() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let first_target = dir.path().join("first.toml");
+        let second_target = dir.path().join("second.toml");
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(&first_target, "model = \"first\"\n").unwrap();
+        fs::write(&second_target, "model = \"second\"\n").unwrap();
+        symlink(&first_target, &config).unwrap();
+
+        install(&config, &record, "http://127.0.0.1:1/s/v1").unwrap();
+        fs::remove_file(&config).unwrap();
+        symlink(&second_target, &config).unwrap();
+        uninstall(&record).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&first_target).unwrap(),
+            "model = \"first\"\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&second_target).unwrap(),
+            "model = \"second\"\n"
+        );
+        assert!(
+            fs::symlink_metadata(&config)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_config_uses_stable_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target_dir = dir.path().join("dotfiles");
+        let linked_dir = dir.path().join("linked-dotfiles");
+        fs::create_dir_all(&target_dir).unwrap();
+        symlink(&target_dir, &linked_dir).unwrap();
+        let config = linked_dir.join("config.toml");
+        let record = dir.path().join("install.json");
+
+        install(&config, &record, "http://127.0.0.1:1/s/v1").unwrap();
+        let stored: InstallRecord = serde_json::from_slice(&fs::read(&record).unwrap()).unwrap();
+
+        assert_eq!(
+            stored.codex_config,
+            fs::canonicalize(&target_dir).unwrap().join("config.toml")
+        );
+        assert!(target_dir.join("config.toml").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uninstall_refuses_if_recorded_target_becomes_a_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.toml");
+        let replacement = dir.path().join("replacement.toml");
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(&target, "model = \"original\"\n").unwrap();
+        fs::write(&replacement, "model = \"replacement\"\n").unwrap();
+        symlink(&target, &config).unwrap();
+        install(&config, &record, "http://127.0.0.1:1/s/v1").unwrap();
+
+        fs::remove_file(&target).unwrap();
+        symlink(&replacement, &target).unwrap();
+        let error = uninstall(&record).unwrap_err();
+
+        assert!(error.to_string().contains("became a symlink"));
+        assert_eq!(
+            fs::read_to_string(&replacement).unwrap(),
+            "model = \"replacement\"\n"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ pub mod config;
 pub mod install;
 pub mod proxy;
 pub mod routing;
+pub mod service;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use comradex::{
     install,
     proxy::App,
     routing::{AffinityStore, Router},
+    service,
     state::Stats,
 };
 use rand::RngCore;
@@ -41,10 +42,21 @@ enum CommandName {
         listener: String,
     },
     Uninstall,
+    Service {
+        #[command(subcommand)]
+        command: ServiceCommand,
+    },
     Login {
         account: String,
     },
     Stats,
+}
+
+#[derive(Subcommand)]
+enum ServiceCommand {
+    Install,
+    Uninstall,
+    Status,
 }
 
 #[tokio::main]
@@ -77,6 +89,7 @@ async fn main() -> Result<()> {
             let config = Config::load(&cli.config)?;
             install::uninstall(&state_dir(&config).join("install.json"))
         }
+        CommandName::Service { command } => service_command(&cli.config, command),
         CommandName::Login { account } => login(&cli.config, &account),
         CommandName::Stats => {
             let config = Config::load(&cli.config)?;
@@ -104,6 +117,7 @@ upstream = "https://chatgpt.com/backend-api/codex"
 switch_at = 80
 max_inflight = 64
 max_upgrades = 32
+responses_websocket_mode = "raw"
 installation_secret = "{}"
 affinity_key = "{}"
 
@@ -144,19 +158,23 @@ async fn serve(path: &Path) -> Result<()> {
     let router = Arc::new(Router::new(&config, affinity));
     let stats = Arc::new(Stats::default());
     let app = App::new(config.clone(), router.clone(), stats.clone())?;
-    let mut tasks = Vec::new();
+    let mut tasks = tokio::task::JoinSet::new();
     for (name, listener) in config.listeners.clone() {
-        tasks.push(tokio::spawn(app.clone().run_listener(name, listener)));
+        tasks.spawn(app.clone().run_listener(name, listener));
     }
     let background_config = config.clone();
     let background_router = router.clone();
     let background_stats = stats.clone();
+    let background_app = app.clone();
     let background = tokio::spawn(async move {
         let mut interval = tokio::time::interval(background_config.snapshot_interval());
         loop {
             interval.tick().await;
             if let Err(e) = background_router.affinity.flush().await {
                 warn!(error = %e, "affinity snapshot failed");
+            }
+            if let Err(e) = background_app.flush_file_owners().await {
+                warn!(error = %e, "file-owner snapshot failed");
             }
             if let Err(e) = background_stats
                 .write(
@@ -169,14 +187,72 @@ async fn serve(path: &Path) -> Result<()> {
             }
         }
     });
-    signal::ctrl_c().await?;
+    let listener_error = tokio::select! {
+        signal = shutdown_signal() => {
+            signal?;
+            None
+        },
+        listener = tasks.join_next() => {
+            Some(match listener {
+                Some(Ok(Ok(()))) => anyhow::anyhow!("listener exited unexpectedly"),
+                Some(Ok(Err(error))) => error.context("listener failed"),
+                Some(Err(error)) => error.into(),
+                None => anyhow::anyhow!("all listeners exited unexpectedly"),
+            })
+        }
+    };
     info!("shutting down");
     background.abort();
-    for task in tasks {
-        task.abort();
-    }
+    let _ = background.await;
+    tasks.abort_all();
+    while tasks.join_next().await.is_some() {}
+    app.shutdown_connections().await;
+    router.clear_inflight().await;
     router.affinity.flush().await?;
+    app.flush_file_owners().await?;
     stats.write(state.join("stats.json"), &router).await?;
+    if let Some(error) = listener_error {
+        return Err(error);
+    }
+    Ok(())
+}
+
+async fn shutdown_signal() -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut terminate = signal::unix::signal(signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = signal::ctrl_c() => result?,
+            _ = terminate.recv() => {},
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        signal::ctrl_c().await?;
+        Ok(())
+    }
+}
+
+fn service_command(config_path: &Path, command: ServiceCommand) -> Result<()> {
+    match command {
+        ServiceCommand::Install => {
+            let config = Config::load(config_path)?;
+            let plist = service::install(config_path, &state_dir(&config))?;
+            println!("installed and started {}", plist.display());
+        }
+        ServiceCommand::Uninstall => match service::uninstall()? {
+            Some(path) => println!("stopped service and removed {}", path.display()),
+            None => println!("service is not installed"),
+        },
+        ServiceCommand::Status => {
+            if service::status()? {
+                println!("service is running");
+            } else {
+                println!("service is not running");
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,20 +1,33 @@
 mod headers;
 mod replay_body;
+#[allow(dead_code)]
+mod sse;
+#[allow(dead_code)]
+mod websocket_protocol;
 
 use std::{
+    collections::{HashMap, VecDeque},
     convert::Infallible,
+    future::Future,
     pin::Pin,
-    sync::{Arc, atomic::Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
     task::{Context as TaskContext, Poll},
     time::Duration,
 };
 
 use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
 use http_body_util::BodyExt;
 use hyper::{
     Method, Request, Response, StatusCode, Uri,
     body::{Body, Frame, Incoming, SizeHint},
-    header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HOST, LOCATION},
+    header::{
+        AUTHORIZATION, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HOST, LOCATION,
+        SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION, UPGRADE,
+    },
     service::service_fn,
 };
 use hyper_rustls::HttpsConnector;
@@ -23,22 +36,146 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
 };
-use tokio::{net::TcpListener, sync::Semaphore};
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex as AsyncMutex, Semaphore, mpsc, oneshot},
+    task::{AbortHandle, JoinSet},
+};
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{Message, protocol::Role},
+};
 use tracing::{error, info, warn};
 
 use crate::{
     auth,
-    config::{Config, ListenerConfig, PoolConfig},
+    config::{Config, ListenerConfig, PoolConfig, ResponsesWebsocketMode},
     routing::{
-        Router,
+        AffinityStore, Router,
         live::{self, LiveCallStore},
         metadata,
     },
     state::Stats,
 };
-use replay_body::{ProxyBody, ReplayBody, empty_body, incoming_body, json_body};
+use replay_body::{ProxyBody, ReplayBody, bytes_body, empty_body, incoming_body, json_body};
+use sse::{ProtocolEvent, SseDecoder, responses_json_events};
+use websocket_protocol::{
+    DownstreamEndAction, FailureClassification, FailureKind, ProtocolLimits, ProtocolState,
+    ReplayContext, ReplayMode, ReplayTarget, Settlement, TerminalKind, TurnEndDisposition, TurnId,
+    UpstreamEnd, classify_failure, fresh_replay_without_previous_response,
+};
+
+const FILE_CREATE_RESPONSE_LIMIT: usize = 1024 * 1024;
+const RESPONSES_JSON_RESPONSE_LIMIT: usize = 16 * 1024 * 1024;
+const BRIDGE_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const UNKNOWN_CONTENT_SNIFF_BYTES: usize = 4 * 1024;
+const SSE_DECODE_SLICE_BYTES: usize = 64 * 1024;
+const MAX_QUEUED_DIRECT_CREATES: usize = 64;
 
 type HttpClient = Client<HttpsConnector<HttpConnector>, ProxyBody>;
+type UpgradedWebSocket = WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>;
+
+struct WebSocketFrameRoute {
+    account_id: String,
+    hard_owner: bool,
+    non_previous_hard_owner: bool,
+    soft_keys: Vec<crate::routing::ThreadKey>,
+}
+
+struct DirectTurn {
+    route: WebSocketFrameRoute,
+    request: Message,
+    value: serde_json::Value,
+}
+
+struct DirectAccountLease {
+    router: Arc<Router>,
+    account: Option<String>,
+}
+
+struct TrackedTask {
+    abort: AbortHandle,
+    done: oneshot::Receiver<()>,
+}
+
+impl TrackedTask {
+    async fn cancel(mut self) {
+        self.abort.abort();
+        let _ = (&mut self.done).await;
+    }
+
+    async fn wait_timeout(mut self, timeout: Duration) {
+        if tokio::time::timeout(timeout, &mut self.done).await.is_err() {
+            self.abort.abort();
+            let _ = (&mut self.done).await;
+        }
+    }
+}
+
+impl Drop for TrackedTask {
+    fn drop(&mut self) {
+        self.abort.abort();
+    }
+}
+
+#[derive(Clone)]
+struct SelectedAccount(String);
+
+struct OpenUpgradeGuard(Arc<Stats>);
+
+impl Drop for OpenUpgradeGuard {
+    fn drop(&mut self) {
+        self.0.open_upgrades.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone)]
+struct BridgeSender {
+    sender: mpsc::Sender<(u64, Message)>,
+    generation: u64,
+}
+
+impl BridgeSender {
+    async fn send(&self, message: Message) -> bool {
+        tokio::time::timeout(
+            BRIDGE_SEND_TIMEOUT,
+            self.sender.send((self.generation, message)),
+        )
+        .await
+        .is_ok_and(|result| result.is_ok())
+    }
+}
+
+impl DirectAccountLease {
+    fn new(router: Arc<Router>, account: String) -> Self {
+        Self {
+            router,
+            account: Some(account),
+        }
+    }
+
+    async fn replace(&mut self, account: String) {
+        if let Some(previous) = self.account.replace(account) {
+            self.router.end(&previous).await;
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.account = None;
+    }
+}
+
+impl Drop for DirectAccountLease {
+    fn drop(&mut self) {
+        let Some(account) = self.account.take() else {
+            return;
+        };
+        let router = self.router.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move { router.end(&account).await });
+        }
+    }
+}
 
 pub struct App {
     config: Arc<Config>,
@@ -50,6 +187,10 @@ pub struct App {
     upgrade_slots: Arc<Semaphore>,
     live_calls: LiveCallStore,
     auth: auth::Resolver,
+    file_owners: Arc<AffinityStore>,
+    tasks: AsyncMutex<JoinSet<()>>,
+    shutting_down: AtomicBool,
+    service_nonce: Option<String>,
 }
 
 impl App {
@@ -67,6 +208,14 @@ impl App {
             .build();
         let client = Client::builder(TokioExecutor::new()).build(https);
         let upgrade_client = Client::builder(TokioExecutor::new()).build(upgrade_https);
+        let state_dir = config.proxy.state_dir.clone().unwrap_or_else(|| ".".into());
+        let file_owners = Arc::new(AffinityStore::load(
+            state_dir.join("file-owners.json"),
+            &config.proxy.affinity_key,
+            config.proxy.max_affinity_entries,
+            config.proxy.max_affinity_bytes,
+            Duration::from_secs(config.proxy.affinity_idle_days * 86_400),
+        )?);
         Ok(Arc::new(Self {
             http_slots: Arc::new(Semaphore::new(config.proxy.max_inflight)),
             upgrade_slots: Arc::new(Semaphore::new(config.proxy.max_upgrades)),
@@ -85,12 +234,63 @@ impl App {
                     .join("live-calls.json"),
             ),
             auth: auth::Resolver::new(&config),
+            file_owners,
             config,
             router,
             client,
             upgrade_client,
             stats,
+            tasks: AsyncMutex::new(JoinSet::new()),
+            shutting_down: AtomicBool::new(false),
+            service_nonce: std::env::var("COMRADEX_SERVICE_NONCE").ok(),
         }))
+    }
+
+    pub async fn flush_file_owners(&self) -> Result<()> {
+        self.file_owners.flush().await
+    }
+
+    async fn spawn_tracked<F>(&self, task: F) -> bool
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return false;
+        }
+        let mut tasks = self.tasks.lock().await;
+        while tasks.try_join_next().is_some() {}
+        if self.shutting_down.load(Ordering::Acquire) {
+            return false;
+        }
+        tasks.spawn(task);
+        true
+    }
+
+    async fn spawn_tracked_task<F>(&self, task: F) -> Option<TrackedTask>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return None;
+        }
+        let mut tasks = self.tasks.lock().await;
+        while tasks.try_join_next().is_some() {}
+        if self.shutting_down.load(Ordering::Acquire) {
+            return None;
+        }
+        let (done_tx, done) = oneshot::channel();
+        let abort = tasks.spawn(async move {
+            task.await;
+            let _ = done_tx.send(());
+        });
+        Some(TrackedTask { abort, done })
+    }
+
+    pub async fn shutdown_connections(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+        let mut tasks = self.tasks.lock().await;
+        tasks.abort_all();
+        while tasks.join_next().await.is_some() {}
     }
 
     pub async fn run_listener(
@@ -115,7 +315,7 @@ impl App {
             let (stream, _) = tcp.accept().await?;
             let app = self.clone();
             let listener = listener.clone();
-            tokio::spawn(async move {
+            self.spawn_tracked(async move {
                 let service = service_fn(move |req| app.clone().handle(req, listener.clone()));
                 if let Err(e) = Builder::new(TokioExecutor::new())
                     .serve_connection_with_upgrades(TokioIo::new(stream), service)
@@ -123,7 +323,8 @@ impl App {
                 {
                     warn!(error = %e, "client connection ended");
                 }
-            });
+            })
+            .await;
         }
     }
 
@@ -132,41 +333,67 @@ impl App {
         req: Request<Incoming>,
         listener: ListenerConfig,
     ) -> Result<Response<ProxyBody>, Infallible> {
-        let response = match self.authorized_path(req.uri()) {
-            None => error_response(StatusCode::NOT_FOUND, "not_found", "unknown proxy path"),
-            Some(path) if is_upgrade(&req) => match live::sideband_call_id(&path) {
-                Err(_) => error_response(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_realtime_call_id",
-                    "malformed or ambiguous realtime call id",
-                ),
-                Ok(call_id) => self
-                    .handle_upgrade(req, &listener, path, call_id)
-                    .await
-                    .unwrap_or_else(internal_error),
-            },
-            Some(path) => {
-                let permit = match self.http_slots.clone().try_acquire_owned() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        return Ok(error_response(
-                            StatusCode::SERVICE_UNAVAILABLE,
-                            "at_capacity",
-                            "HTTP request limit reached",
-                        ));
-                    }
-                };
-                self.stats.inflight_http.fetch_add(1, Ordering::Relaxed);
-                let result = self
-                    .handle_http(req, &listener, path)
-                    .await
-                    .unwrap_or_else(internal_error);
-                self.stats.inflight_http.fetch_sub(1, Ordering::Relaxed);
-                drop(permit);
-                result
+        let response = if self.service_health_path(req.uri()) {
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .body(json_body(serde_json::json!({"status":"ok"})))
+                .expect("static health response is valid")
+        } else {
+            match self.authorized_path(req.uri()) {
+                None => error_response(StatusCode::NOT_FOUND, "not_found", "unknown proxy path"),
+                Some(path)
+                    if is_upgrade(&req)
+                        && is_native_responses(&path)
+                        && self.config.proxy.responses_websocket_mode
+                            == ResponsesWebsocketMode::HttpBridge =>
+                {
+                    self.handle_responses_http_bridge(req, &listener, path)
+                        .await
+                        .unwrap_or_else(internal_error)
+                }
+                Some(path) if is_upgrade(&req) => match live::sideband_call_id(&path) {
+                    Err(_) => error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_realtime_call_id",
+                        "malformed or ambiguous realtime call id",
+                    ),
+                    Ok(call_id) => self
+                        .handle_upgrade(req, &listener, path, call_id)
+                        .await
+                        .unwrap_or_else(internal_error),
+                },
+                Some(path) => {
+                    let permit = match self.http_slots.clone().try_acquire_owned() {
+                        Ok(v) => v,
+                        Err(_) => {
+                            return Ok(error_response(
+                                StatusCode::SERVICE_UNAVAILABLE,
+                                "at_capacity",
+                                "HTTP request limit reached",
+                            ));
+                        }
+                    };
+                    self.stats.inflight_http.fetch_add(1, Ordering::Relaxed);
+                    let result = self
+                        .handle_http(req, &listener, path)
+                        .await
+                        .unwrap_or_else(internal_error);
+                    self.stats.inflight_http.fetch_sub(1, Ordering::Relaxed);
+                    drop(permit);
+                    result
+                }
             }
         };
         Ok(response)
+    }
+
+    fn service_health_path(&self, uri: &Uri) -> bool {
+        uri.query().is_none()
+            && self
+                .service_nonce
+                .as_deref()
+                .is_some_and(|nonce| uri.path() == format!("/__comradex_health/{nonce}"))
     }
 
     fn authorized_path(&self, uri: &Uri) -> Option<String> {
@@ -196,7 +423,7 @@ impl App {
         let (parts, body) = req.into_parts();
         let inbound_headers = parts.headers;
         let method = parts.method;
-        let mut replay = ReplayBody::read(
+        let replay = ReplayBody::read(
             body,
             self.config.proxy.replay_memory_bytes,
             self.config.proxy.max_request_bytes,
@@ -204,12 +431,38 @@ impl App {
             self.stats.clone(),
         )
         .await?;
+        self.handle_http_replay(inbound_headers, method, listener, path, replay)
+            .await
+    }
+
+    async fn handle_http_replay(
+        &self,
+        inbound_headers: hyper::HeaderMap,
+        method: Method,
+        listener: &ListenerConfig,
+        path: String,
+        mut replay: ReplayBody,
+    ) -> Result<Response<ProxyBody>> {
+        if replay.file_ids_overflow() {
+            return Ok(error_response(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "too_many_file_references",
+                "request contains more than 32 distinct file references",
+            ));
+        }
         let pool = self.pool(listener)?;
+        let mut file_ids = replay.file_ids().to_vec();
+        if let Some(file_id) = finalized_file_id(&method, &path)
+            && !file_ids.contains(&file_id)
+        {
+            file_ids.push(file_id);
+        }
         let affinity_values = metadata::affinity_values(
             &inbound_headers,
             replay.thread_id(),
             replay.previous_response_id(),
             replay.prompt_cache_key(),
+            &file_ids,
         );
         let affinity_keys: Vec<_> = affinity_values
             .iter()
@@ -217,8 +470,21 @@ impl App {
             .collect();
         let mut bound_account: Option<String> = None;
         let mut hard_owner = false;
+        let mut known_file_owners = 0usize;
+        let mut missing_hard_owner = false;
         for (kind, key) in &affinity_keys {
-            let Some(binding) = self.router.affinity.get(key).await else {
+            let binding = if *kind == metadata::AffinityKind::File {
+                self.file_owners.get(key).await
+            } else {
+                self.router.affinity.get(key).await
+            };
+            let Some(binding) = binding else {
+                if matches!(
+                    kind,
+                    metadata::AffinityKind::PreviousResponse | metadata::AffinityKind::TurnState
+                ) {
+                    missing_hard_owner = true;
+                }
                 continue;
             };
             if bound_account
@@ -232,23 +498,25 @@ impl App {
                 ));
             }
             hard_owner |= kind.is_hard_continuity();
+            if *kind == metadata::AffinityKind::File {
+                known_file_owners += 1;
+            }
             bound_account = Some(binding.account_id);
         }
-        if bound_account.is_none()
-            && affinity_values.iter().any(|value| {
-                matches!(
-                    value.kind,
-                    metadata::AffinityKind::PreviousResponse | metadata::AffinityKind::TurnState
-                )
-            })
-        {
+        if known_file_owners > 0 && known_file_owners < file_ids.len() {
+            return Ok(error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "file_owner_unavailable",
+                "some referenced files have no known account owner",
+            ));
+        }
+        if missing_hard_owner {
             return Ok(error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "continuity_owner_unavailable",
                 "request carries hard continuity state with no known account owner",
             ));
         }
-        let primary_key = affinity_keys.first().map(|(_, key)| key.clone());
         let first = if let Some(account) = &bound_account {
             match self.router.select_exact(pool, account).await {
                 Some(selection) => selection,
@@ -262,13 +530,10 @@ impl App {
             }
         } else {
             self.router
-                .select(&listener.pool, pool, primary_key.clone(), None)
+                .select(&listener.pool, pool, None, None)
                 .await
                 .context("no eligible account")?
         };
-        for (_, key) in &affinity_keys {
-            self.router.bind(key.clone(), &first.account_id).await;
-        }
         let mut selected = first;
         for attempt in 0..2 {
             let account = selected.account_id.clone();
@@ -277,6 +542,7 @@ impl App {
                 .resolve(&self.config.accounts[&account], &inbound_headers)
                 .await?;
             self.router.begin(&account).await;
+            let mut request_lease = DirectAccountLease::new(self.router.clone(), account.clone());
             let result = self
                 .send_http(
                     &method,
@@ -291,11 +557,13 @@ impl App {
                     self.router
                         .observe_headers(&account, response.headers())
                         .await;
-                    if let Some(turn_state) = response
-                        .headers()
-                        .get("x-codex-turn-state")
-                        .and_then(|value| value.to_str().ok())
-                        .filter(|value| !value.is_empty())
+                    let status = response.status();
+                    if status.is_success()
+                        && let Some(turn_state) = response
+                            .headers()
+                            .get("x-codex-turn-state")
+                            .and_then(|value| value.to_str().ok())
+                            .filter(|value| !value.is_empty())
                     {
                         let alias = self
                             .router
@@ -303,7 +571,6 @@ impl App {
                             .key(&format!("turn-state:{turn_state}"));
                         self.router.bind(alias, &account).await;
                     }
-                    let status = response.status();
                     if status == StatusCode::UNAUTHORIZED {
                         if attempt == 0 {
                             match self
@@ -312,7 +579,6 @@ impl App {
                                 .await
                             {
                                 Ok(Some(_)) => {
-                                    self.router.end(&account).await;
                                     continue;
                                 }
                                 Ok(None) => {}
@@ -325,18 +591,29 @@ impl App {
                         ) {
                             self.router.auth_failure(&account).await;
                         }
+                        request_lease.disarm();
                         return Ok(map_http_response_leased(
                             response,
                             self.router.clone(),
                             account,
+                            false,
                         ));
                     }
                     if status == StatusCode::FORBIDDEN {
+                        request_lease.disarm();
                         return Ok(map_http_response_leased(
                             response,
                             self.router.clone(),
                             account,
+                            false,
                         ));
+                    }
+                    if status.is_success() {
+                        for (kind, key) in &affinity_keys {
+                            if *kind != metadata::AffinityKind::File {
+                                self.router.bind(key.clone(), &account).await;
+                            }
+                        }
                     }
                     if status.is_success() && live::is_call_creation(&path) {
                         let bound = response
@@ -349,13 +626,23 @@ impl App {
                             None => false,
                         };
                         if !binding_ok {
-                            self.router.end(&account).await;
                             return Ok(error_response(
                                 StatusCode::SERVICE_UNAVAILABLE,
                                 "realtime_call_binding_failed",
                                 "successful realtime call could not be bound safely",
                             ));
                         }
+                    }
+                    if status.is_success() && is_file_create(&method, &path) {
+                        let mapped = self.map_file_create_response(response, &account).await;
+                        return mapped;
+                    }
+                    if status.is_success()
+                        && let Some(file_id) = finalized_file_id(&method, &path)
+                    {
+                        return self
+                            .map_file_finalize_response(response, &account, &file_id)
+                            .await;
                     }
                     let retry = retryable_http_status(status, &method, &path);
                     if retry {
@@ -370,25 +657,22 @@ impl App {
                         }
                     }
                     if retry && attempt == 0 && !hard_owner {
-                        self.router.end(&account).await;
                         selected = self
                             .router
-                            .select(&listener.pool, pool, primary_key.clone(), Some(&account))
+                            .select(&listener.pool, pool, None, Some(&account))
                             .await
                             .context("no alternate account")?;
-                        for (_, key) in &affinity_keys {
-                            self.router.bind(key.clone(), &selected.account_id).await;
-                        }
                         continue;
                     }
+                    request_lease.disarm();
                     return Ok(map_http_response_leased(
                         response,
                         self.router.clone(),
                         account,
+                        status.is_success() && is_native_responses(&path),
                     ));
                 }
                 Err(e) => {
-                    self.router.end(&account).await;
                     if attempt == 0
                         && is_connect_failure(&e)
                         && !hard_owner
@@ -400,12 +684,9 @@ impl App {
                         self.router.soft_failure(&account).await;
                         selected = self
                             .router
-                            .select(&listener.pool, pool, primary_key.clone(), Some(&account))
+                            .select(&listener.pool, pool, None, Some(&account))
                             .await
                             .context("no alternate account")?;
-                        for (_, key) in &affinity_keys {
-                            self.router.bind(key.clone(), &selected.account_id).await;
-                        }
                     } else {
                         return Err(e);
                     }
@@ -434,8 +715,1205 @@ impl App {
         Ok(self.client.request(builder.body(body)?).await?)
     }
 
-    async fn handle_upgrade(
+    async fn map_file_create_response(
         &self,
+        response: Response<Incoming>,
+        account: &str,
+    ) -> Result<Response<ProxyBody>> {
+        let (mut parts, mut body) = response.into_parts();
+        let mut bytes = bytes::BytesMut::new();
+        while let Some(frame) = body.frame().await {
+            let frame = frame.context("read file-create response")?;
+            let Ok(data) = frame.into_data() else {
+                continue;
+            };
+            if bytes.len().saturating_add(data.len()) > FILE_CREATE_RESPONSE_LIMIT {
+                anyhow::bail!("file-create response exceeds safety limit")
+            }
+            bytes.extend_from_slice(&data);
+        }
+        let file_id = serde_json::from_slice::<serde_json::Value>(&bytes)
+            .context("parse file-create response")?
+            .get("file_id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .context("successful file-create response has no file_id")?;
+        let key = self.router.affinity.key(&format!("file:{file_id}"));
+        self.file_owners.put(key, account.to_owned(), 0).await;
+        if let Err(error) = self.file_owners.flush().await {
+            error!(%error, "file-owner snapshot failed after creation");
+        }
+        headers::strip_hop_by_hop(&mut parts.headers);
+        let bytes = bytes.freeze();
+        parts.headers.insert(CONTENT_LENGTH, bytes.len().into());
+        Ok(Response::from_parts(parts, bytes_body(bytes)))
+    }
+
+    async fn map_file_finalize_response(
+        &self,
+        response: Response<Incoming>,
+        account: &str,
+        file_id: &str,
+    ) -> Result<Response<ProxyBody>> {
+        let (mut parts, mut body) = response.into_parts();
+        let mut bytes = bytes::BytesMut::new();
+        while let Some(frame) = body.frame().await {
+            let frame = frame.context("read file-finalization response")?;
+            let Ok(data) = frame.into_data() else {
+                continue;
+            };
+            if bytes.len().saturating_add(data.len()) > FILE_CREATE_RESPONSE_LIMIT {
+                anyhow::bail!("file-finalization response exceeds safety limit")
+            }
+            bytes.extend_from_slice(&data);
+        }
+        let authoritative_success = is_authoritative_file_finalize_success(&bytes);
+        if authoritative_success {
+            let key = self.router.affinity.key(&format!("file:{file_id}"));
+            self.file_owners.put(key, account.to_owned(), 0).await;
+            if let Err(error) = self.file_owners.flush().await {
+                error!(%error, "file-owner snapshot failed after finalization");
+            }
+        }
+        headers::strip_hop_by_hop(&mut parts.headers);
+        let bytes = bytes.freeze();
+        parts.headers.insert(CONTENT_LENGTH, bytes.len().into());
+        Ok(Response::from_parts(parts, bytes_body(bytes)))
+    }
+
+    async fn handle_responses_http_bridge(
+        self: &Arc<Self>,
+        mut req: Request<Incoming>,
+        listener: &ListenerConfig,
+        path: String,
+    ) -> Result<Response<ProxyBody>> {
+        let permit = self
+            .upgrade_slots
+            .clone()
+            .try_acquire_owned()
+            .context("WebSocket limit reached")?;
+        let key = req
+            .headers()
+            .get(SEC_WEBSOCKET_KEY)
+            .context("missing Sec-WebSocket-Key")?
+            .as_bytes();
+        if req
+            .headers()
+            .get(SEC_WEBSOCKET_VERSION)
+            .and_then(|value| value.to_str().ok())
+            != Some("13")
+        {
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                "unsupported_websocket_version",
+                "Sec-WebSocket-Version must be 13",
+            ));
+        }
+        let accept = tokio_tungstenite::tungstenite::handshake::derive_accept_key(key);
+        let headers = req.headers().clone();
+        let client_upgrade = hyper::upgrade::on(&mut req);
+        let app = self.clone();
+        let listener = listener.clone();
+        self.stats.open_upgrades.fetch_add(1, Ordering::Relaxed);
+        let upgrade_guard = OpenUpgradeGuard(self.stats.clone());
+        let spawned = self
+            .spawn_tracked(async move {
+                let _upgrade_guard = upgrade_guard;
+                let _permit = permit;
+                match client_upgrade.await {
+                    Ok(client) => {
+                        let websocket = WebSocketStream::from_raw_socket(
+                            TokioIo::new(client),
+                            Role::Server,
+                            None,
+                        )
+                        .await;
+                        if let Err(error) = app
+                            .run_responses_http_bridge(websocket, listener, path, headers)
+                            .await
+                        {
+                            warn!(%error, "Responses HTTP bridge ended");
+                        }
+                    }
+                    Err(error) => warn!(%error, "Responses HTTP bridge upgrade failed"),
+                }
+            })
+            .await;
+        if !spawned {
+            anyhow::bail!("proxy is shutting down")
+        }
+        Ok(Response::builder()
+            .status(StatusCode::SWITCHING_PROTOCOLS)
+            .header(CONNECTION, "Upgrade")
+            .header(UPGRADE, "websocket")
+            .header(SEC_WEBSOCKET_ACCEPT, accept)
+            .body(empty_body())?)
+    }
+
+    async fn run_responses_http_bridge(
+        self: &Arc<Self>,
+        websocket: UpgradedWebSocket,
+        listener: ListenerConfig,
+        path: String,
+        mut headers: hyper::HeaderMap,
+    ) -> Result<()> {
+        headers::strip_hop_by_hop(&mut headers);
+        headers.remove(SEC_WEBSOCKET_KEY);
+        headers.remove(SEC_WEBSOCKET_VERSION);
+        headers.remove(SEC_WEBSOCKET_ACCEPT);
+        headers.remove(CONTENT_LENGTH);
+        headers.insert(CONTENT_TYPE, "application/json".parse()?);
+        let (mut sink, mut source) = websocket.split();
+        let active_generation = Arc::new(AtomicU64::new(0));
+        let delivery_gate = Arc::new(AsyncMutex::new(()));
+        let (outbound, mut outgoing) = mpsc::channel::<(u64, Message)>(8);
+        let (fatal_tx, mut fatal_rx) = mpsc::unbounded_channel::<String>();
+        let control = BridgeSender {
+            sender: outbound.clone(),
+            generation: 0,
+        };
+        let writer_generation = active_generation.clone();
+        let writer_gate = delivery_gate.clone();
+        let writer_fatal = fatal_tx.clone();
+        let mut writer = Some(
+            self.spawn_tracked_task(async move {
+                while let Some((generation, message)) = outgoing.recv().await {
+                    let _delivery = writer_gate.lock().await;
+                    if generation != 0 && generation != writer_generation.load(Ordering::Acquire) {
+                        continue;
+                    }
+                    if !matches!(
+                        tokio::time::timeout(BRIDGE_SEND_TIMEOUT, sink.send(message)).await,
+                        Ok(Ok(()))
+                    ) {
+                        let _ = writer_fatal.send("downstream WebSocket writer failed".into());
+                        break;
+                    }
+                }
+                let _ = tokio::time::timeout(BRIDGE_SEND_TIMEOUT, sink.close()).await;
+            })
+            .await
+            .context("proxy is shutting down")?,
+        );
+        let mut active_turn: Option<TrackedTask> = None;
+        let mut read_error: Option<String> = None;
+        loop {
+            let message = tokio::select! {
+                fatal = fatal_rx.recv() => {
+                    read_error = Some(fatal.unwrap_or_else(|| "downstream WebSocket writer stopped".into()));
+                    break;
+                }
+                message = source.next() => {
+                    let Some(message) = message else { break };
+                    message
+                }
+            };
+            let message = match message {
+                Ok(message) => message,
+                Err(error) => {
+                    read_error = Some(error.to_string());
+                    break;
+                }
+            };
+            match message {
+                Message::Ping(payload) => {
+                    if !control.send(Message::Pong(payload)).await {
+                        break;
+                    }
+                }
+                Message::Close(frame) => {
+                    active_generation.fetch_add(1, Ordering::AcqRel);
+                    if let Some(turn) = active_turn.take() {
+                        turn.cancel().await;
+                    }
+                    let _ = control.send(Message::Close(frame)).await;
+                    break;
+                }
+                Message::Text(text) => {
+                    let Ok(mut frame) = serde_json::from_str::<serde_json::Value>(text.as_str())
+                    else {
+                        send_ws_error(&control, "invalid_request_error", "invalid JSON frame")
+                            .await;
+                        continue;
+                    };
+                    let frame_type = frame.get("type").and_then(serde_json::Value::as_str);
+                    if frame_type == Some("response.processed") {
+                        continue;
+                    }
+                    if frame_type != Some("response.create") {
+                        send_ws_error(
+                            &control,
+                            "invalid_request_error",
+                            "expected response.create",
+                        )
+                        .await;
+                        continue;
+                    }
+                    // Cancel upstream work immediately. The gate is acquired only afterward,
+                    // so a blocked downstream send cannot keep consuming account usage.
+                    let generation = active_generation.fetch_add(1, Ordering::AcqRel) + 1;
+                    if let Some(turn) = active_turn.take() {
+                        turn.cancel().await;
+                    }
+                    // Do not begin replacement delivery until any already-started old send
+                    // has either completed or hit its bounded writer timeout.
+                    let delivery = delivery_gate.lock().await;
+                    drop(delivery);
+                    let turn_outbound = BridgeSender {
+                        sender: outbound.clone(),
+                        generation,
+                    };
+                    if frame.get("generate").and_then(serde_json::Value::as_bool) == Some(false) {
+                        for warmup in warmup_frames(&frame) {
+                            if !turn_outbound.send(Message::Text(warmup.into())).await {
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                    let Some(object) = frame.as_object_mut() else {
+                        continue;
+                    };
+                    object.remove("type");
+                    object.insert("stream".into(), serde_json::Value::Bool(true));
+                    let body = match serde_json::to_vec(&frame) {
+                        Ok(body) => bytes::Bytes::from(body),
+                        Err(error) => {
+                            send_ws_error(
+                                &turn_outbound,
+                                "invalid_request_error",
+                                &error.to_string(),
+                            )
+                            .await;
+                            continue;
+                        }
+                    };
+                    let app = self.clone();
+                    let listener = listener.clone();
+                    let path = path.clone();
+                    let headers = headers.clone();
+                    let outbound = turn_outbound;
+                    let fatal = fatal_tx.clone();
+                    active_turn = self
+                        .spawn_tracked_task(async move {
+                            let _http_permit = match app.http_slots.clone().try_acquire_owned() {
+                                Ok(permit) => permit,
+                                Err(_) => {
+                                    send_ws_error(
+                                        &outbound,
+                                        "server_busy",
+                                        "HTTP request limit reached",
+                                    )
+                                    .await;
+                                    return;
+                                }
+                            };
+                            let replay = match ReplayBody::from_bytes(
+                                body,
+                                app.config.proxy.max_request_bytes,
+                                app.config.proxy.max_spool_bytes,
+                                app.stats.clone(),
+                            ) {
+                                Ok(replay) => replay,
+                                Err(error) => {
+                                    send_ws_error(
+                                        &outbound,
+                                        "invalid_request_error",
+                                        &error.to_string(),
+                                    )
+                                    .await;
+                                    return;
+                                }
+                            };
+                            match app
+                                .handle_http_replay(headers, Method::POST, &listener, path, replay)
+                                .await
+                            {
+                                Ok(response) => {
+                                    if let Err(error) =
+                                        pump_http_response_to_websocket(response, &outbound, &app)
+                                            .await
+                                    {
+                                        if error
+                                            .to_string()
+                                            .contains("backpressure prevented event delivery")
+                                        {
+                                            let _ = fatal.send(error.to_string());
+                                            return;
+                                        }
+                                        send_ws_error(
+                                            &outbound,
+                                            "websocket_protocol_error",
+                                            &error.to_string(),
+                                        )
+                                        .await;
+                                    }
+                                }
+                                Err(error) => {
+                                    send_ws_error(&outbound, "proxy_error", &error.to_string())
+                                        .await;
+                                }
+                            }
+                        })
+                        .await;
+                    if active_turn.is_none() {
+                        break;
+                    }
+                }
+                Message::Binary(_) => {
+                    send_ws_error(
+                        &control,
+                        "invalid_request_error",
+                        "Responses WebSocket accepts JSON text frames only",
+                    )
+                    .await;
+                }
+                Message::Pong(_) | Message::Frame(_) => {}
+            }
+        }
+        if let Some(turn) = active_turn {
+            turn.cancel().await;
+        }
+        drop(control);
+        drop(outbound);
+        if let Some(writer_task) = writer.take() {
+            writer_task.wait_timeout(Duration::from_secs(6)).await;
+        }
+        match read_error {
+            Some(error) => anyhow::bail!("Responses WebSocket bridge failed: {error}"),
+            None => Ok(()),
+        }
+    }
+
+    async fn route_websocket_frame(
+        &self,
+        listener: &ListenerConfig,
+        headers: &hyper::HeaderMap,
+        replay: &ReplayBody,
+        preferred_account: Option<&str>,
+    ) -> Result<WebSocketFrameRoute> {
+        if replay.file_ids_overflow() {
+            anyhow::bail!("request contains more than 32 distinct file references")
+        }
+        let pool = self.pool(listener)?;
+        let affinity_values = metadata::affinity_values(
+            headers,
+            replay.thread_id(),
+            replay.previous_response_id(),
+            replay.prompt_cache_key(),
+            replay.file_ids(),
+        );
+        let affinity_keys: Vec<_> = affinity_values
+            .iter()
+            .map(|value| (value.kind, self.router.affinity.key(&value.namespaced())))
+            .collect();
+        let mut bound_account: Option<String> = None;
+        let mut hard_owner = false;
+        let mut non_previous_hard_owner = false;
+        let mut known_file_owners = 0usize;
+        let mut missing_hard_owner = false;
+        for (kind, key) in &affinity_keys {
+            let binding = if *kind == metadata::AffinityKind::File {
+                self.file_owners.get(key).await
+            } else {
+                self.router.affinity.get(key).await
+            };
+            let Some(binding) = binding else {
+                if matches!(
+                    kind,
+                    metadata::AffinityKind::PreviousResponse | metadata::AffinityKind::TurnState
+                ) {
+                    missing_hard_owner = true;
+                }
+                continue;
+            };
+            if bound_account
+                .as_ref()
+                .is_some_and(|account| account != &binding.account_id)
+            {
+                anyhow::bail!("request continuity keys resolve to different accounts")
+            }
+            hard_owner |= kind.is_hard_continuity();
+            non_previous_hard_owner |=
+                kind.is_hard_continuity() && *kind != metadata::AffinityKind::PreviousResponse;
+            if *kind == metadata::AffinityKind::File {
+                known_file_owners += 1;
+            }
+            bound_account = Some(binding.account_id);
+        }
+        if known_file_owners > 0 && known_file_owners < replay.file_ids().len() {
+            anyhow::bail!("some referenced files have no known account owner")
+        }
+        if missing_hard_owner {
+            anyhow::bail!("request carries hard continuity state with no known account owner")
+        }
+        let selection = if let Some(account) = &bound_account {
+            self.router
+                .select_exact(pool, account)
+                .await
+                .context("required continuity account is unavailable")?
+        } else if let Some(account) = preferred_account {
+            self.router
+                .select_exact(pool, account)
+                .await
+                .context("current direct WebSocket account is unavailable")?
+        } else {
+            self.router
+                .select(&listener.pool, pool, None, None)
+                .await
+                .context("no eligible account")?
+        };
+        let mut soft_keys = Vec::new();
+        for (kind, key) in &affinity_keys {
+            if *kind != metadata::AffinityKind::File {
+                soft_keys.push(key.clone());
+            }
+        }
+        Ok(WebSocketFrameRoute {
+            account_id: selection.account_id,
+            hard_owner,
+            non_previous_hard_owner,
+            soft_keys,
+        })
+    }
+
+    async fn connect_direct_upstream(
+        &self,
+        account: &str,
+        path: &str,
+        inbound_headers: &hyper::HeaderMap,
+        clear_session_state: bool,
+    ) -> Result<UpgradedWebSocket> {
+        for attempt in 0..2 {
+            let uri = self.upstream_uri(path, false)?;
+            let mut upstream_req = Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .body(empty_body())?;
+            *upstream_req.headers_mut() = inbound_headers.clone();
+            upstream_req.headers_mut().remove(HOST);
+            if clear_session_state {
+                strip_direct_session_headers(upstream_req.headers_mut());
+            }
+            normalize_websocket_beta(upstream_req.headers_mut(), path);
+            let credentials = self
+                .auth
+                .resolve(&self.config.accounts[account], inbound_headers)
+                .await?;
+            apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
+            self.router.begin(account).await;
+            let mut response = match self.upgrade_client.request(upstream_req).await {
+                Ok(response) => response,
+                Err(error) => {
+                    self.router.end(account).await;
+                    return Err(error.into());
+                }
+            };
+            if response.status() == StatusCode::SWITCHING_PROTOCOLS {
+                if !selected_subprotocol_is_offered(inbound_headers, response.headers()) {
+                    self.router.end(account).await;
+                    anyhow::bail!("upstream selected an unoffered WebSocket subprotocol")
+                }
+                let upgrade = hyper::upgrade::on(&mut response).await;
+                match upgrade {
+                    Ok(upgraded) => {
+                        return Ok(WebSocketStream::from_raw_socket(
+                            TokioIo::new(upgraded),
+                            Role::Client,
+                            None,
+                        )
+                        .await);
+                    }
+                    Err(error) => {
+                        self.router.end(account).await;
+                        return Err(error.into());
+                    }
+                }
+            }
+            let status = response.status();
+            self.router.end(account).await;
+            if status == StatusCode::UNAUTHORIZED && attempt == 0 {
+                match self
+                    .auth
+                    .force_refresh(&self.config.accounts[account], &credentials)
+                    .await
+                {
+                    Ok(Some(_)) => continue,
+                    Ok(None) => {}
+                    Err(error) => {
+                        warn!(account, %error, "direct WebSocket credential refresh failed")
+                    }
+                }
+            }
+            if is_quota_status(status) {
+                self.router.quota_failure(account, response.headers()).await;
+            } else if is_selected_gateway_failure(status) {
+                self.router.soft_failure(account).await;
+            } else if status == StatusCode::UNAUTHORIZED
+                && matches!(
+                    self.config.accounts[account],
+                    crate::config::AccountConfig::CodexHome { .. }
+                )
+            {
+                self.router.auth_failure(account).await;
+            }
+            anyhow::bail!("upstream WebSocket handshake failed with {status}")
+        }
+        unreachable!()
+    }
+
+    async fn run_responses_direct(
+        self: &Arc<Self>,
+        mut client: UpgradedWebSocket,
+        mut upstream: UpgradedWebSocket,
+        listener: ListenerConfig,
+        path: String,
+        headers: hyper::HeaderMap,
+        mut account: String,
+    ) -> Result<()> {
+        let mut lease = DirectAccountLease::new(self.router.clone(), account.clone());
+        let mut protocol = ProtocolState::new(ProtocolLimits::default())
+            .map_err(|error| anyhow::anyhow!("invalid direct protocol limits: {error:?}"))?;
+        let mut turns = HashMap::<TurnId, DirectTurn>::new();
+        let mut awaiting_response_created: Option<TurnId> = None;
+        let mut queued_creates = VecDeque::<Message>::new();
+        loop {
+            let queued_message = if awaiting_response_created.is_none() {
+                queued_creates.pop_front()
+            } else {
+                None
+            };
+            tokio::select! {
+                biased;
+                client_message = async {
+                    match queued_message {
+                        Some(message) => Some(Ok(message)),
+                        None => client.next().await,
+                    }
+                } => {
+                    let Some(client_message) = client_message else { break };
+                    let client_message = client_message.context("read downstream Responses frame")?;
+                    if let Message::Text(text) = &client_message {
+                        let parsed = serde_json::from_str::<serde_json::Value>(text.as_str()).ok();
+                        if parsed.as_ref().and_then(|value| value.get("type")).and_then(serde_json::Value::as_str)
+                            == Some("response.create")
+                        {
+                            if awaiting_response_created.is_some() {
+                                if queued_creates.len() >= MAX_QUEUED_DIRECT_CREATES {
+                                    send_direct_error(
+                                        &mut client,
+                                        "server_busy",
+                                        "too many response.create frames are waiting for upstream acceptance",
+                                    )
+                                    .await?;
+                                } else {
+                                    queued_creates.push_back(client_message);
+                                }
+                                continue;
+                            }
+                            if text.len() > self.config.proxy.max_request_bytes {
+                                send_direct_error(&mut client, "invalid_request_error", "response.create exceeds configured request limit").await?;
+                                continue;
+                            }
+                            let replay = ReplayBody::from_bytes(
+                                bytes::Bytes::copy_from_slice(text.as_bytes()),
+                                self.config.proxy.max_request_bytes,
+                                self.config.proxy.max_spool_bytes,
+                                self.stats.clone(),
+                            )?;
+                            let route = match self
+                                .route_websocket_frame(&listener, &headers, &replay, Some(&account))
+                                .await
+                            {
+                                Ok(route) => route,
+                                Err(error) => {
+                                    send_direct_error(&mut client, "continuity_error", &error.to_string()).await?;
+                                    continue;
+                                }
+                            };
+                            if protocol.pending_len() > 0 && route.account_id != account {
+                                send_direct_error(
+                                    &mut client,
+                                    "continuity_owner_conflict",
+                                    "cannot switch upstream account while other Responses turns are pending",
+                                )
+                                .await?;
+                                continue;
+                            }
+                            if protocol.pending_len() == 0 && route.account_id != account {
+                                let replacement = match self
+                                    .connect_direct_upstream(
+                                        &route.account_id,
+                                        &path,
+                                        &headers,
+                                        route.account_id != account,
+                                    )
+                                    .await
+                                {
+                                    Ok(replacement) => replacement,
+                                    Err(error) => {
+                                        send_direct_error(&mut client, "upstream_error", &error.to_string()).await?;
+                                        continue;
+                                    }
+                                };
+                                let _ = tokio::time::timeout(
+                                    Duration::from_secs(2),
+                                    upstream.close(None),
+                                )
+                                .await;
+                                account = route.account_id.clone();
+                                lease.replace(account.clone()).await;
+                                upstream = replacement;
+                            }
+                            let value = parsed.expect("response.create was checked");
+                            let turn_id = match protocol.admit_response_create(&value) {
+                                Ok(turn_id) => turn_id,
+                                Err(error) => {
+                                    send_direct_error(
+                                        &mut client,
+                                        "invalid_request_error",
+                                        &format!("response.create rejected: {error:?}"),
+                                    )
+                                    .await?;
+                                    continue;
+                                }
+                            };
+                            upstream.send(client_message.clone()).await?;
+                            awaiting_response_created = Some(turn_id);
+                            turns.insert(turn_id, DirectTurn {
+                                route,
+                                request: client_message,
+                                value,
+                            });
+                            continue;
+                        }
+                    }
+                    let closes = matches!(client_message, Message::Close(_));
+                    upstream.send(client_message).await?;
+                    if closes { break; }
+                }
+                upstream_message = upstream.next() => {
+                    match upstream_message {
+                        Some(Ok(message)) => {
+                            if let Message::Close(frame) = &message {
+                                let end = UpstreamEnd::Close {
+                                    code: frame.as_ref().map_or(1005, |frame| u16::from(frame.code)),
+                                };
+                                let close_downstream = self
+                                    .recover_or_settle_direct_end(
+                                        &mut protocol,
+                                        &mut turns,
+                                        &mut client,
+                                        &mut upstream,
+                                        &listener,
+                                        &path,
+                                        &headers,
+                                        &mut account,
+                                        &mut lease,
+                                        end,
+                                    )
+                                    .await?;
+                                if awaiting_response_created
+                                    .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
+                                {
+                                    awaiting_response_created = None;
+                                }
+                                if close_downstream {
+                                    break;
+                                }
+                                continue;
+                            }
+                            let parsed = match &message {
+                                Message::Text(text) => serde_json::from_str::<serde_json::Value>(text.as_str()).ok(),
+                                _ => None,
+                            };
+                            let Some(event) = parsed else {
+                                client.send(message).await?;
+                                continue;
+                            };
+                            let failure = classify_failure(&event);
+                            if failure.kind != FailureKind::None
+                                && matches!(
+                                    event.get("type").and_then(serde_json::Value::as_str),
+                                    Some("response.failed" | "response.incomplete" | "response.cancelled" | "error")
+                                )
+                                && let Some(response_id) = failure.response_id.as_deref()
+                            {
+                                protocol
+                                    .associate_precreated_terminal_response_id(response_id)
+                                    .map_err(|error| anyhow::anyhow!("associate pre-created terminal: {error:?}"))?;
+                            }
+                            let anchor_hint = direct_failure_anchor_hint(&protocol, &failure);
+                            let failure_turns = direct_failure_turns(
+                                &protocol,
+                                &failure,
+                                anchor_hint.as_deref(),
+                            );
+                            if failure.kind != FailureKind::None && failure_turns.len() == 1 {
+                                let turn_id = failure_turns[0];
+                                if let Some((replacement, replacement_account)) = self
+                                    .try_replay_direct_turn(
+                                        &mut protocol,
+                                        &mut turns,
+                                        turn_id,
+                                        failure.kind,
+                                        ReplayContext::from_failure(&failure),
+                                        &listener,
+                                        &path,
+                                        &headers,
+                                        &account,
+                                    )
+                                    .await?
+                                {
+                                    let _ = tokio::time::timeout(
+                                        Duration::from_secs(2),
+                                        upstream.close(None),
+                                    )
+                                    .await;
+                                    account = replacement_account;
+                                    lease.replace(account.clone()).await;
+                                    upstream = replacement;
+                                    continue;
+                                }
+                            } else if failure.kind != FailureKind::None {
+                                match failure.kind {
+                                    FailureKind::Quota => {
+                                        self.router
+                                            .quota_failure(&account, &hyper::HeaderMap::new())
+                                            .await;
+                                    }
+                                    FailureKind::Authentication { .. } => {
+                                        self.router.auth_failure(&account).await;
+                                    }
+                                    FailureKind::Transient => {
+                                        self.router.soft_failure(&account).await;
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            let association = protocol
+                                .observe_upstream_event(&event, anchor_hint.as_deref())
+                                .map_err(|error| anyhow::anyhow!("associate upstream event: {error:?}"))?;
+                            if association.failure.kind == FailureKind::PreviousResponseNotFound
+                                && !association.turn_ids.is_empty()
+                            {
+                                for turn_id in association.turn_ids {
+                                    if awaiting_response_created == Some(turn_id) {
+                                        awaiting_response_created = None;
+                                    }
+                                    let response_id = protocol
+                                        .turn(turn_id)
+                                        .and_then(|turn| turn.response_id())
+                                        .unwrap_or("");
+                                    client
+                                        .send(Message::Text(
+                                            serde_json::json!({
+                                                "type": "response.failed",
+                                                "response": {
+                                                    "id": response_id,
+                                                    "status": "failed",
+                                                    "error": {
+                                                        "type": "server_error",
+                                                        "code": "stream_incomplete",
+                                                        "message": "upstream continuity could not be resumed; retry the task",
+                                                        "retryable": true
+                                                    }
+                                                }
+                                            })
+                                            .to_string()
+                                            .into(),
+                                        ))
+                                        .await?;
+                                    let _ = protocol.settle(turn_id, Settlement::Failed);
+                                    turns.remove(&turn_id);
+                                }
+                                continue;
+                            }
+                            if association.failure.kind == FailureKind::PreviousResponseNotFound {
+                                // Never expose account-scoped continuity identifiers from an
+                                // unassociated upstream miss. It may belong to another in-flight
+                                // request, so keep our pending turns alive.
+                                send_direct_error(
+                                    &mut client,
+                                    "stream_incomplete",
+                                    "upstream continuity could not be resumed",
+                                )
+                                .await?;
+                                continue;
+                            }
+                            if association.event_type.as_deref() == Some("response.created") {
+                                for turn_id in &association.turn_ids {
+                                    if awaiting_response_created == Some(*turn_id) {
+                                        awaiting_response_created = None;
+                                    }
+                                    if let Some(turn) = turns.get(turn_id) {
+                                        for key in &turn.route.soft_keys {
+                                            self.router.bind(key.clone(), &account).await;
+                                        }
+                                    }
+                                }
+                            }
+                            if let Some(response_id) = association.response_id.as_deref()
+                                && !association.turn_ids.is_empty()
+                            {
+                                let key = self.router.affinity.key(&format!("previous-response:{response_id}"));
+                                self.router.bind(key, &account).await;
+                                for turn_id in &association.turn_ids {
+                                    if let Some(turn) = turns.get(turn_id) {
+                                        for key in &turn.route.soft_keys {
+                                            self.router.bind(key.clone(), &account).await;
+                                        }
+                                    }
+                                }
+                            }
+                            client.send(message).await?;
+                            for turn_id in &association.turn_ids {
+                                protocol
+                                    .mark_downstream_delivered(*turn_id, &event)
+                                    .map_err(|error| anyhow::anyhow!("mark downstream event: {error:?}"))?;
+                            }
+                            if let Some(terminal) = association.terminal {
+                                let settlement = settlement_for_terminal(terminal);
+                                for turn_id in association.turn_ids {
+                                    if awaiting_response_created == Some(turn_id) {
+                                        awaiting_response_created = None;
+                                    }
+                                    protocol
+                                        .settle(turn_id, settlement)
+                                        .map_err(|error| anyhow::anyhow!("settle direct turn: {error:?}"))?;
+                                    turns.remove(&turn_id);
+                                }
+                            }
+                        }
+                        Some(Err(error)) => {
+                            let close_downstream = self
+                                .recover_or_settle_direct_end(
+                                    &mut protocol,
+                                    &mut turns,
+                                    &mut client,
+                                    &mut upstream,
+                                    &listener,
+                                    &path,
+                                    &headers,
+                                    &mut account,
+                                    &mut lease,
+                                    UpstreamEnd::TransportError { process_wide: false },
+                                )
+                                .await?;
+                            if awaiting_response_created
+                                .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
+                            {
+                                awaiting_response_created = None;
+                            }
+                            if close_downstream {
+                                return Err(error.into());
+                            }
+                        }
+                        None => {
+                            let close_downstream = self
+                                .recover_or_settle_direct_end(
+                                    &mut protocol,
+                                    &mut turns,
+                                    &mut client,
+                                    &mut upstream,
+                                    &listener,
+                                    &path,
+                                    &headers,
+                                    &mut account,
+                                    &mut lease,
+                                    UpstreamEnd::Eof,
+                                )
+                                .await?;
+                            if awaiting_response_created
+                                .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
+                            {
+                                awaiting_response_created = None;
+                            }
+                            if close_downstream {
+                                break;
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn try_replay_direct_turn(
+        &self,
+        protocol: &mut ProtocolState,
+        turns: &mut HashMap<TurnId, DirectTurn>,
+        turn_id: TurnId,
+        failure: FailureKind,
+        context: ReplayContext,
+        listener: &ListenerConfig,
+        path: &str,
+        headers: &hyper::HeaderMap,
+        account: &str,
+    ) -> Result<Option<(UpgradedWebSocket, String)>> {
+        let Some(turn) = turns.get(&turn_id) else {
+            return Ok(None);
+        };
+        let mut plan = match protocol.replay_plan(turn_id, failure, context) {
+            Ok(plan) => plan,
+            Err(_) => {
+                match failure {
+                    FailureKind::Quota => {
+                        self.router
+                            .quota_failure(account, &hyper::HeaderMap::new())
+                            .await;
+                    }
+                    FailureKind::Authentication { .. } => {
+                        self.router.auth_failure(account).await;
+                    }
+                    FailureKind::Transient => self.router.soft_failure(account).await,
+                    _ => {}
+                }
+                return Ok(None);
+            }
+        };
+        let mut replacement_account =
+            match plan.target {
+                ReplayTarget::SameAccountAfterRefresh => {
+                    let credentials = self
+                        .auth
+                        .resolve(&self.config.accounts[account], headers)
+                        .await?;
+                    match self
+                        .auth
+                        .force_refresh(&self.config.accounts[account], &credentials)
+                        .await
+                    {
+                        Ok(Some(_)) => account.to_owned(),
+                        Ok(None) | Err(_) => {
+                            // Consume the unavailable refresh stage before moving to the explicit
+                            // failover stage; otherwise the state machine would propose refresh again.
+                            protocol.skip_auth_refresh_stage(turn_id).map_err(|error| {
+                                anyhow::anyhow!("consume direct auth refresh stage: {error:?}")
+                            })?;
+                            plan = protocol.replay_plan(turn_id, failure, context).map_err(
+                                |error| anyhow::anyhow!("plan direct auth failover: {error:?}"),
+                            )?;
+                            String::new()
+                        }
+                    }
+                }
+                ReplayTarget::AlternateAccount => String::new(),
+                ReplayTarget::Unspecified if failure == FailureKind::PreviousResponseNotFound => {
+                    // A safe full resend intentionally drops the stale response anchor. It can and
+                    // should recover on the same account, including a one-account deployment.
+                    account.to_owned()
+                }
+                ReplayTarget::Unspecified => {
+                    if failure == FailureKind::Quota {
+                        self.router
+                            .quota_failure(account, &hyper::HeaderMap::new())
+                            .await;
+                    } else {
+                        self.router.soft_failure(account).await;
+                    }
+                    String::new()
+                }
+            };
+        if plan.target == ReplayTarget::AlternateAccount || replacement_account.is_empty() {
+            if matches!(failure, FailureKind::Authentication { .. }) {
+                self.router.auth_failure(account).await;
+            }
+            if turn.route.hard_owner && plan.mode == ReplayMode::OriginalRequest {
+                return Ok(None);
+            }
+            let Some(selection) = self
+                .router
+                .select(&listener.pool, self.pool(listener)?, None, Some(account))
+                .await
+            else {
+                return Ok(None);
+            };
+            replacement_account = selection.account_id;
+        }
+        let mode = plan.mode;
+        let mut replacement = match self
+            .connect_direct_upstream(
+                &replacement_account,
+                path,
+                headers,
+                replacement_account != account
+                    || mode == ReplayMode::FreshRequestWithoutPreviousResponse,
+            )
+            .await
+        {
+            Ok(replacement) => replacement,
+            Err(error) => {
+                warn!(%error, account = replacement_account, "safe direct replay reconnect failed");
+                if plan.target == ReplayTarget::SameAccountAfterRefresh {
+                    protocol.skip_auth_refresh_stage(turn_id).map_err(|error| {
+                        anyhow::anyhow!("consume failed direct auth reconnect: {error:?}")
+                    })?;
+                    return Box::pin(self.try_replay_direct_turn(
+                        protocol, turns, turn_id, failure, context, listener, path, headers,
+                        account,
+                    ))
+                    .await;
+                }
+                return Ok(None);
+            }
+        };
+        let mut replacement_lease =
+            DirectAccountLease::new(self.router.clone(), replacement_account.clone());
+        let replay_value = match mode {
+            ReplayMode::OriginalRequest => turn.value.clone(),
+            ReplayMode::FreshRequestWithoutPreviousResponse => {
+                fresh_replay_without_previous_response(&turn.value, ProtocolLimits::default())
+                    .map_err(|error| anyhow::anyhow!("prepare fresh direct replay: {error:?}"))?
+            }
+        };
+        let replay_message = match mode {
+            ReplayMode::OriginalRequest => turn.request.clone(),
+            ReplayMode::FreshRequestWithoutPreviousResponse => {
+                Message::Text(serde_json::to_string(&replay_value)?.into())
+            }
+        };
+        let committed = protocol
+            .prepare_replay_plan(turn_id, failure, context)
+            .map_err(|error| anyhow::anyhow!("commit direct replay plan: {error:?}"))?;
+        if committed != plan {
+            anyhow::bail!("direct replay plan changed before commit")
+        }
+        if let Err(error) = replacement.send(replay_message.clone()).await {
+            warn!(%error, account = replacement_account, "safe direct replay send failed");
+            return Ok(None);
+        }
+        if let Some(turn) = turns.get_mut(&turn_id) {
+            turn.request = replay_message;
+            turn.value = replay_value;
+            turn.route.account_id = replacement_account.clone();
+            if mode == ReplayMode::FreshRequestWithoutPreviousResponse {
+                turn.route.hard_owner = turn.route.non_previous_hard_owner;
+            }
+        }
+        if replacement_account != account {
+            protocol
+                .reset_auth_sequence_after_account_switch(turn_id)
+                .map_err(|error| anyhow::anyhow!("reset direct auth sequence: {error:?}"))?;
+        }
+        replacement_lease.disarm();
+        Ok(Some((replacement, replacement_account)))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn recover_or_settle_direct_end(
+        &self,
+        protocol: &mut ProtocolState,
+        turns: &mut HashMap<TurnId, DirectTurn>,
+        client: &mut UpgradedWebSocket,
+        upstream: &mut UpgradedWebSocket,
+        listener: &ListenerConfig,
+        path: &str,
+        headers: &hyper::HeaderMap,
+        account: &mut String,
+        lease: &mut DirectAccountLease,
+        end: UpstreamEnd,
+    ) -> Result<bool> {
+        if protocol.pending_len() == 1 && !matches!(end, UpstreamEnd::Close { code: 1000 }) {
+            let turn_id = protocol.pending().next().expect("one pending").id();
+            if let Some((replacement, replacement_account)) = self
+                .try_replay_direct_turn(
+                    protocol,
+                    turns,
+                    turn_id,
+                    FailureKind::Transient,
+                    ReplayContext::default(),
+                    listener,
+                    path,
+                    headers,
+                    account,
+                )
+                .await?
+            {
+                let _ = tokio::time::timeout(Duration::from_secs(2), upstream.close(None)).await;
+                *account = replacement_account;
+                lease.replace(account.clone()).await;
+                *upstream = replacement;
+                return Ok(false);
+            }
+        }
+        let plan = protocol.classify_upstream_end(end);
+        if plan.penalize_account {
+            self.router.soft_failure(account).await;
+        }
+        for action in plan.turns {
+            let response_id = protocol
+                .turn(action.turn_id)
+                .and_then(|turn| turn.response_id())
+                .unwrap_or("")
+                .to_owned();
+            match action.disposition {
+                TurnEndDisposition::RejectedInput => {
+                    send_direct_error(
+                        client,
+                        "upstream_rejected_input",
+                        "upstream closed cleanly before accepting response.create",
+                    )
+                    .await?;
+                    let _ = protocol.settle(action.turn_id, Settlement::RejectedInput);
+                }
+                TurnEndDisposition::StreamIncomplete => {
+                    let payload = serde_json::json!({
+                        "type":"response.failed",
+                        "response":{
+                            "id":response_id,
+                            "status":"failed",
+                            "error":{"type":"server_error","code":"stream_incomplete","message":"upstream stream ended before a terminal event"}
+                        }
+                    });
+                    client
+                        .send(Message::Text(payload.to_string().into()))
+                        .await?;
+                    let _ = protocol.settle(action.turn_id, Settlement::Incomplete);
+                }
+                TurnEndDisposition::StreamIncompleteNoSynthetic => {
+                    let _ = protocol.settle(action.turn_id, Settlement::Incomplete);
+                }
+            }
+            turns.remove(&action.turn_id);
+        }
+        if plan.downstream == DownstreamEndAction::Close1011 {
+            let _ = client
+                .close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                    code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error,
+                    reason: "upstream stream incomplete".into(),
+                }))
+                .await;
+            return Ok(true);
+        }
+        match self
+            .connect_direct_upstream(account, path, headers, true)
+            .await
+        {
+            Ok(replacement) => {
+                let _ = tokio::time::timeout(Duration::from_secs(2), upstream.close(None)).await;
+                lease.replace(account.clone()).await;
+                *upstream = replacement;
+                Ok(false)
+            }
+            Err(error) => {
+                warn!(%error, "failed to reopen direct Responses upstream");
+                let _ = client
+                    .close(Some(tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error,
+                        reason: "upstream reconnect failed".into(),
+                    }))
+                    .await;
+                Ok(true)
+            }
+        }
+    }
+
+    async fn handle_upgrade(
+        self: &Arc<Self>,
         mut req: Request<Incoming>,
         listener: &ListenerConfig,
         path: String,
@@ -449,7 +1927,10 @@ impl App {
         let inbound_headers = req.headers().clone();
         let pool = self.pool(listener)?;
         let forced_live = live_call_id.is_some();
-        let affinity_values = metadata::affinity_values(&inbound_headers, None, None, None);
+        let frame_aware_direct = !forced_live
+            && is_native_responses(&path)
+            && self.config.proxy.responses_websocket_mode == ResponsesWebsocketMode::Direct;
+        let affinity_values = metadata::affinity_values(&inbound_headers, None, None, None, &[]);
         let affinity_keys: Vec<_> = affinity_values
             .iter()
             .map(|value| (value.kind, self.router.affinity.key(&value.namespaced())))
@@ -514,13 +1995,19 @@ impl App {
             selection
         } else {
             self.router
-                .select(&listener.pool, pool, key.clone(), None)
+                .select(
+                    &listener.pool,
+                    pool,
+                    if frame_aware_direct {
+                        None
+                    } else {
+                        key.clone()
+                    },
+                    None,
+                )
                 .await
                 .context("no eligible account")?
         };
-        for (_, alias) in &affinity_keys {
-            self.router.bind(alias.clone(), &selection.account_id).await;
-        }
         let attempts = 2;
         for attempt in 0..attempts {
             let uri = self.upstream_uri(&path, live::uses_v1_origin(&path))?;
@@ -556,6 +2043,9 @@ impl App {
                         "upstream selected a websocket subprotocol not offered by the client",
                     ));
                 }
+                for (_, alias) in &affinity_keys {
+                    self.router.bind(alias.clone(), &selection.account_id).await;
+                }
                 if let Some(turn_state) = response
                     .headers()
                     .get("x-codex-turn-state")
@@ -573,22 +2063,67 @@ impl App {
                 let stats = self.stats.clone();
                 let router = self.router.clone();
                 let account = selection.account_id.clone();
+                let app = self.clone();
+                let listener = listener.clone();
+                let path = path.clone();
+                let headers = inbound_headers.clone();
+                let direct = !forced_live
+                    && is_native_responses(&path)
+                    && self.config.proxy.responses_websocket_mode == ResponsesWebsocketMode::Direct;
                 stats.open_upgrades.fetch_add(1, Ordering::Relaxed);
-                tokio::spawn(async move {
-                    let _permit = permit;
-                    match tokio::try_join!(client_upgrade, upstream_upgrade) {
-                        Ok((client, upstream)) => {
-                            let _ = tokio::io::copy_bidirectional(
-                                &mut TokioIo::new(client),
-                                &mut TokioIo::new(upstream),
-                            )
-                            .await;
+                let upgrade_guard = OpenUpgradeGuard(stats.clone());
+                let spawned = self
+                    .spawn_tracked(async move {
+                        let _upgrade_guard = upgrade_guard;
+                        let _permit = permit;
+                        match tokio::try_join!(client_upgrade, upstream_upgrade) {
+                            Ok((client, upstream)) => {
+                                if direct {
+                                    let client = WebSocketStream::from_raw_socket(
+                                        TokioIo::new(client),
+                                        Role::Server,
+                                        None,
+                                    )
+                                    .await;
+                                    let upstream = WebSocketStream::from_raw_socket(
+                                        TokioIo::new(upstream),
+                                        Role::Client,
+                                        None,
+                                    )
+                                    .await;
+                                    if let Err(error) = app
+                                        .run_responses_direct(
+                                            client,
+                                            upstream,
+                                            listener,
+                                            path,
+                                            headers,
+                                            account.clone(),
+                                        )
+                                        .await
+                                    {
+                                        warn!(%error, "direct Responses WebSocket ended");
+                                    }
+                                } else {
+                                    let _ = tokio::io::copy_bidirectional(
+                                        &mut TokioIo::new(client),
+                                        &mut TokioIo::new(upstream),
+                                    )
+                                    .await;
+                                    router.end(&account).await;
+                                }
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "upgrade failed");
+                                router.end(&account).await;
+                            }
                         }
-                        Err(e) => warn!(error = %e, "upgrade failed"),
-                    }
-                    stats.open_upgrades.fetch_sub(1, Ordering::Relaxed);
-                    router.end(&account).await;
-                });
+                    })
+                    .await;
+                if !spawned {
+                    self.router.end(&selection.account_id).await;
+                    anyhow::bail!("proxy is shutting down")
+                }
                 return Ok(map_upgrade_response(response));
             }
             self.router.end(&selection.account_id).await;
@@ -669,6 +2204,18 @@ impl App {
     }
 }
 
+fn is_authoritative_file_finalize_success(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("status")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .is_some_and(|status| status.eq_ignore_ascii_case("success"))
+}
+
 fn apply_credentials(headers: &mut hyper::HeaderMap, credentials: auth::Credentials) -> Result<()> {
     headers.insert(AUTHORIZATION, credentials.authorization.parse()?);
     match credentials.account_id {
@@ -725,6 +2272,21 @@ fn normalize_websocket_beta(headers: &mut hyper::HeaderMap, path: &str) {
     }
 }
 
+fn strip_direct_session_headers(headers: &mut hyper::HeaderMap) {
+    for name in [
+        "x-codex-turn-state",
+        "session_id",
+        "session-id",
+        "x-codex-session-id",
+        "x-codex-conversation-id",
+        "thread-id",
+        "x-codex-parent-thread-id",
+        "x-codex-turn-metadata",
+    ] {
+        headers.remove(name);
+    }
+}
+
 fn selected_subprotocol_is_offered(
     request: &hyper::HeaderMap,
     response: &hyper::HeaderMap,
@@ -778,6 +2340,19 @@ fn is_native_responses(path: &str) -> bool {
     )
 }
 
+fn is_file_create(method: &Method, path: &str) -> bool {
+    *method == Method::POST && path.split('?').next() == Some("/files")
+}
+
+fn finalized_file_id(method: &Method, path: &str) -> Option<String> {
+    if *method != Method::POST {
+        return None;
+    }
+    let path = path.split('?').next()?;
+    let middle = path.strip_prefix("/files/")?.strip_suffix("/uploaded")?;
+    (!middle.is_empty() && !middle.contains('/')).then(|| middle.to_owned())
+}
+
 fn is_connect_failure(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<hyper_util::client::legacy::Error>()
@@ -794,15 +2369,33 @@ fn map_http_response_leased(
     response: Response<Incoming>,
     router: Arc<Router>,
     account: String,
+    observe_response_ids: bool,
 ) -> Response<ProxyBody> {
     let (mut parts, body) = response.into_parts();
     headers::strip_hop_by_hop(&mut parts.headers);
+    parts.extensions.insert(SelectedAccount(account.clone()));
+    let observer = observe_response_ids.then(|| {
+        if parts
+            .headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.to_ascii_lowercase().contains("application/json"))
+        {
+            HttpResponseObserver::Json(Vec::new())
+        } else {
+            HttpResponseObserver::Sse(SseDecoder::default())
+        }
+    });
     Response::from_parts(
         parts,
         BodyExt::boxed(LeasedIncoming {
             inner: body,
             router,
             account: Some(account),
+            observer,
+            pending_frame: None,
+            pending_binding: None,
+            pending_end: false,
         }),
     )
 }
@@ -811,6 +2404,15 @@ struct LeasedIncoming {
     inner: Incoming,
     router: Arc<Router>,
     account: Option<String>,
+    observer: Option<HttpResponseObserver>,
+    pending_frame: Option<Frame<bytes::Bytes>>,
+    pending_binding: Option<Pin<Box<dyn Future<Output = ()> + Send + Sync>>>,
+    pending_end: bool,
+}
+
+enum HttpResponseObserver {
+    Sse(SseDecoder),
+    Json(Vec<u8>),
 }
 
 impl Body for LeasedIncoming {
@@ -821,9 +2423,47 @@ impl Body for LeasedIncoming {
         mut self: Pin<&mut Self>,
         cx: &mut TaskContext<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        Pin::new(&mut self.inner)
-            .poll_frame(cx)
-            .map(|frame| frame.map(|result| result.map_err(std::io::Error::other)))
+        loop {
+            if let Some(binding) = self.pending_binding.as_mut() {
+                if binding.as_mut().poll(cx).is_pending() {
+                    return Poll::Pending;
+                }
+                self.pending_binding = None;
+                if let Some(frame) = self.pending_frame.take() {
+                    return Poll::Ready(Some(Ok(frame)));
+                }
+                if self.pending_end {
+                    self.pending_end = false;
+                    return Poll::Ready(None);
+                }
+            }
+
+            match Pin::new(&mut self.inner).poll_frame(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Err(error))) => {
+                    return Poll::Ready(Some(Err(std::io::Error::other(error))));
+                }
+                Poll::Ready(Some(Ok(frame))) => {
+                    let ids = frame
+                        .data_ref()
+                        .map(|data| self.observe_response_data(data))
+                        .unwrap_or_default();
+                    if ids.is_empty() {
+                        return Poll::Ready(Some(Ok(frame)));
+                    }
+                    self.pending_frame = Some(frame);
+                    self.pending_binding = self.response_binding(ids);
+                }
+                Poll::Ready(None) => {
+                    let ids = self.finish_response_observer();
+                    if ids.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    self.pending_end = true;
+                    self.pending_binding = self.response_binding(ids);
+                }
+            }
+        }
     }
 
     fn is_end_stream(&self) -> bool {
@@ -833,6 +2473,88 @@ impl Body for LeasedIncoming {
     fn size_hint(&self) -> SizeHint {
         self.inner.size_hint()
     }
+}
+
+impl LeasedIncoming {
+    fn observe_response_data(&mut self, data: &[u8]) -> Vec<String> {
+        match self.observer.as_mut() {
+            Some(HttpResponseObserver::Sse(decoder)) => {
+                let mut response_id = None;
+                for slice in data.chunks(SSE_DECODE_SLICE_BYTES) {
+                    if let Ok(events) = decoder.push(slice)
+                        && response_id.is_none()
+                    {
+                        response_id = events.into_iter().find_map(response_id_from_protocol_event);
+                    }
+                }
+                response_id.into_iter().collect()
+            }
+            Some(HttpResponseObserver::Json(bytes))
+                if bytes.len().saturating_add(data.len()) <= RESPONSES_JSON_RESPONSE_LIMIT =>
+            {
+                bytes.extend_from_slice(data);
+                Vec::new()
+            }
+            Some(HttpResponseObserver::Json(_)) => {
+                self.observer = None;
+                Vec::new()
+            }
+            None => Vec::new(),
+        }
+    }
+
+    fn finish_response_observer(&mut self) -> Vec<String> {
+        match self.observer.take() {
+            Some(HttpResponseObserver::Sse(mut decoder)) => decoder
+                .finish()
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(response_id_from_protocol_event)
+                .collect(),
+            Some(HttpResponseObserver::Json(bytes)) => response_ids_from_json(&bytes),
+            None => Vec::new(),
+        }
+    }
+
+    fn response_binding(
+        &self,
+        ids: Vec<String>,
+    ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + Sync>>> {
+        let account = self.account.clone()?;
+        let router = self.router.clone();
+        Some(Box::pin(async move {
+            for response_id in ids {
+                let key = router
+                    .affinity
+                    .key(&format!("previous-response:{response_id}"));
+                router.bind(key, &account).await;
+            }
+        }))
+    }
+}
+
+fn response_id_from_protocol_event(event: ProtocolEvent) -> Option<String> {
+    event
+        .value
+        .get("response")
+        .and_then(|response| response.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+}
+
+fn response_ids_from_json(bytes: &[u8]) -> Vec<String> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return Vec::new();
+    };
+    value
+        .get("response")
+        .unwrap_or(&value)
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(|id| vec![id.to_owned()])
+        .unwrap_or_default()
 }
 
 impl Drop for LeasedIncoming {
@@ -869,17 +2591,449 @@ fn internal_error(error: anyhow::Error) -> Response<ProxyBody> {
     error_response(StatusCode::BAD_GATEWAY, "proxy_error", &error.to_string())
 }
 
+fn warmup_frames(frame: &serde_json::Value) -> [String; 2] {
+    let created_at = chrono::Utc::now().timestamp();
+    let model = frame
+        .get("model")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let base = serde_json::json!({
+        "id": "",
+        "object": "response",
+        "created_at": created_at,
+        "model": model,
+        "output": [],
+    });
+    [
+        serde_json::json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {"id":"","object":"response","created_at":created_at,"model":model,"output":[],"status":"in_progress"}
+        })
+        .to_string(),
+        serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": {"id":"","object":"response","created_at":created_at,"model":base["model"],"output":[],"status":"completed"}
+        })
+        .to_string(),
+    ]
+}
+
+async fn send_ws_error(outbound: &BridgeSender, kind: &str, message: &str) {
+    let (status, retryable) = match kind {
+        "server_busy" => (StatusCode::SERVICE_UNAVAILABLE, true),
+        "proxy_error" | "websocket_protocol_error" => (StatusCode::BAD_GATEWAY, true),
+        _ => (StatusCode::BAD_REQUEST, false),
+    };
+    let mut safe_headers = serde_json::Map::new();
+    if kind == "server_busy" {
+        safe_headers.insert("retry-after".into(), serde_json::Value::String("1".into()));
+    }
+    let error_type = if kind == "websocket_protocol_error" {
+        "protocol_error"
+    } else {
+        kind
+    };
+    let payload = serde_json::json!({
+        "type": "error",
+        "status": status.as_u16(),
+        "error": {"type": error_type, "code": kind, "message": message, "retryable": retryable},
+        "headers": safe_headers,
+    })
+    .to_string();
+    let _ = outbound.send(Message::Text(payload.into())).await;
+}
+
+async fn send_direct_error(
+    websocket: &mut UpgradedWebSocket,
+    kind: &str,
+    message: &str,
+) -> Result<()> {
+    websocket
+        .send(Message::Text(
+            serde_json::json!({
+                "type": "error",
+                "error": {"type": kind, "message": message}
+            })
+            .to_string()
+            .into(),
+        ))
+        .await?;
+    Ok(())
+}
+
+fn direct_failure_turns(
+    protocol: &ProtocolState,
+    failure: &FailureClassification,
+    anchor_hint: Option<&str>,
+) -> Vec<TurnId> {
+    if let Some(response_id) = failure.response_id.as_deref() {
+        return protocol
+            .pending()
+            .filter(|turn| turn.response_id() == Some(response_id))
+            .map(|turn| turn.id())
+            .collect();
+    }
+    if failure.kind == FailureKind::PreviousResponseNotFound
+        && let Some(anchor) = anchor_hint
+    {
+        return protocol
+            .pending()
+            .filter(|turn| turn.previous_response_id() == Some(anchor))
+            .map(|turn| turn.id())
+            .collect();
+    }
+    if protocol.pending_len() == 1 {
+        return protocol.pending().map(|turn| turn.id()).collect();
+    }
+    Vec::new()
+}
+
+fn direct_failure_anchor_hint(
+    protocol: &ProtocolState,
+    failure: &FailureClassification,
+) -> Option<String> {
+    if failure.kind != FailureKind::PreviousResponseNotFound || failure.response_id.is_some() {
+        return None;
+    }
+    let message = failure.message.as_deref().unwrap_or_default();
+    let mut anchors: Vec<&str> = protocol
+        .pending()
+        .filter_map(|turn| turn.previous_response_id())
+        .filter(|anchor| message.contains(anchor))
+        .collect();
+    anchors.sort_unstable();
+    anchors.dedup();
+    if anchors.len() == 1 {
+        return Some(anchors[0].to_owned());
+    }
+    let mut all_anchors: Vec<&str> = protocol
+        .pending()
+        .filter_map(|turn| turn.previous_response_id())
+        .collect();
+    all_anchors.sort_unstable();
+    all_anchors.dedup();
+    (all_anchors.len() == 1).then(|| all_anchors[0].to_owned())
+}
+
+fn settlement_for_terminal(terminal: TerminalKind) -> Settlement {
+    match terminal {
+        TerminalKind::Completed => Settlement::Completed,
+        TerminalKind::Failed => Settlement::Failed,
+        TerminalKind::Cancelled => Settlement::Cancelled,
+        TerminalKind::Incomplete => Settlement::Incomplete,
+    }
+}
+
+async fn bind_response_id_from_event(app: &Arc<App>, event: &str, account: &str) {
+    let Some(response_id) = serde_json::from_str::<serde_json::Value>(event)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("response")
+                .and_then(|response| response.get("id"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_owned)
+        })
+    else {
+        return;
+    };
+    let key = app
+        .router
+        .affinity
+        .key(&format!("previous-response:{response_id}"));
+    app.router.bind(key, account).await;
+}
+
+async fn pump_http_response_to_websocket(
+    response: Response<ProxyBody>,
+    outbound: &BridgeSender,
+    app: &Arc<App>,
+) -> Result<()> {
+    let status = response.status();
+    let response_headers = response.headers().clone();
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let (parts, mut body) = response.into_parts();
+    let selected_account = parts
+        .extensions
+        .get::<SelectedAccount>()
+        .map(|selected| selected.0.clone());
+    if !status.is_success() {
+        let bytes = collect_proxy_body(&mut body, FILE_CREATE_RESPONSE_LIMIT).await?;
+        let parsed = serde_json::from_slice::<serde_json::Value>(&bytes).ok();
+        let error = parsed
+            .as_ref()
+            .and_then(|value| value.get("error"))
+            .filter(|error| error.is_object())
+            .cloned()
+            .unwrap_or_else(|| {
+                let text = String::from_utf8_lossy(&bytes);
+                let text = text.trim();
+                let bounded: String = text.chars().take(4096).collect();
+                let message = if bounded.is_empty() {
+                    format!("HTTP {status}")
+                } else {
+                    format!("HTTP {status}: {bounded}")
+                };
+                serde_json::json!({"type":"upstream_error","code":"upstream_error","message":message})
+            });
+        send_ws_http_error(outbound, status, error, &response_headers).await;
+        return Ok(());
+    }
+    let explicit_sse = content_type.contains("text/event-stream");
+    let explicit_json = content_type.contains("application/json");
+    let (sniffed_sse, initial_chunks) = if !explicit_sse && !explicit_json {
+        let (kind, chunks) = sniff_unknown_responses_body(&mut body).await?;
+        (kind == SniffedBodyKind::Sse, chunks)
+    } else {
+        (false, Vec::new())
+    };
+    if explicit_sse || sniffed_sse {
+        let mut decoder = SseDecoder::default();
+        for data in initial_chunks {
+            if send_sse_data(
+                &mut decoder,
+                &data,
+                outbound,
+                app,
+                selected_account.as_deref(),
+            )
+            .await?
+            {
+                return Ok(());
+            }
+        }
+        while let Some(frame) = body.frame().await {
+            let frame = frame?;
+            let Ok(data) = frame.into_data() else {
+                continue;
+            };
+            if send_sse_data(
+                &mut decoder,
+                &data,
+                outbound,
+                app,
+                selected_account.as_deref(),
+            )
+            .await?
+            {
+                return Ok(());
+            }
+        }
+        if send_protocol_events(
+            decoder.finish()?,
+            outbound,
+            app,
+            selected_account.as_deref(),
+        )
+        .await?
+        {
+            return Ok(());
+        }
+        anyhow::bail!("upstream SSE ended without a terminal event")
+    }
+    let bytes =
+        collect_proxy_body_with_initial(&mut body, initial_chunks, RESPONSES_JSON_RESPONSE_LIMIT)
+            .await?;
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(value) => value,
+        Err(json_error) if explicit_json => {
+            return Err(json_error.into());
+        }
+        Err(_) => anyhow::bail!("successful Responses body was not valid JSON"),
+    };
+    let events = if value.get("type").is_some() {
+        vec![ProtocolEvent::from_value(value)?]
+    } else {
+        let response = value.get("response").cloned().unwrap_or(value);
+        responses_json_events(response)?
+    };
+    if !send_protocol_events(events, outbound, app, selected_account.as_deref()).await? {
+        anyhow::bail!("successful Responses JSON produced no terminal event")
+    }
+    Ok(())
+}
+
+async fn send_protocol_events(
+    events: Vec<ProtocolEvent>,
+    outbound: &BridgeSender,
+    app: &Arc<App>,
+    account: Option<&str>,
+) -> Result<bool> {
+    for event in events {
+        if let Some(account) = account {
+            bind_response_id_from_event(app, &event.payload, account).await;
+        }
+        let terminal = event.terminal.is_some();
+        if !outbound.send(Message::Text(event.payload.into())).await {
+            anyhow::bail!("downstream WebSocket backpressure prevented event delivery")
+        }
+        if terminal {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn send_sse_data(
+    decoder: &mut SseDecoder,
+    data: &[u8],
+    outbound: &BridgeSender,
+    app: &Arc<App>,
+    account: Option<&str>,
+) -> Result<bool> {
+    for slice in data.chunks(SSE_DECODE_SLICE_BYTES) {
+        if send_protocol_events(decoder.push(slice)?, outbound, app, account).await? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+async fn send_ws_http_error(
+    outbound: &BridgeSender,
+    status: StatusCode,
+    error: serde_json::Value,
+    headers: &hyper::HeaderMap,
+) {
+    let mut safe_headers = serde_json::Map::new();
+    for name in [
+        "retry-after",
+        "x-request-id",
+        "openai-request-id",
+        "openai-model",
+        "x-models-etag",
+        "x-reasoning-included",
+        "x-codex-turn-state",
+        "x-codex-primary-used-percent",
+        "x-codex-secondary-used-percent",
+        "x-codex-primary-window-minutes",
+        "x-codex-secondary-window-minutes",
+    ] {
+        if let Some(value) = headers.get(name).and_then(|value| value.to_str().ok()) {
+            safe_headers.insert(name.to_owned(), serde_json::Value::String(value.to_owned()));
+        }
+    }
+    for (name, value) in headers {
+        let name = name.as_str();
+        if (name.starts_with("x-ratelimit-") || is_safe_codex_quota_header(name))
+            && let Ok(value) = value.to_str()
+        {
+            safe_headers.insert(name.to_owned(), serde_json::Value::String(value.to_owned()));
+        }
+    }
+    let payload = serde_json::json!({
+        "type": "error",
+        "status": status.as_u16(),
+        "error": error,
+        "headers": safe_headers,
+    });
+    let _ = outbound
+        .send(Message::Text(payload.to_string().into()))
+        .await;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SniffedBodyKind {
+    Json,
+    Sse,
+}
+
+async fn sniff_unknown_responses_body(
+    body: &mut ProxyBody,
+) -> Result<(SniffedBodyKind, Vec<bytes::Bytes>)> {
+    let mut prefix = bytes::BytesMut::new();
+    let mut chunks = Vec::new();
+    while prefix.len() < UNKNOWN_CONTENT_SNIFF_BYTES {
+        let Some(frame) = body.frame().await else {
+            break;
+        };
+        let frame = frame?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        let remaining = UNKNOWN_CONTENT_SNIFF_BYTES - prefix.len();
+        prefix.extend_from_slice(&data[..data.len().min(remaining)]);
+        chunks.push(data);
+        let trimmed = prefix
+            .iter()
+            .position(|byte| !byte.is_ascii_whitespace())
+            .map(|offset| &prefix[offset..]);
+        if let Some(trimmed) = trimmed {
+            if matches!(trimmed.first(), Some(b'{') | Some(b'[')) {
+                return Ok((SniffedBodyKind::Json, chunks));
+            }
+            if [b"data:".as_slice(), b"event:", b"id:", b"retry:", b":"]
+                .iter()
+                .any(|marker| trimmed.starts_with(marker))
+            {
+                return Ok((SniffedBodyKind::Sse, chunks));
+            }
+        }
+    }
+    Ok((SniffedBodyKind::Json, chunks))
+}
+
+fn is_safe_codex_quota_header(name: &str) -> bool {
+    name.starts_with("x-codex-")
+        && (name.ends_with("-limit-name")
+            || (["-primary-", "-secondary-", "-tertiary-"]
+                .iter()
+                .any(|part| name.contains(part))
+                && ["-used-percent", "-window-minutes", "-reset-at"]
+                    .iter()
+                    .any(|suffix| name.ends_with(suffix))))
+}
+
+async fn collect_proxy_body(body: &mut ProxyBody, limit: usize) -> Result<bytes::Bytes> {
+    collect_proxy_body_with_initial(body, Vec::new(), limit).await
+}
+
+async fn collect_proxy_body_with_initial(
+    body: &mut ProxyBody,
+    initial: Vec<bytes::Bytes>,
+    limit: usize,
+) -> Result<bytes::Bytes> {
+    let mut bytes = bytes::BytesMut::new();
+    for data in initial {
+        if bytes.len().saturating_add(data.len()) > limit {
+            anyhow::bail!("upstream response exceeds bridge safety limit")
+        }
+        bytes.extend_from_slice(&data);
+    }
+    while let Some(frame) = body.frame().await {
+        let frame = frame?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        if bytes.len().saturating_add(data.len()) > limit {
+            anyhow::bail!("upstream response exceeds bridge safety limit")
+        }
+        bytes.extend_from_slice(&data);
+    }
+    Ok(bytes.freeze())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        config::{AccountConfig, ProxyConfig},
+        config::{AccountConfig, ProxyConfig, ResponsesWebsocketMode},
         routing::AffinityStore,
     };
     use bytes::Bytes;
     use http_body_util::{BodyExt, Full};
     use hyper_util::client::legacy::{Client as TestClient, connect::HttpConnector};
     use std::{collections::BTreeMap, fs, path::PathBuf, sync::Mutex, time::Duration};
+    use tokio::net::TcpStream;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
     #[derive(Clone, Debug)]
     struct Seen {
@@ -915,6 +3069,31 @@ mod tests {
             &Method::POST,
             "/anything-new",
         ));
+    }
+
+    #[test]
+    fn file_finalization_requires_explicit_success_status() {
+        assert!(is_authoritative_file_finalize_success(
+            br#"{"status":"success"}"#
+        ));
+        assert!(is_authoritative_file_finalize_success(
+            br#"{"status":"SUCCESS"}"#
+        ));
+        assert!(!is_authoritative_file_finalize_success(
+            br#"{"status":"retry"}"#
+        ));
+        assert!(!is_authoritative_file_finalize_success(br#"{"ok":true}"#));
+    }
+
+    #[test]
+    fn codex_quota_header_allowlist_excludes_identity_headers() {
+        assert!(is_safe_codex_quota_header("x-codex-tertiary-reset-at"));
+        assert!(is_safe_codex_quota_header(
+            "x-codex-team-primary-window-minutes"
+        ));
+        assert!(is_safe_codex_quota_header("x-codex-plan-limit-name"));
+        assert!(!is_safe_codex_quota_header("x-codex-account-id"));
+        assert!(!is_safe_codex_quota_header("x-codex-turn-metadata"));
     }
 
     #[tokio::test]
@@ -1060,6 +3239,423 @@ mod tests {
                 .all(|v| v.path == "/backend-api/codex/responses/compact?test=1")
         );
 
+        proxy_task.abort();
+        upstream_task.abort();
+    }
+
+    #[tokio::test]
+    async fn uploaded_file_routes_finalize_and_responses_to_creator() {
+        let dir = tempfile::tempdir().unwrap();
+        let seen = Arc::new(Mutex::new(Vec::<Seen>::new()));
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let seen_task = seen.clone();
+        let upstream_task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let seen = seen_task.clone();
+                tokio::spawn(async move {
+                    let service = service_fn(move |req: Request<Incoming>| {
+                        let seen = seen.clone();
+                        async move {
+                            let path = req.uri().path_and_query().unwrap().to_string();
+                            let authorization = req
+                                .headers()
+                                .get(AUTHORIZATION)
+                                .unwrap()
+                                .to_str()
+                                .unwrap()
+                                .to_owned();
+                            let body = req.into_body().collect().await.unwrap().to_bytes();
+                            seen.lock().unwrap().push(Seen {
+                                path: path.clone(),
+                                authorization,
+                                body,
+                            });
+                            let mut builder = Response::builder()
+                                .status(StatusCode::OK)
+                                .header(CONTENT_TYPE, "application/json");
+                            let body = if path == "/backend-api/codex/files" {
+                                builder = builder.header("x-codex-primary-used-percent", "100");
+                                Bytes::from_static(br#"{"file_id":"file_owned","upload_url":"https://blob.invalid/upload"}"#)
+                            } else if path.ends_with("/files/file_owned/uploaded") {
+                                Bytes::from_static(br#"{"status":"success"}"#)
+                            } else {
+                                Bytes::from_static(br#"{"ok":true}"#)
+                            };
+                            Ok::<_, Infallible>(builder.body(Full::new(body)).unwrap())
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+
+        let account_a = dir.path().join("a");
+        let account_b = dir.path().join("b");
+        fs::create_dir_all(&account_a).unwrap();
+        fs::create_dir_all(&account_b).unwrap();
+        fs::write(
+            account_a.join("auth.json"),
+            r#"{"tokens":{"access_token":"token-a"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            account_b.join("auth.json"),
+            r#"{"tokens":{"access_token":"token-b"}}"#,
+        )
+        .unwrap();
+
+        let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_tcp.local_addr().unwrap();
+        let listener = ListenerConfig {
+            address: proxy_addr,
+            pool: "default".into(),
+        };
+        let config = Arc::new(Config {
+            proxy: ProxyConfig {
+                upstream: format!("http://{upstream_addr}/backend-api/codex"),
+                installation_secret: "0123456789abcdef".into(),
+                affinity_key: "0123456789abcdef0123456789abcdef".into(),
+                state_dir: Some(dir.path().join("state")),
+                ..ProxyConfig::default()
+            },
+            listeners: BTreeMap::from([("default".into(), listener.clone())]),
+            pools: BTreeMap::from([(
+                "default".into(),
+                PoolConfig {
+                    members: vec!["a".into(), "b".into()],
+                },
+            )]),
+            accounts: BTreeMap::from([
+                ("a".into(), AccountConfig::CodexHome { path: account_a }),
+                ("b".into(), AccountConfig::CodexHome { path: account_b }),
+            ]),
+        });
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("affinity.json"),
+                &config.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Arc::new(Router::new(&config, affinity));
+        let app = App::new(config, router, Arc::new(Stats::default())).unwrap();
+        let proxy_task = tokio::spawn(app.serve_tcp("default".into(), listener, proxy_tcp));
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let base = format!("http://{proxy_addr}/0123456789abcdef/v1");
+
+        for (path, payload) in [
+            (
+                "/files",
+                br#"{"file_name":"a.txt","file_size":1,"use_case":"codex"}"#.as_slice(),
+            ),
+            ("/responses", br#"{"input":"fresh"}"#.as_slice()),
+            ("/files/file_owned/uploaded", br#"{}"#.as_slice()),
+            (
+                "/responses",
+                br#"{"input":[{"type":"input_file","file_id":"file_owned"}]}"#.as_slice(),
+            ),
+        ] {
+            let request = Request::builder()
+                .method(Method::POST)
+                .uri(format!("{base}{path}"))
+                .body(Full::new(Bytes::copy_from_slice(payload)))
+                .unwrap();
+            let response = client.request(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            response.into_body().collect().await.unwrap();
+        }
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(calls.len(), 4);
+        assert_eq!(calls[0].authorization, "Bearer token-a");
+        assert_eq!(calls[1].authorization, "Bearer token-b");
+        assert_eq!(calls[2].authorization, "Bearer token-a");
+        assert_eq!(calls[3].authorization, "Bearer token-a");
+
+        proxy_task.abort();
+        upstream_task.abort();
+    }
+
+    async fn start_caller_proxy(
+        dir: &std::path::Path,
+        upstream: String,
+        mode: ResponsesWebsocketMode,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<Result<()>>) {
+        let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_addr = proxy_tcp.local_addr().unwrap();
+        let listener = ListenerConfig {
+            address: proxy_addr,
+            pool: "default".into(),
+        };
+        let config = Arc::new(Config {
+            proxy: ProxyConfig {
+                upstream,
+                responses_websocket_mode: mode,
+                installation_secret: "0123456789abcdef".into(),
+                affinity_key: "0123456789abcdef0123456789abcdef".into(),
+                state_dir: Some(dir.join("state")),
+                ..ProxyConfig::default()
+            },
+            listeners: BTreeMap::from([("default".into(), listener.clone())]),
+            pools: BTreeMap::from([(
+                "default".into(),
+                PoolConfig {
+                    members: vec!["caller".into()],
+                },
+            )]),
+            accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),
+        });
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.join("affinity.json"),
+                &config.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Arc::new(Router::new(&config, affinity));
+        let app = App::new(config, router, Arc::new(Stats::default())).unwrap();
+        let task = tokio::spawn(app.serve_tcp("default".into(), listener, proxy_tcp));
+        (proxy_addr, task)
+    }
+
+    async fn connect_test_websocket(address: std::net::SocketAddr) -> WebSocketStream<TcpStream> {
+        let stream = TcpStream::connect(address).await.unwrap();
+        let mut request = format!("ws://{address}/0123456789abcdef/v1/responses")
+            .into_client_request()
+            .unwrap();
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION, "Bearer caller-token".parse().unwrap());
+        let (websocket, _) = tokio_tungstenite::client_async(request, stream)
+            .await
+            .unwrap();
+        websocket
+    }
+
+    async fn spawn_websocket_upstream(
+        multiplex: bool,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let service = service_fn(move |mut req: Request<Incoming>| async move {
+                        let key = req.headers()[SEC_WEBSOCKET_KEY].as_bytes();
+                        let accept =
+                            tokio_tungstenite::tungstenite::handshake::derive_accept_key(key);
+                        let upgrade = hyper::upgrade::on(&mut req);
+                        tokio::spawn(async move {
+                            let upgraded = upgrade.await.unwrap();
+                            let mut websocket = WebSocketStream::from_raw_socket(
+                                TokioIo::new(upgraded),
+                                Role::Server,
+                                None,
+                            )
+                            .await;
+                            if multiplex {
+                                let first = websocket.next().await.unwrap().unwrap();
+                                assert!(matches!(first, Message::Text(_)));
+                                websocket
+                                    .send(Message::Text(
+                                        serde_json::json!({"type":"response.created","sequence_number":0,"response":{"id":"resp_a","status":"in_progress"}})
+                                            .to_string()
+                                            .into(),
+                                    ))
+                                    .await
+                                    .unwrap();
+                                let second = websocket.next().await.unwrap().unwrap();
+                                assert!(matches!(second, Message::Text(_)));
+                                for payload in [
+                                    serde_json::json!({"type":"response.created","sequence_number":0,"response":{"id":"resp_b","status":"in_progress"}}),
+                                    serde_json::json!({"type":"response.completed","sequence_number":1,"response":{"id":"resp_b","status":"completed"}}),
+                                    serde_json::json!({"type":"response.completed","sequence_number":1,"response":{"id":"resp_a","status":"completed"}}),
+                                ] {
+                                    websocket
+                                        .send(Message::Text(payload.to_string().into()))
+                                        .await
+                                        .unwrap();
+                                }
+                            } else if let Some(Ok(message)) = websocket.next().await {
+                                websocket.send(message).await.unwrap();
+                            }
+                        });
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(StatusCode::SWITCHING_PROTOCOLS)
+                                .header(CONNECTION, "Upgrade")
+                                .header(UPGRADE, "websocket")
+                                .header(SEC_WEBSOCKET_ACCEPT, accept)
+                                .body(Full::new(Bytes::new()))
+                                .unwrap(),
+                        )
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .with_upgrades()
+                        .await;
+                });
+            }
+        });
+        (address, task)
+    }
+
+    #[tokio::test]
+    async fn raw_websocket_mode_preserves_binary_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        let (upstream_addr, upstream_task) = spawn_websocket_upstream(false).await;
+        let (proxy_addr, proxy_task) = start_caller_proxy(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+            ResponsesWebsocketMode::Raw,
+        )
+        .await;
+        let mut websocket = connect_test_websocket(proxy_addr).await;
+        let payload = Bytes::from_static(b"opaque-binary-frame");
+        websocket
+            .send(Message::Binary(payload.clone()))
+            .await
+            .unwrap();
+        assert_eq!(
+            websocket.next().await.unwrap().unwrap(),
+            Message::Binary(payload)
+        );
+        proxy_task.abort();
+        upstream_task.abort();
+    }
+
+    #[tokio::test]
+    async fn http_bridge_websocket_mode_converts_terminal_sse_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let service = service_fn(move |req: Request<Incoming>| async move {
+                        assert_eq!(req.headers()[CONTENT_TYPE], "application/json");
+                        assert!(req.headers().get(SEC_WEBSOCKET_KEY).is_none());
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(StatusCode::OK)
+                                .header(CONTENT_TYPE, "text/event-stream")
+                                .body(Full::new(Bytes::from_static(
+                                    b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_bridge\",\"status\":\"in_progress\"}}\n\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_bridge\",\"status\":\"completed\"}}\n\n",
+                                )))
+                                .unwrap(),
+                        )
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+        let (proxy_addr, proxy_task) = start_caller_proxy(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+            ResponsesWebsocketMode::HttpBridge,
+        )
+        .await;
+        let mut websocket = connect_test_websocket(proxy_addr).await;
+        websocket
+            .send(Message::Text(
+                serde_json::json!({"type":"response.create","input":[]})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        let created = websocket
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_text()
+            .unwrap();
+        let completed = websocket
+            .next()
+            .await
+            .unwrap()
+            .unwrap()
+            .into_text()
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&created).unwrap()["type"],
+            "response.created"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&completed).unwrap()["type"],
+            "response.completed"
+        );
+        proxy_task.abort();
+        upstream_task.abort();
+    }
+
+    #[tokio::test]
+    async fn direct_websocket_mode_tracks_multiplexed_out_of_order_terminals() {
+        let dir = tempfile::tempdir().unwrap();
+        let (upstream_addr, upstream_task) = spawn_websocket_upstream(true).await;
+        let (proxy_addr, proxy_task) = start_caller_proxy(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+            ResponsesWebsocketMode::Direct,
+        )
+        .await;
+        let mut websocket = connect_test_websocket(proxy_addr).await;
+        for thread in ["thread-a", "thread-b"] {
+            websocket
+                .send(Message::Text(
+                    serde_json::json!({
+                        "type":"response.create",
+                        "client_metadata":{"thread_id":thread},
+                        "input":[]
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        }
+        let mut event_types = Vec::new();
+        let mut terminal_ids = Vec::new();
+        for _ in 0..4 {
+            let message = websocket
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .into_text()
+                .unwrap();
+            let event: serde_json::Value = serde_json::from_str(&message).unwrap();
+            event_types.push(event["type"].as_str().unwrap().to_owned());
+            if event["type"] == "response.completed" {
+                terminal_ids.push(event["response"]["id"].as_str().unwrap().to_owned());
+            }
+        }
+        assert_eq!(
+            event_types,
+            [
+                "response.created",
+                "response.created",
+                "response.completed",
+                "response.completed"
+            ]
+        );
+        assert_eq!(terminal_ids, ["resp_b", "resp_a"]);
         proxy_task.abort();
         upstream_task.abort();
     }

--- a/src/proxy/replay_body.rs
+++ b/src/proxy/replay_body.rs
@@ -26,6 +26,8 @@ pub struct ReplayBody {
     thread_id: Option<String>,
     previous_response_id: Option<String>,
     prompt_cache_key: Option<String>,
+    file_ids: Vec<String>,
+    file_ids_overflow: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -34,13 +36,16 @@ enum KeyKind {
     ThreadId,
     PreviousResponseId,
     PromptCacheKey,
+    FileId,
+    Type,
     Other,
 }
 
-#[derive(Clone, Copy)]
 struct Container {
     object: bool,
     expect_key: bool,
+    file_id: Option<String>,
+    account_scoped_file: bool,
 }
 
 #[derive(Default)]
@@ -58,17 +63,15 @@ struct MetadataScanner {
     thread_id: Option<String>,
     previous_response_id: Option<String>,
     prompt_cache_key: Option<String>,
+    file_ids: Vec<String>,
+    file_ids_overflow: bool,
     disabled: bool,
 }
 
 impl MetadataScanner {
     fn feed(&mut self, bytes: &[u8]) {
         for &byte in bytes {
-            if self.disabled
-                || (self.thread_id.is_some()
-                    && self.previous_response_id.is_some()
-                    && self.prompt_cache_key.is_some())
-            {
+            if self.disabled {
                 return;
             }
             if self.in_string {
@@ -106,6 +109,8 @@ impl MetadataScanner {
                             KeyKind::ThreadId
                                 | KeyKind::PreviousResponseId
                                 | KeyKind::PromptCacheKey
+                                | KeyKind::FileId
+                                | KeyKind::Type
                         )
                     });
                     self.string_is_key = self.capture_value.is_none()
@@ -127,6 +132,8 @@ impl MetadataScanner {
                     self.containers.push(Container {
                         object: true,
                         expect_key: true,
+                        file_id: None,
+                        account_scoped_file: false,
                     });
                     if is_client {
                         self.client_depth = Some(self.containers.len());
@@ -141,13 +148,26 @@ impl MetadataScanner {
                     self.containers.push(Container {
                         object: false,
                         expect_key: false,
+                        file_id: None,
+                        account_scoped_file: false,
                     });
                 }
                 b'}' | b']' => {
                     if self.client_depth == Some(self.containers.len()) {
                         self.client_depth = None;
                     }
-                    self.containers.pop();
+                    if let Some(container) = self.containers.pop()
+                        && container.account_scoped_file
+                        && let Some(file_id) = container.file_id
+                        && !self.file_ids.contains(&file_id)
+                    {
+                        if self.file_ids.len() < 32 {
+                            self.file_ids.push(file_id);
+                        } else {
+                            self.file_ids_overflow = true;
+                            self.disabled = true;
+                        }
+                    }
                     self.pending_value = None;
                     self.key = None;
                 }
@@ -178,6 +198,18 @@ impl MetadataScanner {
                     KeyKind::ThreadId => self.thread_id = value,
                     KeyKind::PreviousResponseId => self.previous_response_id = value,
                     KeyKind::PromptCacheKey => self.prompt_cache_key = value,
+                    KeyKind::FileId => {
+                        if let Some(container) = self.containers.last_mut() {
+                            container.file_id = value;
+                        }
+                    }
+                    KeyKind::Type => {
+                        if let (Some(container), Some(value)) = (self.containers.last_mut(), value)
+                        {
+                            container.account_scoped_file =
+                                matches!(value.as_str(), "input_file" | "input_image");
+                        }
+                    }
                     KeyKind::ClientMetadata | KeyKind::Other => {}
                 }
             }
@@ -192,6 +224,10 @@ impl MetadataScanner {
                 Some(KeyKind::PreviousResponseId)
             } else if at_root && !self.token_overflow && self.token == b"prompt_cache_key" {
                 Some(KeyKind::PromptCacheKey)
+            } else if !self.token_overflow && self.token == b"file_id" {
+                Some(KeyKind::FileId)
+            } else if !self.token_overflow && self.token == b"type" {
+                Some(KeyKind::Type)
             } else {
                 Some(KeyKind::Other)
             };
@@ -240,6 +276,38 @@ enum Storage {
 }
 
 impl ReplayBody {
+    pub fn from_bytes(
+        bytes: Bytes,
+        hard_limit: usize,
+        global_limit: usize,
+        stats: Arc<Stats>,
+    ) -> Result<Self> {
+        if bytes.len() > hard_limit {
+            bail!("request body exceeds configured limit")
+        }
+        let previous = stats
+            .active_spool_bytes
+            .fetch_add(bytes.len(), Ordering::AcqRel);
+        if previous.saturating_add(bytes.len()) > global_limit {
+            stats
+                .active_spool_bytes
+                .fetch_sub(bytes.len(), Ordering::AcqRel);
+            bail!("global replay spool limit exceeded")
+        }
+        let mut metadata = MetadataScanner::default();
+        metadata.feed(&bytes);
+        Ok(Self {
+            len: bytes.len(),
+            storage: Storage::Memory(bytes),
+            stats,
+            thread_id: metadata.thread_id,
+            previous_response_id: metadata.previous_response_id,
+            prompt_cache_key: metadata.prompt_cache_key,
+            file_ids: metadata.file_ids,
+            file_ids_overflow: metadata.file_ids_overflow,
+        })
+    }
+
     pub async fn read(
         incoming: Incoming,
         memory_limit: usize,
@@ -298,6 +366,8 @@ impl ReplayBody {
             thread_id: metadata.thread_id,
             previous_response_id: metadata.previous_response_id,
             prompt_cache_key: metadata.prompt_cache_key,
+            file_ids: metadata.file_ids,
+            file_ids_overflow: metadata.file_ids_overflow,
         })
     }
 
@@ -311,6 +381,14 @@ impl ReplayBody {
 
     pub fn prompt_cache_key(&self) -> Option<&str> {
         self.prompt_cache_key.as_deref()
+    }
+
+    pub fn file_ids(&self) -> &[String] {
+        &self.file_ids
+    }
+
+    pub fn file_ids_overflow(&self) -> bool {
+        self.file_ids_overflow
     }
 
     pub fn body(&mut self, attempt: usize) -> Result<ProxyBody> {
@@ -351,6 +429,10 @@ pub fn json_body(value: serde_json::Value) -> ProxyBody {
         .boxed()
 }
 
+pub fn bytes_body(bytes: Bytes) -> ProxyBody {
+    Full::new(bytes).map_err(never_to_io).boxed()
+}
+
 fn never_to_io(never: std::convert::Infallible) -> std::io::Error {
     match never {}
 }
@@ -372,5 +454,10 @@ mod tests {
         scanner.feed(br#"{"previous_response_id":"resp_123","prompt_cache_key":"cache_456"}"#);
         assert_eq!(scanner.previous_response_id.as_deref(), Some("resp_123"));
         assert_eq!(scanner.prompt_cache_key.as_deref(), Some("cache_456"));
+        let mut scanner = MetadataScanner::default();
+        scanner.feed(
+            br#"{"input":[{"type":"input_file","file_id":"file_1"},{"file_id":"file_2","type":"input_image"},{"type":"function_call_output","output":{"file_id":"not_an_upload"}}]}"#,
+        );
+        assert_eq!(scanner.file_ids, ["file_1", "file_2"]);
     }
 }

--- a/src/proxy/sse.rs
+++ b/src/proxy/sse.rs
@@ -1,0 +1,582 @@
+use std::{error::Error, fmt};
+
+use serde_json::{Map, Value, json};
+
+pub const DEFAULT_MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalStatus {
+    Completed,
+    Failed,
+    Incomplete,
+}
+
+impl TerminalStatus {
+    pub fn event_type(self) -> &'static str {
+        match self {
+            Self::Completed => "response.completed",
+            Self::Failed => "response.failed",
+            Self::Incomplete => "response.incomplete",
+        }
+    }
+
+    fn from_event_type(event_type: &str) -> Option<Self> {
+        match event_type {
+            "response.completed" => Some(Self::Completed),
+            "response.failed" => Some(Self::Failed),
+            "response.incomplete" => Some(Self::Incomplete),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProtocolEvent {
+    /// The exact JSON text to place in a Responses WebSocket text frame.
+    pub payload: String,
+    /// Parsed payload for routing, logging, and response-id observation.
+    pub value: Value,
+    pub event_type: String,
+    pub terminal: Option<TerminalStatus>,
+}
+
+impl ProtocolEvent {
+    pub fn from_value(value: Value) -> Result<Self, DecodeError> {
+        let event_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or(DecodeError::MissingEventType)?
+            .to_owned();
+        let terminal = TerminalStatus::from_event_type(&event_type);
+        let payload = serde_json::to_string(&value)
+            .map_err(|error| DecodeError::InvalidJson(error.to_string()))?;
+        Ok(Self {
+            payload,
+            value,
+            event_type,
+            terminal,
+        })
+    }
+
+    fn from_payload(payload: String) -> Result<Self, DecodeError> {
+        let value: Value = serde_json::from_str(&payload)
+            .map_err(|error| DecodeError::InvalidJson(error.to_string()))?;
+        let event_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .ok_or(DecodeError::MissingEventType)?
+            .to_owned();
+        let terminal = TerminalStatus::from_event_type(&event_type);
+        Ok(Self {
+            payload,
+            value,
+            event_type,
+            terminal,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    EventTooLarge { limit: usize },
+    InvalidUtf8,
+    InvalidJson(String),
+    MissingEventType,
+    InvalidResponsesJson(&'static str),
+    PrematureEof,
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EventTooLarge { limit } => {
+                write!(formatter, "upstream SSE event exceeds {limit} byte limit")
+            }
+            Self::InvalidUtf8 => formatter.write_str("upstream SSE data is not valid UTF-8"),
+            Self::InvalidJson(message) => {
+                write!(
+                    formatter,
+                    "invalid JSON payload in upstream SSE event: {message}"
+                )
+            }
+            Self::MissingEventType => {
+                formatter.write_str("upstream Responses event has no string type")
+            }
+            Self::InvalidResponsesJson(message) => {
+                write!(formatter, "invalid successful Responses JSON: {message}")
+            }
+            Self::PrematureEof => {
+                formatter.write_str("upstream stream ended before response terminal event")
+            }
+        }
+    }
+}
+
+impl Error for DecodeError {}
+
+/// Incrementally converts an HTTP Responses SSE body into validated WebSocket events.
+///
+/// Comments and empty SSE blocks are ignored. A standalone `[DONE]` data payload is
+/// ignored, but does not count as a terminal Responses event; EOF afterward is an
+/// error. Once the first terminal event is returned, trailing input is discarded.
+pub struct SseDecoder {
+    buffer: Vec<u8>,
+    max_event_bytes: usize,
+    terminal: Option<TerminalStatus>,
+    previous_lf: Option<usize>,
+}
+
+impl Default for SseDecoder {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_EVENT_BYTES)
+    }
+}
+
+impl SseDecoder {
+    pub fn new(max_event_bytes: usize) -> Self {
+        Self {
+            buffer: Vec::new(),
+            max_event_bytes,
+            terminal: None,
+            previous_lf: None,
+        }
+    }
+
+    pub fn terminal_status(&self) -> Option<TerminalStatus> {
+        self.terminal
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.terminal.is_some()
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<ProtocolEvent>, DecodeError> {
+        if self.is_terminal() {
+            return Ok(Vec::new());
+        }
+
+        let mut events = Vec::new();
+        let mut offset = 0;
+        while offset < chunk.len() && !self.is_terminal() {
+            let remaining = &chunk[offset..];
+            let Some(relative_lf) = remaining.iter().position(|byte| *byte == b'\n') else {
+                self.extend_bounded(remaining)?;
+                break;
+            };
+            let end = offset + relative_lf + 1;
+            let through_lf = &chunk[offset..end];
+            let before_lf = &through_lf[..through_lf.len() - 1];
+
+            if self.completes_boundary(before_lf) {
+                let previous_lf = self.previous_lf.expect("boundary requires previous LF");
+                let block_end = if previous_lf > 0 && self.buffer[previous_lf - 1] == b'\r' {
+                    previous_lf - 1
+                } else {
+                    previous_lf
+                };
+                if block_end > self.max_event_bytes {
+                    return Err(DecodeError::EventTooLarge {
+                        limit: self.max_event_bytes,
+                    });
+                }
+                let event = decode_block(&self.buffer[..block_end])?;
+                self.buffer.clear();
+                self.previous_lf = None;
+                if let Some(event) = event {
+                    let terminal = event.terminal;
+                    events.push(event);
+                    if let Some(status) = terminal {
+                        self.terminal = Some(status);
+                    }
+                }
+            } else {
+                self.extend_bounded(through_lf)?;
+                self.previous_lf = Some(self.buffer.len() - 1);
+            }
+            offset = end;
+        }
+        Ok(events)
+    }
+
+    /// Completes decoding at HTTP-body EOF.
+    ///
+    /// An unterminated final SSE block is parsed, matching browser/EventSource
+    /// behavior. Completion is successful only if a Responses terminal event has
+    /// been observed.
+    pub fn finish(&mut self) -> Result<Vec<ProtocolEvent>, DecodeError> {
+        if self.is_terminal() {
+            self.buffer.clear();
+            self.previous_lf = None;
+            return Ok(Vec::new());
+        }
+
+        let mut events = Vec::new();
+        if !self.buffer.is_empty() {
+            if self.buffer.len() > self.max_event_bytes {
+                return Err(DecodeError::EventTooLarge {
+                    limit: self.max_event_bytes,
+                });
+            }
+            let block = std::mem::take(&mut self.buffer);
+            self.previous_lf = None;
+            if let Some(event) = decode_block(&block)? {
+                let terminal = event.terminal;
+                events.push(event);
+                if let Some(status) = terminal {
+                    self.terminal = Some(status);
+                }
+            }
+        }
+
+        if self.is_terminal() {
+            Ok(events)
+        } else {
+            Err(DecodeError::PrematureEof)
+        }
+    }
+
+    fn extend_bounded(&mut self, bytes: &[u8]) -> Result<(), DecodeError> {
+        // At most three bytes beyond the event limit can be a split prefix of
+        // `\r?\n\r?\n`. Reject before copying anything that cannot fit.
+        let max_buffer = self.max_event_bytes.saturating_add(3);
+        if bytes.len() > max_buffer.saturating_sub(self.buffer.len()) {
+            return Err(DecodeError::EventTooLarge {
+                limit: self.max_event_bytes,
+            });
+        }
+        self.buffer.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    fn completes_boundary(&self, before_lf: &[u8]) -> bool {
+        let Some(previous_lf) = self.previous_lf else {
+            return false;
+        };
+        let buffered_between = &self.buffer[previous_lf + 1..];
+        (buffered_between.is_empty() && before_lf.is_empty())
+            || (buffered_between == b"\r" && before_lf.is_empty())
+            || (buffered_between.is_empty() && before_lf == b"\r")
+    }
+}
+
+fn decode_block(block: &[u8]) -> Result<Option<ProtocolEvent>, DecodeError> {
+    let mut data = Vec::new();
+    for line in block.split(|byte| *byte == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        let Some(value) = line.strip_prefix(b"data:") else {
+            continue;
+        };
+        if !data.is_empty() {
+            data.push(b'\n');
+        }
+        data.extend_from_slice(value.strip_prefix(b" ").unwrap_or(value));
+    }
+
+    if data.is_empty() {
+        return Ok(None);
+    }
+    let payload = String::from_utf8(data).map_err(|_| DecodeError::InvalidUtf8)?;
+    if payload == "[DONE]" {
+        return Ok(None);
+    }
+    ProtocolEvent::from_payload(payload).map(Some)
+}
+
+/// Converts a successful, non-streaming Responses JSON object into the event
+/// lifecycle expected by the Responses WebSocket transport.
+pub fn responses_json_events(response: Value) -> Result<Vec<ProtocolEvent>, DecodeError> {
+    let object = response
+        .as_object()
+        .ok_or(DecodeError::InvalidResponsesJson(
+            "top-level value must be an object",
+        ))?;
+    let output = object
+        .get("output")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut created_response = object.clone();
+    created_response.insert("status".to_owned(), Value::String("in_progress".to_owned()));
+    created_response.insert("output".to_owned(), Value::Array(Vec::new()));
+
+    let mut events = Vec::with_capacity(output.len().saturating_add(2));
+    events.push(ProtocolEvent::from_value(json!({
+        "type": "response.created",
+        "response": Value::Object(created_response),
+    }))?);
+
+    for (output_index, item) in output.into_iter().enumerate() {
+        events.push(ProtocolEvent::from_value(json!({
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": item,
+        }))?);
+    }
+
+    let final_status = match object.get("status").and_then(Value::as_str) {
+        Some("failed") => TerminalStatus::Failed,
+        Some("incomplete") => TerminalStatus::Incomplete,
+        _ => TerminalStatus::Completed,
+    };
+    let mut terminal_response: Map<String, Value> = object.clone();
+    terminal_response.insert(
+        "status".to_owned(),
+        Value::String(
+            match final_status {
+                TerminalStatus::Completed => "completed",
+                TerminalStatus::Failed => "failed",
+                TerminalStatus::Incomplete => "incomplete",
+            }
+            .to_owned(),
+        ),
+    );
+    events.push(ProtocolEvent::from_value(json!({
+        "type": final_status.event_type(),
+        "response": Value::Object(terminal_response),
+    }))?);
+    Ok(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(event_type: &str) -> String {
+        json!({"type": event_type}).to_string()
+    }
+
+    #[test]
+    fn chooses_earliest_boundary_across_line_endings() {
+        let mut decoder = SseDecoder::default();
+        let input = format!(
+            "data: {}\n\ndata: {}\r\n\r\n",
+            event("response.created"),
+            event("response.completed")
+        );
+        let events = decoder.push(input.as_bytes()).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event_type.as_str())
+                .collect::<Vec<_>>(),
+            ["response.created", "response.completed"]
+        );
+        assert_eq!(decoder.terminal_status(), Some(TerminalStatus::Completed));
+    }
+
+    #[test]
+    fn accepts_mixed_and_chunked_boundaries() {
+        let mut decoder = SseDecoder::default();
+        assert!(
+            decoder
+                .push(format!("data: {}\r\n", event("response.created")).as_bytes())
+                .unwrap()
+                .is_empty()
+        );
+        let events = decoder
+            .push(b"\ndata: {\"type\":\"response.failed\"}\n\r\n")
+            .unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].terminal, Some(TerminalStatus::Failed));
+    }
+
+    #[test]
+    fn joins_multiple_data_lines() {
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(b"data: {\"type\":\ndata: \"response.completed\"}\n\n")
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].terminal, Some(TerminalStatus::Completed));
+    }
+
+    #[test]
+    fn ignores_comments_empty_blocks_and_done_without_treating_done_as_terminal() {
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(b": heartbeat\n\ndata: [DONE]\n\n\n\ndata: {\"type\":\"response.completed\"}\n\n")
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].terminal, Some(TerminalStatus::Completed));
+    }
+
+    #[test]
+    fn rejects_done_followed_by_eof_without_terminal_event() {
+        let mut decoder = SseDecoder::default();
+        assert!(decoder.push(b"data: [DONE]\n\n").unwrap().is_empty());
+        assert_eq!(decoder.finish(), Err(DecodeError::PrematureEof));
+    }
+
+    #[test]
+    fn rejects_invalid_json_and_missing_string_type() {
+        let mut decoder = SseDecoder::default();
+        assert!(matches!(
+            decoder.push(b"data: not-json\n\n"),
+            Err(DecodeError::InvalidJson(_))
+        ));
+
+        let mut decoder = SseDecoder::default();
+        assert_eq!(
+            decoder.push(b"data: {\"type\":42}\n\n"),
+            Err(DecodeError::MissingEventType)
+        );
+    }
+
+    #[test]
+    fn rejects_premature_eof_but_accepts_unterminated_terminal_block() {
+        let mut decoder = SseDecoder::default();
+        decoder
+            .push(b"data: {\"type\":\"response.created\"}\n\n")
+            .unwrap();
+        assert_eq!(decoder.finish(), Err(DecodeError::PrematureEof));
+
+        let mut decoder = SseDecoder::default();
+        decoder
+            .push(b"data: {\"type\":\"response.created\"}\n\n")
+            .unwrap();
+        decoder
+            .push(b"data: {\"type\":\"response.incomplete\"}")
+            .unwrap();
+        let events = decoder.finish().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].terminal, Some(TerminalStatus::Incomplete));
+    }
+
+    #[test]
+    fn stops_at_first_terminal_and_discards_trailing_data() {
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(b"data: {\"type\":\"response.completed\"}\n\ndata: not-json\n\n")
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(decoder.is_terminal());
+        assert!(decoder.push(b"data: also-not-json\n\n").unwrap().is_empty());
+        assert!(decoder.finish().unwrap().is_empty());
+    }
+
+    #[test]
+    fn enforces_event_limit_across_chunks() {
+        let mut decoder = SseDecoder::new(8);
+        assert!(decoder.push(b"data: 12").unwrap().is_empty());
+        assert_eq!(
+            decoder.push(b"3456"),
+            Err(DecodeError::EventTooLarge { limit: 8 })
+        );
+
+        let mut decoder = SseDecoder::new(35);
+        let block = b"data: {\"type\":\"response.completed\"}";
+        assert_eq!(block.len(), 35);
+        assert!(decoder.push(block).unwrap().is_empty());
+        let events = decoder.push(b"\r\n\r\n").unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn rejects_a_huge_unterminated_chunk_before_copying_it() {
+        let mut decoder = SseDecoder::new(64);
+        decoder.push(b"data: ").unwrap();
+        let before = decoder.buffer.clone();
+        let huge = vec![b'x'; 1024 * 1024];
+
+        assert_eq!(
+            decoder.push(&huge),
+            Err(DecodeError::EventTooLarge { limit: 64 })
+        );
+        assert_eq!(decoder.buffer, before);
+        assert!(decoder.buffer.capacity() <= 67);
+    }
+
+    #[test]
+    fn stops_scanning_a_huge_chunk_immediately_after_terminal() {
+        let mut decoder = SseDecoder::new(64);
+        let mut chunk = b"data: {\"type\":\"response.completed\"}\n\n".to_vec();
+        chunk.extend(std::iter::repeat_n(b'x', 1024 * 1024));
+
+        let events = decoder.push(&chunk).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].terminal, Some(TerminalStatus::Completed));
+        assert!(decoder.buffer.is_empty());
+        assert!(decoder.buffer.capacity() <= 67);
+    }
+
+    #[test]
+    fn incrementally_accepts_many_bounded_events_in_one_large_chunk() {
+        let mut decoder = SseDecoder::new(64);
+        let mut chunk = Vec::new();
+        for _ in 0..1024 {
+            chunk.extend_from_slice(b"data: {\"type\":\"response.created\"}\n\n");
+        }
+        chunk.extend_from_slice(b"data: {\"type\":\"response.completed\"}\n\n");
+        assert!(chunk.len() > decoder.max_event_bytes);
+
+        let events = decoder.push(&chunk).unwrap();
+        assert_eq!(events.len(), 1025);
+        assert_eq!(
+            events.last().unwrap().terminal,
+            Some(TerminalStatus::Completed)
+        );
+        assert!(decoder.buffer.is_empty());
+        assert!(decoder.buffer.capacity() <= decoder.max_event_bytes.saturating_mul(2));
+    }
+
+    #[test]
+    fn synthesizes_non_streaming_response_lifecycle() {
+        let response = json!({
+            "id": "resp_123",
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {"type": "message", "id": "msg_1"},
+                {"type": "reasoning", "id": "rs_1"}
+            ]
+        });
+        let events = responses_json_events(response).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event_type.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "response.created",
+                "response.output_item.done",
+                "response.output_item.done",
+                "response.completed"
+            ]
+        );
+        assert_eq!(events[1].value["output_index"], 0);
+        assert_eq!(events[2].value["output_index"], 1);
+        assert_eq!(events[0].value["response"]["output"], json!([]));
+        assert_eq!(events[3].terminal, Some(TerminalStatus::Completed));
+    }
+
+    #[test]
+    fn preserves_failed_and_incomplete_non_streaming_statuses() {
+        let failed = responses_json_events(json!({"status":"failed","output":[]})).unwrap();
+        assert_eq!(
+            failed.last().unwrap().terminal,
+            Some(TerminalStatus::Failed)
+        );
+        let incomplete = responses_json_events(json!({"status":"incomplete","output":[]})).unwrap();
+        assert_eq!(
+            incomplete.last().unwrap().terminal,
+            Some(TerminalStatus::Incomplete)
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_response_and_treats_non_array_output_as_empty() {
+        assert!(matches!(
+            responses_json_events(json!([])),
+            Err(DecodeError::InvalidResponsesJson(_))
+        ));
+        let events = responses_json_events(json!({"output": {}})).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.event_type.as_str())
+                .collect::<Vec<_>>(),
+            ["response.created", "response.completed"]
+        );
+    }
+}

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -1,0 +1,1771 @@
+//! Pure protocol state for account-aware Responses WebSocket relays.
+//!
+//! This module deliberately contains no sockets, tasks, authentication, or
+//! account selection.  A relay can use it to associate multiplexed upstream
+//! events with requests and to decide whether replay or close recovery is
+//! protocol-safe before performing any side effects.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use serde_json::Value;
+
+pub const DEFAULT_MAX_PENDING_TURNS: usize = 64;
+pub const HARD_MAX_PENDING_TURNS: usize = 1_024;
+pub const DEFAULT_MAX_IDENTIFIER_BYTES: usize = 512;
+pub const HARD_MAX_IDENTIFIER_BYTES: usize = 4_096;
+pub const DEFAULT_MAX_TRACKED_TOOL_CALLS: usize = 1_024;
+pub const HARD_MAX_TRACKED_TOOL_CALLS: usize = 16_384;
+pub const HARD_MAX_REPLAYS_PER_TURN: u8 = 1;
+pub const HARD_MAX_AUTH_REFRESH_REPLAYS_PER_TURN: u8 = 1;
+pub const HARD_MAX_AUTH_FAILOVER_REPLAYS_PER_TURN: u8 = 1;
+pub const MAX_CLASSIFIED_CODE_BYTES: usize = 128;
+pub const MAX_CLASSIFIED_MESSAGE_BYTES: usize = 2_048;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TurnId(u64);
+
+impl TurnId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProtocolLimits {
+    pub max_pending_turns: usize,
+    pub max_identifier_bytes: usize,
+    pub max_tracked_tool_calls: usize,
+    /// Non-auth replay budget. Authentication has two independent stages.
+    pub max_replays_per_turn: u8,
+    pub max_auth_refresh_replays_per_turn: u8,
+    pub max_auth_failover_replays_per_turn: u8,
+}
+
+impl Default for ProtocolLimits {
+    fn default() -> Self {
+        Self {
+            max_pending_turns: DEFAULT_MAX_PENDING_TURNS,
+            max_identifier_bytes: DEFAULT_MAX_IDENTIFIER_BYTES,
+            max_tracked_tool_calls: DEFAULT_MAX_TRACKED_TOOL_CALLS,
+            max_replays_per_turn: 1,
+            max_auth_refresh_replays_per_turn: 1,
+            max_auth_failover_replays_per_turn: 1,
+        }
+    }
+}
+
+impl ProtocolLimits {
+    pub fn validate(self) -> Result<Self, ProtocolError> {
+        if self.max_pending_turns == 0 || self.max_pending_turns > HARD_MAX_PENDING_TURNS {
+            return Err(ProtocolError::InvalidLimits("max_pending_turns"));
+        }
+        if self.max_identifier_bytes == 0 || self.max_identifier_bytes > HARD_MAX_IDENTIFIER_BYTES {
+            return Err(ProtocolError::InvalidLimits("max_identifier_bytes"));
+        }
+        if self.max_tracked_tool_calls == 0
+            || self.max_tracked_tool_calls > HARD_MAX_TRACKED_TOOL_CALLS
+        {
+            return Err(ProtocolError::InvalidLimits("max_tracked_tool_calls"));
+        }
+        if self.max_replays_per_turn > HARD_MAX_REPLAYS_PER_TURN {
+            return Err(ProtocolError::InvalidLimits("max_replays_per_turn"));
+        }
+        if self.max_auth_refresh_replays_per_turn > HARD_MAX_AUTH_REFRESH_REPLAYS_PER_TURN {
+            return Err(ProtocolError::InvalidLimits(
+                "max_auth_refresh_replays_per_turn",
+            ));
+        }
+        if self.max_auth_failover_replays_per_turn > HARD_MAX_AUTH_FAILOVER_REPLAYS_PER_TURN {
+            return Err(ProtocolError::InvalidLimits(
+                "max_auth_failover_replays_per_turn",
+            ));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProtocolError {
+    InvalidLimits(&'static str),
+    NotResponseCreate,
+    PendingLimitReached,
+    IdentifierTooLong(&'static str),
+    TurnIdExhausted,
+    UnknownTurn(TurnId),
+    DuplicateResponseId,
+    ResponseCreatedHasNoPendingTurn,
+    EventAssociationAmbiguous,
+    ReplayNotEligible(ReplayRefusal),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FullResendRefusal {
+    NoPreviousResponse,
+    InputIsNotAnArray,
+    InsufficientHistory,
+    UnmatchedToolOutput,
+    TooManyToolCalls,
+    FileBacked,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FullResendSafety {
+    Eligible,
+    Refused(FullResendRefusal),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateAnalysis {
+    pub previous_response_id: Option<String>,
+    pub input_item_count: usize,
+    pub has_file_references: bool,
+    pub full_resend: FullResendSafety,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SequenceNumber {
+    Signed(i64),
+    Unsigned(u64),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalKind {
+    Completed,
+    Failed,
+    Cancelled,
+    Incomplete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Settlement {
+    Completed,
+    Failed,
+    Cancelled,
+    Incomplete,
+    RejectedInput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettledTurn {
+    pub id: TurnId,
+    pub response_id: Option<String>,
+    pub settlement: Settlement,
+    pub finite_sequence_visible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingTurn {
+    id: TurnId,
+    original_previous_response_id: Option<String>,
+    previous_response_id: Option<String>,
+    response_id: Option<String>,
+    response_created: bool,
+    response_event_count: u32,
+    downstream_visible: bool,
+    last_visible_sequence: Option<SequenceNumber>,
+    replay_count: u8,
+    auth_refresh_replay_count: u8,
+    auth_failover_replay_count: u8,
+    analysis: CreateAnalysis,
+}
+
+impl PendingTurn {
+    pub fn id(&self) -> TurnId {
+        self.id
+    }
+
+    pub fn previous_response_id(&self) -> Option<&str> {
+        self.previous_response_id.as_deref()
+    }
+
+    pub fn original_previous_response_id(&self) -> Option<&str> {
+        self.original_previous_response_id.as_deref()
+    }
+
+    pub fn response_id(&self) -> Option<&str> {
+        self.response_id.as_deref()
+    }
+
+    pub fn response_created(&self) -> bool {
+        self.response_created
+    }
+
+    pub fn response_event_count(&self) -> u32 {
+        self.response_event_count
+    }
+
+    pub fn downstream_visible(&self) -> bool {
+        self.downstream_visible
+    }
+
+    pub fn last_visible_sequence(&self) -> Option<SequenceNumber> {
+        self.last_visible_sequence
+    }
+
+    pub fn replay_count(&self) -> u8 {
+        self.replay_count
+    }
+
+    pub fn auth_refresh_replay_count(&self) -> u8 {
+        self.auth_refresh_replay_count
+    }
+
+    pub fn auth_failover_replay_count(&self) -> u8 {
+        self.auth_failover_replay_count
+    }
+
+    pub fn analysis(&self) -> &CreateAnalysis {
+        &self.analysis
+    }
+
+    fn is_precreated(&self) -> bool {
+        !self.response_created && self.response_event_count == 0 && self.response_id.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventAssociation {
+    pub turn_ids: Vec<TurnId>,
+    pub event_type: Option<String>,
+    pub response_id: Option<String>,
+    pub terminal: Option<TerminalKind>,
+    pub failure: FailureClassification,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureKind {
+    None,
+    Quota,
+    Authentication { requires_reauthentication: bool },
+    PreviousResponseNotFound,
+    Transient,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailureClassification {
+    pub kind: FailureKind,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub response_id: Option<String>,
+}
+
+impl FailureClassification {
+    fn none() -> Self {
+        Self {
+            kind: FailureKind::None,
+            code: None,
+            message: None,
+            response_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayMode {
+    OriginalRequest,
+    FreshRequestWithoutPreviousResponse,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayTarget {
+    /// Routing is failure-specific and remains the integration's decision.
+    Unspecified,
+    /// Refresh credentials and reconnect to the account that just failed.
+    SameAccountAfterRefresh,
+    /// Exclude the account that just failed and select another account.
+    AlternateAccount,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplayPlan {
+    pub mode: ReplayMode,
+    pub target: ReplayTarget,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayRefusal {
+    UnknownTurn,
+    MultiplePendingTurns,
+    AlreadyReplayed,
+    AuthReplaySequenceExhausted,
+    ResponseCreated,
+    PriorResponseEvent,
+    DownstreamVisible,
+    FiniteSequenceVisible,
+    FileBacked,
+    ResponseIdAssigned,
+    HardContinuity,
+    UnsafeFullResend(FullResendRefusal),
+    UnsupportedFailure,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayDecision {
+    Eligible(ReplayMode),
+    Refused(ReplayRefusal),
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReplayContext {
+    /// True when the failure event being classified carries a response ID.
+    /// Quota failures may still be pre-created capacity rejection envelopes;
+    /// other failures with an ID are treated as accepted work.
+    pub current_event_has_response_id: bool,
+}
+
+impl ReplayContext {
+    pub fn from_failure(failure: &FailureClassification) -> Self {
+        Self {
+            current_event_has_response_id: failure.response_id.is_some(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpstreamEnd {
+    Close { code: u16 },
+    Eof,
+    TransportError { process_wide: bool },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnEndDisposition {
+    /// A clean 1000 close before any response event is deterministic input
+    /// rejection and must not be transparently replayed.
+    RejectedInput,
+    /// Emit a synthetic stream_incomplete terminal event for this turn.
+    StreamIncomplete,
+    /// Settle as stream_incomplete, but emit no synthetic frame because a
+    /// numeric sequence from the old generation is already downstream-visible.
+    StreamIncompleteNoSynthetic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TurnEndAction {
+    pub turn_id: TurnId,
+    pub disposition: TurnEndDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DownstreamEndAction {
+    KeepOpen,
+    Close1011,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamEndPlan {
+    pub turns: Vec<TurnEndAction>,
+    pub downstream: DownstreamEndAction,
+    pub penalize_account: bool,
+    pub process_wide: bool,
+}
+
+pub struct ProtocolState {
+    limits: ProtocolLimits,
+    next_turn_id: u64,
+    pending: VecDeque<PendingTurn>,
+    response_index: HashMap<String, TurnId>,
+}
+
+impl ProtocolState {
+    pub fn new(limits: ProtocolLimits) -> Result<Self, ProtocolError> {
+        Ok(Self {
+            limits: limits.validate()?,
+            next_turn_id: 1,
+            pending: VecDeque::new(),
+            response_index: HashMap::new(),
+        })
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub fn pending(&self) -> impl Iterator<Item = &PendingTurn> {
+        self.pending.iter()
+    }
+
+    pub fn turn(&self, id: TurnId) -> Option<&PendingTurn> {
+        self.pending.iter().find(|turn| turn.id == id)
+    }
+
+    pub fn admit_response_create(&mut self, frame: &Value) -> Result<TurnId, ProtocolError> {
+        if self.pending.len() >= self.limits.max_pending_turns {
+            return Err(ProtocolError::PendingLimitReached);
+        }
+        let analysis = analyze_response_create(frame, self.limits)?;
+        let id = TurnId(self.next_turn_id);
+        self.next_turn_id = self
+            .next_turn_id
+            .checked_add(1)
+            .ok_or(ProtocolError::TurnIdExhausted)?;
+        let previous_response_id = analysis.previous_response_id.clone();
+        self.pending.push_back(PendingTurn {
+            id,
+            original_previous_response_id: previous_response_id.clone(),
+            previous_response_id,
+            response_id: None,
+            response_created: false,
+            response_event_count: 0,
+            downstream_visible: false,
+            last_visible_sequence: None,
+            replay_count: 0,
+            auth_refresh_replay_count: 0,
+            auth_failover_replay_count: 0,
+            analysis,
+        });
+        Ok(id)
+    }
+
+    /// Associates and records an upstream event without assuming it was sent
+    /// downstream. Pass an anchor hint only when it was extracted by a trusted
+    /// parser; multiple pending turns sharing that anchor are returned together.
+    pub fn observe_upstream_event(
+        &mut self,
+        event: &Value,
+        previous_response_anchor_hint: Option<&str>,
+    ) -> Result<EventAssociation, ProtocolError> {
+        if let Some(anchor) = previous_response_anchor_hint {
+            validate_identifier(
+                anchor,
+                self.limits.max_identifier_bytes,
+                "previous_response_anchor_hint",
+            )?;
+        }
+        let event_type =
+            event_type(event).map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES));
+        let response_id = response_id(event).map(str::to_owned);
+        if let Some(id) = response_id.as_deref() {
+            validate_identifier(id, self.limits.max_identifier_bytes, "response_id")?;
+        }
+        let failure = classify_failure(event);
+        let terminal = terminal_kind(event_type.as_deref());
+
+        let mut turn_ids = if event_type.as_deref() == Some("response.created") {
+            vec![self.associate_response_created(response_id.as_deref())?]
+        } else if let Some(id) = response_id.as_deref() {
+            if let Some(turn_id) = self.response_index.get(id).copied() {
+                vec![turn_id]
+            } else if terminal.is_some() {
+                self.associate_precreated_terminal_response_id(id)?
+                    .into_iter()
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        } else if failure.kind == FailureKind::PreviousResponseNotFound {
+            self.match_previous_response_miss(previous_response_anchor_hint)
+        } else if self.pending.len() == 1 {
+            self.pending
+                .front()
+                .map(|turn| turn.id)
+                .into_iter()
+                .collect()
+        } else {
+            Vec::new()
+        };
+        turn_ids.sort_by_key(|id| id.0);
+        turn_ids.dedup();
+
+        if event_type
+            .as_deref()
+            .is_some_and(|kind| kind.starts_with("response."))
+        {
+            for id in &turn_ids {
+                if let Some(turn) = self.pending.iter_mut().find(|turn| turn.id == *id) {
+                    turn.response_event_count = turn.response_event_count.saturating_add(1);
+                }
+            }
+        }
+
+        Ok(EventAssociation {
+            turn_ids,
+            event_type,
+            response_id,
+            terminal,
+            failure,
+        })
+    }
+
+    /// Records visibility only after the downstream send succeeds.
+    pub fn mark_downstream_delivered(
+        &mut self,
+        id: TurnId,
+        event: &Value,
+    ) -> Result<(), ProtocolError> {
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.id == id)
+            .ok_or(ProtocolError::UnknownTurn(id))?;
+        turn.downstream_visible = true;
+        if let Some(sequence) = finite_sequence_number(event) {
+            turn.last_visible_sequence = Some(sequence);
+        }
+        Ok(())
+    }
+
+    /// Evaluates replay against state preceding the current failure event.
+    /// Callers should classify and decide before recording that terminal event.
+    pub fn replay_decision(
+        &self,
+        id: TurnId,
+        failure: FailureKind,
+        context: ReplayContext,
+    ) -> ReplayDecision {
+        match self.replay_plan(id, failure, context) {
+            Ok(plan) => ReplayDecision::Eligible(plan.mode),
+            Err(reason) => ReplayDecision::Refused(reason),
+        }
+    }
+
+    /// Returns both the replay body mode and the required routing action.
+    /// Authentication deliberately has a distinct two-stage budget:
+    /// same-account forced refresh, then alternate-account failover.
+    pub fn replay_plan(
+        &self,
+        id: TurnId,
+        failure: FailureKind,
+        context: ReplayContext,
+    ) -> Result<ReplayPlan, ReplayRefusal> {
+        let Some(turn) = self.turn(id) else {
+            return Err(ReplayRefusal::UnknownTurn);
+        };
+        if self.pending.len() != 1 {
+            return Err(ReplayRefusal::MultiplePendingTurns);
+        }
+        if turn.last_visible_sequence.is_some() {
+            return Err(ReplayRefusal::FiniteSequenceVisible);
+        }
+        if turn.downstream_visible {
+            return Err(ReplayRefusal::DownstreamVisible);
+        }
+        if turn.response_created {
+            return Err(ReplayRefusal::ResponseCreated);
+        }
+        if turn.response_event_count > 0 {
+            return Err(ReplayRefusal::PriorResponseEvent);
+        }
+        if turn.analysis.has_file_references {
+            return Err(ReplayRefusal::FileBacked);
+        }
+        if context.current_event_has_response_id {
+            return Err(ReplayRefusal::ResponseIdAssigned);
+        }
+
+        let supported = matches!(
+            failure,
+            FailureKind::Quota
+                | FailureKind::Authentication { .. }
+                | FailureKind::PreviousResponseNotFound
+                | FailureKind::Transient
+        );
+        if !supported {
+            return Err(ReplayRefusal::UnsupportedFailure);
+        }
+
+        let target = if let FailureKind::Authentication {
+            requires_reauthentication,
+        } = failure
+        {
+            if turn.auth_failover_replay_count > 0 {
+                return Err(ReplayRefusal::AuthReplaySequenceExhausted);
+            }
+            if !requires_reauthentication
+                && turn.auth_refresh_replay_count < self.limits.max_auth_refresh_replays_per_turn
+            {
+                ReplayTarget::SameAccountAfterRefresh
+            } else if turn.auth_failover_replay_count
+                < self.limits.max_auth_failover_replays_per_turn
+            {
+                ReplayTarget::AlternateAccount
+            } else {
+                return Err(ReplayRefusal::AuthReplaySequenceExhausted);
+            }
+        } else {
+            if turn.replay_count >= self.limits.max_replays_per_turn {
+                return Err(ReplayRefusal::AlreadyReplayed);
+            }
+            ReplayTarget::Unspecified
+        };
+
+        let mode = if turn.previous_response_id.is_none() {
+            if failure == FailureKind::PreviousResponseNotFound {
+                return Err(ReplayRefusal::HardContinuity);
+            }
+            ReplayMode::OriginalRequest
+        } else {
+            match turn.analysis.full_resend {
+                FullResendSafety::Eligible => ReplayMode::FreshRequestWithoutPreviousResponse,
+                FullResendSafety::Refused(reason) => {
+                    return Err(ReplayRefusal::UnsafeFullResend(reason));
+                }
+            }
+        };
+
+        Ok(ReplayPlan { mode, target })
+    }
+
+    pub fn prepare_replay_plan(
+        &mut self,
+        id: TurnId,
+        failure: FailureKind,
+        context: ReplayContext,
+    ) -> Result<ReplayPlan, ProtocolError> {
+        let plan = self
+            .replay_plan(id, failure, context)
+            .map_err(ProtocolError::ReplayNotEligible)?;
+        let response_id = self.turn(id).and_then(|turn| turn.response_id.clone());
+        if let Some(response_id) = response_id.as_deref() {
+            self.response_index.remove(response_id);
+        }
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.id == id)
+            .ok_or(ProtocolError::UnknownTurn(id))?;
+        match plan.target {
+            ReplayTarget::SameAccountAfterRefresh => {
+                turn.auth_refresh_replay_count = turn.auth_refresh_replay_count.saturating_add(1);
+            }
+            ReplayTarget::AlternateAccount => {
+                turn.auth_failover_replay_count = turn.auth_failover_replay_count.saturating_add(1);
+            }
+            ReplayTarget::Unspecified => {}
+        }
+        turn.replay_count = turn.replay_count.saturating_add(1);
+        turn.response_id = None;
+        turn.response_created = false;
+        turn.response_event_count = 0;
+        if plan.mode == ReplayMode::FreshRequestWithoutPreviousResponse {
+            turn.previous_response_id = None;
+        }
+        Ok(plan)
+    }
+
+    pub fn prepare_replay(
+        &mut self,
+        id: TurnId,
+        failure: FailureKind,
+        context: ReplayContext,
+    ) -> Result<ReplayMode, ProtocolError> {
+        self.prepare_replay_plan(id, failure, context)
+            .map(|plan| plan.mode)
+    }
+
+    pub fn skip_auth_refresh_stage(&mut self, id: TurnId) -> Result<(), ProtocolError> {
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.id == id)
+            .ok_or(ProtocolError::UnknownTurn(id))?;
+        turn.auth_refresh_replay_count = turn.auth_refresh_replay_count.saturating_add(1);
+        Ok(())
+    }
+
+    pub fn reset_auth_sequence_after_account_switch(
+        &mut self,
+        id: TurnId,
+    ) -> Result<(), ProtocolError> {
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.id == id)
+            .ok_or(ProtocolError::UnknownTurn(id))?;
+        turn.auth_refresh_replay_count = 0;
+        turn.auth_failover_replay_count = 0;
+        Ok(())
+    }
+
+    pub fn settle(
+        &mut self,
+        id: TurnId,
+        settlement: Settlement,
+    ) -> Result<SettledTurn, ProtocolError> {
+        let index = self
+            .pending
+            .iter()
+            .position(|turn| turn.id == id)
+            .ok_or(ProtocolError::UnknownTurn(id))?;
+        let turn = self
+            .pending
+            .remove(index)
+            .expect("position came from deque");
+        if let Some(response_id) = turn.response_id.as_deref() {
+            self.response_index.remove(response_id);
+        }
+        Ok(SettledTurn {
+            id,
+            response_id: turn.response_id,
+            settlement,
+            finite_sequence_visible: turn.last_visible_sequence.is_some(),
+        })
+    }
+
+    pub fn classify_upstream_end(&self, end: UpstreamEnd) -> UpstreamEndPlan {
+        let process_wide = matches!(end, UpstreamEnd::TransportError { process_wide: true });
+        let clean = matches!(end, UpstreamEnd::Close { code: 1000 });
+        let turns: Vec<_> = self
+            .pending
+            .iter()
+            .map(|turn| {
+                let disposition = if clean && turn.is_precreated() && !turn.downstream_visible {
+                    TurnEndDisposition::RejectedInput
+                } else if turn.last_visible_sequence.is_some() {
+                    TurnEndDisposition::StreamIncompleteNoSynthetic
+                } else {
+                    TurnEndDisposition::StreamIncomplete
+                };
+                TurnEndAction {
+                    turn_id: turn.id,
+                    disposition,
+                }
+            })
+            .collect();
+        let downstream = if turns
+            .iter()
+            .any(|turn| turn.disposition == TurnEndDisposition::StreamIncompleteNoSynthetic)
+        {
+            DownstreamEndAction::Close1011
+        } else {
+            DownstreamEndAction::KeepOpen
+        };
+        let has_incomplete = turns.iter().any(|turn| {
+            matches!(
+                turn.disposition,
+                TurnEndDisposition::StreamIncomplete
+                    | TurnEndDisposition::StreamIncompleteNoSynthetic
+            )
+        });
+        UpstreamEndPlan {
+            turns,
+            downstream,
+            penalize_account: has_incomplete && !process_wide,
+            process_wide,
+        }
+    }
+
+    fn associate_response_created(
+        &mut self,
+        response_id: Option<&str>,
+    ) -> Result<TurnId, ProtocolError> {
+        if let Some(response_id) = response_id
+            && let Some(id) = self.response_index.get(response_id)
+        {
+            return Ok(*id);
+        }
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.response_id.is_none() && !turn.response_created)
+            .ok_or(ProtocolError::ResponseCreatedHasNoPendingTurn)?;
+        turn.response_created = true;
+        if let Some(response_id) = response_id {
+            if self.response_index.contains_key(response_id) {
+                return Err(ProtocolError::DuplicateResponseId);
+            }
+            turn.response_id = Some(response_id.to_owned());
+            self.response_index.insert(response_id.to_owned(), turn.id);
+        }
+        Ok(turn.id)
+    }
+
+    /// Associates a terminal that assigned an ID without first emitting
+    /// `response.created`. Guessing is safe only when exactly one pending turn
+    /// is still wholly pre-created; otherwise the event remains unassociated.
+    ///
+    /// A relay that may transparently replay the terminal should call this
+    /// before `replay_plan`, then call `observe_upstream_event` only if it will
+    /// deliver or settle the event. This preserves pre-event replay semantics.
+    pub fn associate_precreated_terminal_response_id(
+        &mut self,
+        response_id: &str,
+    ) -> Result<Option<TurnId>, ProtocolError> {
+        validate_identifier(response_id, self.limits.max_identifier_bytes, "response_id")?;
+        if let Some(turn_id) = self.response_index.get(response_id).copied() {
+            return Ok(Some(turn_id));
+        }
+        let mut candidates = self
+            .pending
+            .iter()
+            .filter(|turn| turn.is_precreated())
+            .map(|turn| turn.id);
+        let Some(candidate) = candidates.next() else {
+            return Ok(None);
+        };
+        if candidates.next().is_some() {
+            return Ok(None);
+        }
+
+        let turn = self
+            .pending
+            .iter_mut()
+            .find(|turn| turn.id == candidate)
+            .expect("candidate came from pending turns");
+        turn.response_id = Some(response_id.to_owned());
+        self.response_index
+            .insert(response_id.to_owned(), candidate);
+        Ok(Some(candidate))
+    }
+
+    fn match_previous_response_miss(&self, anchor_hint: Option<&str>) -> Vec<TurnId> {
+        if let Some(anchor) = anchor_hint {
+            return self
+                .pending
+                .iter()
+                .filter(|turn| turn.previous_response_id.as_deref() == Some(anchor))
+                .map(|turn| turn.id)
+                .collect();
+        }
+        if self.pending.len() == 1 {
+            return self
+                .pending
+                .front()
+                .map(|turn| turn.id)
+                .into_iter()
+                .collect();
+        }
+        Vec::new()
+    }
+}
+
+pub fn analyze_response_create(
+    frame: &Value,
+    limits: ProtocolLimits,
+) -> Result<CreateAnalysis, ProtocolError> {
+    limits.validate()?;
+    let object = frame.as_object().ok_or(ProtocolError::NotResponseCreate)?;
+    if object.get("type").and_then(Value::as_str) != Some("response.create") {
+        return Err(ProtocolError::NotResponseCreate);
+    }
+    let previous_response_id = object
+        .get("previous_response_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned);
+    if let Some(previous_response_id) = previous_response_id.as_deref() {
+        validate_identifier(
+            previous_response_id,
+            limits.max_identifier_bytes,
+            "previous_response_id",
+        )?;
+    }
+    let input = object.get("input");
+    let input_item_count = input.and_then(Value::as_array).map_or(0, Vec::len);
+    let has_file_references = input.is_some_and(has_file_reference);
+    let full_resend = analyze_full_resend(
+        previous_response_id.as_deref(),
+        input,
+        has_file_references,
+        limits,
+    );
+    Ok(CreateAnalysis {
+        previous_response_id,
+        input_item_count,
+        has_file_references,
+        full_resend,
+    })
+}
+
+/// Returns a verified fresh replay payload with the stale anchor removed.
+pub fn fresh_replay_without_previous_response(
+    frame: &Value,
+    limits: ProtocolLimits,
+) -> Result<Value, ProtocolError> {
+    let analysis = analyze_response_create(frame, limits)?;
+    match analysis.full_resend {
+        FullResendSafety::Eligible => {}
+        FullResendSafety::Refused(reason) => {
+            return Err(ProtocolError::ReplayNotEligible(
+                ReplayRefusal::UnsafeFullResend(reason),
+            ));
+        }
+    }
+    let mut fresh = frame.clone();
+    fresh
+        .as_object_mut()
+        .expect("analysis accepted an object")
+        .remove("previous_response_id");
+    Ok(fresh)
+}
+
+pub fn classify_failure(event: &Value) -> FailureClassification {
+    let response_id =
+        response_id(event).map(|value| bounded_owned(value, DEFAULT_MAX_IDENTIFIER_BYTES));
+    let Some(error) = event
+        .get("error")
+        .or_else(|| {
+            event
+                .get("response")
+                .and_then(|response| response.get("error"))
+        })
+        .and_then(Value::as_object)
+        .or_else(|| {
+            (event.get("type").and_then(Value::as_str) == Some("error"))
+                .then(|| event.as_object())
+                .flatten()
+        })
+    else {
+        return FailureClassification::none();
+    };
+    let raw_code = error
+        .get("code")
+        .or_else(|| error.get("type"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty());
+    let code =
+        raw_code.map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES).to_ascii_lowercase());
+    let error_type = error
+        .get("error_type")
+        .or_else(|| error.get("type"))
+        .and_then(Value::as_str)
+        .map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES).to_ascii_lowercase())
+        .unwrap_or_default();
+    let param = error
+        .get("param")
+        .and_then(Value::as_str)
+        .map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES).to_ascii_lowercase())
+        .unwrap_or_default();
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(|value| bounded_owned(value, MAX_CLASSIFIED_MESSAGE_BYTES));
+    let normalized_message = message.as_deref().unwrap_or_default().to_ascii_lowercase();
+    let normalized_code = code.as_deref().unwrap_or_default();
+
+    let previous_response_not_found = normalized_code == "previous_response_not_found"
+        || (param == "previous_response_id"
+            && normalized_message.contains("previous response")
+            && normalized_message.contains("not found"));
+    let quota = [
+        "rate_limit_exceeded",
+        "usage_limit_reached",
+        "insufficient_quota",
+        "usage_not_included",
+        "quota_exceeded",
+        "overloaded_error",
+        "server_is_overloaded",
+    ]
+    .contains(&normalized_code)
+        || normalized_message.contains("usage limit")
+        || normalized_message.contains("insufficient quota")
+        || normalized_message.contains("server is overloaded");
+    let authentication = [
+        "invalid_api_key",
+        "authentication_error",
+        "account_auth_invalidated",
+        "session_expired",
+        "token_expired",
+    ]
+    .contains(&normalized_code)
+        || error_type == "authentication_error";
+    let requires_reauthentication = [
+        "reauthentication required",
+        "re-authentication required",
+        "sign in again",
+        "log in again",
+        "login again",
+    ]
+    .iter()
+    .any(|marker| normalized_message.contains(marker));
+    let transient = [
+        "server_error",
+        "bad_gateway",
+        "service_unavailable",
+        "gateway_timeout",
+        "upstream_unavailable",
+        "stream_incomplete",
+    ]
+    .contains(&normalized_code);
+
+    let kind = if previous_response_not_found {
+        FailureKind::PreviousResponseNotFound
+    } else if authentication {
+        FailureKind::Authentication {
+            requires_reauthentication,
+        }
+    } else if quota {
+        FailureKind::Quota
+    } else if transient {
+        FailureKind::Transient
+    } else {
+        FailureKind::Other
+    };
+    FailureClassification {
+        kind,
+        code,
+        message,
+        response_id,
+    }
+}
+
+pub fn response_id(event: &Value) -> Option<&str> {
+    event
+        .get("response")
+        .and_then(|response| response.get("id"))
+        .or_else(|| event.get("response_id"))
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+pub fn finite_sequence_number(event: &Value) -> Option<SequenceNumber> {
+    let value = event.get("sequence_number")?;
+    if let Some(value) = value.as_i64() {
+        return Some(SequenceNumber::Signed(value));
+    }
+    value.as_u64().map(SequenceNumber::Unsigned)
+}
+
+pub fn terminal_kind(event_type: Option<&str>) -> Option<TerminalKind> {
+    match event_type {
+        Some("response.completed") => Some(TerminalKind::Completed),
+        Some("response.failed") => Some(TerminalKind::Failed),
+        Some("response.cancelled") => Some(TerminalKind::Cancelled),
+        Some("response.incomplete") => Some(TerminalKind::Incomplete),
+        Some("error") => Some(TerminalKind::Failed),
+        _ => None,
+    }
+}
+
+fn event_type(event: &Value) -> Option<&str> {
+    event.get("type").and_then(Value::as_str)
+}
+
+fn analyze_full_resend(
+    previous_response_id: Option<&str>,
+    input: Option<&Value>,
+    has_file_references: bool,
+    limits: ProtocolLimits,
+) -> FullResendSafety {
+    if previous_response_id.is_none() {
+        return FullResendSafety::Refused(FullResendRefusal::NoPreviousResponse);
+    }
+    let Some(items) = input.and_then(Value::as_array) else {
+        return FullResendSafety::Refused(FullResendRefusal::InputIsNotAnArray);
+    };
+    if items.len() <= 1 {
+        return FullResendSafety::Refused(FullResendRefusal::InsufficientHistory);
+    }
+    if has_file_references {
+        return FullResendSafety::Refused(FullResendRefusal::FileBacked);
+    }
+    match tool_outputs_are_self_contained(items, limits.max_tracked_tool_calls) {
+        Ok(true) => FullResendSafety::Eligible,
+        Ok(false) => FullResendSafety::Refused(FullResendRefusal::UnmatchedToolOutput),
+        Err(()) => FullResendSafety::Refused(FullResendRefusal::TooManyToolCalls),
+    }
+}
+
+fn tool_outputs_are_self_contained(items: &[Value], max_calls: usize) -> Result<bool, ()> {
+    let mut calls: HashMap<&str, HashSet<&str>> = HashMap::from([
+        ("function_call", HashSet::new()),
+        ("custom_tool_call", HashSet::new()),
+        ("apply_patch_call", HashSet::new()),
+    ]);
+    let mut consumed: HashSet<(&str, &str)> = HashSet::new();
+    let mut tracked = 0usize;
+    for item in items {
+        let Some(object) = item.as_object() else {
+            continue;
+        };
+        let item_type = object
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let call_id = object
+            .get("call_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty());
+        if let Some(seen) = calls.get_mut(item_type) {
+            if let Some(call_id) = call_id {
+                tracked = tracked.saturating_add(1);
+                if tracked > max_calls {
+                    return Err(());
+                }
+                seen.insert(call_id);
+            }
+            continue;
+        }
+        let call_type = match item_type {
+            "function_call_output" => Some("function_call"),
+            "custom_tool_call_output" => Some("custom_tool_call"),
+            "apply_patch_call_output" => Some("apply_patch_call"),
+            _ => None,
+        };
+        let Some(call_type) = call_type else {
+            continue;
+        };
+        let Some(call_id) = call_id else {
+            return Ok(false);
+        };
+        if !calls[call_type].contains(call_id) || !consumed.insert((call_type, call_id)) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn has_file_reference(value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(has_file_reference),
+        Value::Object(object) => {
+            let item_type = object.get("type").and_then(Value::as_str);
+            let direct_file = matches!(item_type, Some("input_file") | Some("input_image"))
+                && object
+                    .get("file_id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|value| !value.is_empty());
+            let sediment = object
+                .get("image_url")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value.starts_with("sediment://"));
+            direct_file || sediment || object.values().any(has_file_reference)
+        }
+        _ => false,
+    }
+}
+
+fn validate_identifier(
+    value: &str,
+    max_bytes: usize,
+    field: &'static str,
+) -> Result<(), ProtocolError> {
+    if value.len() > max_bytes {
+        return Err(ProtocolError::IdentifierTooLong(field));
+    }
+    Ok(())
+}
+
+fn bounded_owned(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn state() -> ProtocolState {
+        ProtocolState::new(ProtocolLimits::default()).unwrap()
+    }
+
+    fn create(input: Value) -> Value {
+        json!({"type":"response.create","model":"gpt-test","input":input})
+    }
+
+    #[test]
+    fn pending_turns_are_bounded_and_response_created_associates_fifo() {
+        let mut state = ProtocolState::new(ProtocolLimits {
+            max_pending_turns: 2,
+            ..ProtocolLimits::default()
+        })
+        .unwrap();
+        let first = state.admit_response_create(&create(json!("one"))).unwrap();
+        let second = state.admit_response_create(&create(json!("two"))).unwrap();
+        assert_eq!(
+            state.admit_response_create(&create(json!("three"))),
+            Err(ProtocolError::PendingLimitReached)
+        );
+
+        let association = state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_a"}}),
+                None,
+            )
+            .unwrap();
+        assert_eq!(association.turn_ids, [first]);
+        let association = state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_b"}}),
+                None,
+            )
+            .unwrap();
+        assert_eq!(association.turn_ids, [second]);
+    }
+
+    #[test]
+    fn terminals_match_response_ids_out_of_order_and_settle_independently() {
+        let mut state = state();
+        let first = state.admit_response_create(&create(json!("one"))).unwrap();
+        let second = state.admit_response_create(&create(json!("two"))).unwrap();
+        state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_a"}}),
+                None,
+            )
+            .unwrap();
+        state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_b"}}),
+                None,
+            )
+            .unwrap();
+        let completed_b = json!({"type":"response.completed","response":{"id":"resp_b"}});
+        let association = state.observe_upstream_event(&completed_b, None).unwrap();
+        assert_eq!(association.turn_ids, [second]);
+        assert_eq!(association.terminal, Some(TerminalKind::Completed));
+        state
+            .mark_downstream_delivered(second, &completed_b)
+            .unwrap();
+        state.settle(second, Settlement::Completed).unwrap();
+        assert!(state.turn(first).is_some());
+        assert!(state.turn(second).is_none());
+    }
+
+    #[test]
+    fn id_bearing_terminal_before_created_associates_the_sole_precreated_turn() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let failed = json!({
+            "type":"response.failed",
+            "response":{"id":"resp_failed","error":{"code":"server_error"}}
+        });
+
+        let association = state.observe_upstream_event(&failed, None).unwrap();
+
+        assert_eq!(association.turn_ids, [turn]);
+        assert_eq!(association.response_id.as_deref(), Some("resp_failed"));
+        assert_eq!(association.terminal, Some(TerminalKind::Failed));
+        let pending = state.turn(turn).unwrap();
+        assert_eq!(pending.response_id(), Some("resp_failed"));
+        assert!(!pending.response_created());
+        assert_eq!(pending.response_event_count(), 1);
+
+        let settled = state.settle(turn, Settlement::Failed).unwrap();
+        assert_eq!(settled.response_id.as_deref(), Some("resp_failed"));
+        assert_eq!(state.pending_len(), 0);
+    }
+
+    #[test]
+    fn id_bearing_terminal_claims_the_only_remaining_precreated_turn() {
+        let mut state = state();
+        let first = state.admit_response_create(&create(json!("one"))).unwrap();
+        let second = state.admit_response_create(&create(json!("two"))).unwrap();
+        state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_a"}}),
+                None,
+            )
+            .unwrap();
+
+        let association = state
+            .observe_upstream_event(
+                &json!({"type":"response.incomplete","response":{"id":"resp_b"}}),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(association.turn_ids, [second]);
+        assert_eq!(state.turn(first).unwrap().response_id(), Some("resp_a"));
+        assert_eq!(state.turn(second).unwrap().response_id(), Some("resp_b"));
+        assert!(!state.turn(second).unwrap().response_created());
+    }
+
+    #[test]
+    fn id_bearing_terminal_does_not_guess_between_precreated_turns() {
+        let mut state = state();
+        let first = state.admit_response_create(&create(json!("one"))).unwrap();
+        let second = state.admit_response_create(&create(json!("two"))).unwrap();
+
+        let association = state
+            .observe_upstream_event(
+                &json!({"type":"response.failed","response":{"id":"resp_unknown"}}),
+                None,
+            )
+            .unwrap();
+
+        assert!(association.turn_ids.is_empty());
+        assert_eq!(state.turn(first).unwrap().response_id(), None);
+        assert_eq!(state.turn(second).unwrap().response_id(), None);
+        assert_eq!(state.turn(first).unwrap().response_event_count(), 0);
+        assert_eq!(state.turn(second).unwrap().response_event_count(), 0);
+    }
+
+    #[test]
+    fn finite_sequence_visibility_is_committed_only_after_delivery() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let event = json!({"type":"codex.keepalive","sequence_number":0});
+        assert_eq!(state.turn(turn).unwrap().last_visible_sequence(), None);
+        state.mark_downstream_delivered(turn, &event).unwrap();
+        assert_eq!(
+            state.turn(turn).unwrap().last_visible_sequence(),
+            Some(SequenceNumber::Signed(0))
+        );
+
+        let mut non_integer_state = ProtocolState::new(ProtocolLimits::default()).unwrap();
+        let turn = non_integer_state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        non_integer_state
+            .mark_downstream_delivered(turn, &json!({"sequence_number":1.5}))
+            .unwrap();
+        assert_eq!(
+            non_integer_state
+                .turn(turn)
+                .unwrap()
+                .last_visible_sequence(),
+            None
+        );
+    }
+
+    #[test]
+    fn replay_requires_a_single_previsible_unsettled_turn() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Quota, ReplayContext::default()),
+            ReplayDecision::Eligible(ReplayMode::OriginalRequest)
+        );
+        let other = state
+            .admit_response_create(&create(json!("other")))
+            .unwrap();
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Quota, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::MultiplePendingTurns)
+        );
+        state.settle(other, Settlement::Cancelled).unwrap();
+        state
+            .mark_downstream_delivered(turn, &json!({"type":"codex.rate_limits"}))
+            .unwrap();
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Quota, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::DownstreamVisible)
+        );
+    }
+
+    #[test]
+    fn replay_after_finite_sequence_is_never_allowed() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        state
+            .mark_downstream_delivered(turn, &json!({"sequence_number":7}))
+            .unwrap();
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Transient, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::FiniteSequenceVisible)
+        );
+    }
+
+    #[test]
+    fn replay_budget_is_consumed_explicitly() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        assert_eq!(
+            state
+                .prepare_replay(turn, FailureKind::Quota, ReplayContext::default())
+                .unwrap(),
+            ReplayMode::OriginalRequest
+        );
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Quota, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::AlreadyReplayed)
+        );
+    }
+
+    #[test]
+    fn generic_auth_replay_sequence_is_refresh_then_failover_then_stop() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let auth = FailureKind::Authentication {
+            requires_reauthentication: false,
+        };
+
+        let refresh = state
+            .prepare_replay_plan(turn, auth, ReplayContext::default())
+            .unwrap();
+        assert_eq!(
+            refresh,
+            ReplayPlan {
+                mode: ReplayMode::OriginalRequest,
+                target: ReplayTarget::SameAccountAfterRefresh,
+            }
+        );
+        assert_eq!(state.turn(turn).unwrap().auth_refresh_replay_count(), 1);
+        assert_eq!(state.turn(turn).unwrap().auth_failover_replay_count(), 0);
+        assert_eq!(state.turn(turn).unwrap().replay_count(), 1);
+
+        let failover = state
+            .prepare_replay_plan(turn, auth, ReplayContext::default())
+            .unwrap();
+        assert_eq!(
+            failover,
+            ReplayPlan {
+                mode: ReplayMode::OriginalRequest,
+                target: ReplayTarget::AlternateAccount,
+            }
+        );
+        assert_eq!(state.turn(turn).unwrap().auth_refresh_replay_count(), 1);
+        assert_eq!(state.turn(turn).unwrap().auth_failover_replay_count(), 1);
+        assert_eq!(state.turn(turn).unwrap().replay_count(), 2);
+        assert_eq!(
+            state.replay_plan(turn, auth, ReplayContext::default()),
+            Err(ReplayRefusal::AuthReplaySequenceExhausted)
+        );
+    }
+
+    #[test]
+    fn reauthentication_required_skips_refresh_and_permanently_consumes_auth_sequence() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let session_ended = FailureKind::Authentication {
+            requires_reauthentication: true,
+        };
+
+        let failover = state
+            .prepare_replay_plan(turn, session_ended, ReplayContext::default())
+            .unwrap();
+        assert_eq!(failover.target, ReplayTarget::AlternateAccount);
+        assert_eq!(state.turn(turn).unwrap().auth_refresh_replay_count(), 0);
+        assert_eq!(state.turn(turn).unwrap().auth_failover_replay_count(), 1);
+
+        let generic_auth = FailureKind::Authentication {
+            requires_reauthentication: false,
+        };
+        assert_eq!(
+            state.replay_plan(turn, generic_auth, ReplayContext::default()),
+            Err(ReplayRefusal::AuthReplaySequenceExhausted)
+        );
+    }
+
+    #[test]
+    fn auth_replay_consumes_the_non_auth_replay_budget() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let auth = FailureKind::Authentication {
+            requires_reauthentication: false,
+        };
+        state
+            .prepare_replay_plan(turn, auth, ReplayContext::default())
+            .unwrap();
+
+        assert_eq!(
+            state.replay_decision(turn, FailureKind::Quota, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::AlreadyReplayed)
+        );
+        assert_eq!(
+            state
+                .replay_plan(turn, auth, ReplayContext::default())
+                .unwrap()
+                .target,
+            ReplayTarget::AlternateAccount
+        );
+    }
+
+    #[test]
+    fn id_bearing_precreated_auth_terminal_is_associated_but_not_replayed() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        assert_eq!(
+            state
+                .associate_precreated_terminal_response_id("resp_auth")
+                .unwrap(),
+            Some(turn)
+        );
+        let auth = FailureKind::Authentication {
+            requires_reauthentication: false,
+        };
+
+        assert_eq!(
+            state.replay_plan(
+                turn,
+                auth,
+                ReplayContext {
+                    current_event_has_response_id: true,
+                },
+            ),
+            Err(ReplayRefusal::ResponseIdAssigned)
+        );
+        assert_eq!(state.turn(turn).unwrap().response_id(), Some("resp_auth"));
+    }
+
+    #[test]
+    fn replay_limits_cannot_expand_codex_lb_budgets() {
+        assert_eq!(
+            ProtocolState::new(ProtocolLimits {
+                max_replays_per_turn: 2,
+                ..ProtocolLimits::default()
+            })
+            .err(),
+            Some(ProtocolError::InvalidLimits("max_replays_per_turn"))
+        );
+        assert_eq!(
+            ProtocolState::new(ProtocolLimits {
+                max_auth_refresh_replays_per_turn: 2,
+                ..ProtocolLimits::default()
+            })
+            .err(),
+            Some(ProtocolError::InvalidLimits(
+                "max_auth_refresh_replays_per_turn"
+            ))
+        );
+        assert_eq!(
+            ProtocolState::new(ProtocolLimits {
+                max_auth_failover_replays_per_turn: 2,
+                ..ProtocolLimits::default()
+            })
+            .err(),
+            Some(ProtocolError::InvalidLimits(
+                "max_auth_failover_replays_per_turn"
+            ))
+        );
+    }
+
+    #[test]
+    fn clean_precreated_close_is_rejected_input_without_replay_or_penalty() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let plan = state.classify_upstream_end(UpstreamEnd::Close { code: 1000 });
+        assert_eq!(
+            plan.turns,
+            [TurnEndAction {
+                turn_id: turn,
+                disposition: TurnEndDisposition::RejectedInput,
+            }]
+        );
+        assert_eq!(plan.downstream, DownstreamEndAction::KeepOpen);
+        assert!(!plan.penalize_account);
+    }
+
+    #[test]
+    fn interrupted_unsequenced_turn_gets_synthetic_stream_incomplete() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        state
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_a"}}),
+                None,
+            )
+            .unwrap();
+        let plan = state.classify_upstream_end(UpstreamEnd::Eof);
+        assert_eq!(
+            plan.turns[0],
+            TurnEndAction {
+                turn_id: turn,
+                disposition: TurnEndDisposition::StreamIncomplete,
+            }
+        );
+        assert_eq!(plan.downstream, DownstreamEndAction::KeepOpen);
+        assert!(plan.penalize_account);
+    }
+
+    #[test]
+    fn interrupted_sequenced_turn_requires_1011_without_synthetic_frame() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        state
+            .mark_downstream_delivered(
+                turn,
+                &json!({"type":"response.created","sequence_number":0}),
+            )
+            .unwrap();
+        let plan = state.classify_upstream_end(UpstreamEnd::Eof);
+        assert_eq!(
+            plan.turns[0].disposition,
+            TurnEndDisposition::StreamIncompleteNoSynthetic
+        );
+        assert_eq!(plan.downstream, DownstreamEndAction::Close1011);
+        assert!(plan.penalize_account);
+    }
+
+    #[test]
+    fn process_wide_transport_failure_is_account_neutral() {
+        let mut state = state();
+        state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let plan = state.classify_upstream_end(UpstreamEnd::TransportError { process_wide: true });
+        assert!(plan.process_wide);
+        assert!(!plan.penalize_account);
+    }
+
+    #[test]
+    fn failure_classifier_distinguishes_quota_auth_and_previous_response_loss() {
+        assert_eq!(
+            classify_failure(&json!({"type":"error","error":{"code":"usage_limit_reached"}})).kind,
+            FailureKind::Quota
+        );
+        assert_eq!(
+            classify_failure(&json!({"type":"error","error":{"type":"authentication_error","message":"Reauthentication required"}})).kind,
+            FailureKind::Authentication {
+                requires_reauthentication: true,
+            }
+        );
+        assert_eq!(
+            classify_failure(&json!({"type":"error","error":{"code":"invalid_request_error","param":"previous_response_id","message":"Previous response was not found"}})).kind,
+            FailureKind::PreviousResponseNotFound
+        );
+        assert_eq!(
+            classify_failure(&json!({"type":"error","code":"usage_limit_reached"})).kind,
+            FailureKind::Quota
+        );
+        assert_eq!(
+            classify_failure(&json!({
+                "type":"error",
+                "status":401,
+                "error_type":"authentication_error",
+                "message":"token invalidated"
+            }))
+            .kind,
+            FailureKind::Authentication {
+                requires_reauthentication: false,
+            }
+        );
+    }
+
+    #[test]
+    fn top_level_error_is_terminal_and_associates_the_pending_turn() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let association = state
+            .observe_upstream_event(
+                &json!({"type":"error","code":"server_error","message":"failed"}),
+                None,
+            )
+            .unwrap();
+        assert_eq!(association.turn_ids, [turn]);
+        assert_eq!(association.terminal, Some(TerminalKind::Failed));
+    }
+
+    #[test]
+    fn anonymous_previous_response_miss_can_target_all_turns_sharing_an_anchor() {
+        let mut state = state();
+        let frame = json!({
+            "type":"response.create",
+            "previous_response_id":"resp_anchor",
+            "input":[{"role":"user","content":"old"},{"role":"user","content":"new"}]
+        });
+        let first = state.admit_response_create(&frame).unwrap();
+        let second = state.admit_response_create(&frame).unwrap();
+        let event = json!({"type":"error","error":{"code":"previous_response_not_found"}});
+        let association = state
+            .observe_upstream_event(&event, Some("resp_anchor"))
+            .unwrap();
+        assert_eq!(association.turn_ids, [first, second]);
+    }
+
+    #[test]
+    fn matched_tool_output_full_resend_is_eligible_and_anchor_can_be_removed() {
+        let frame = json!({
+            "type":"response.create",
+            "previous_response_id":"resp_old",
+            "input":[
+                {"type":"function_call","call_id":"call_1","name":"f","arguments":"{}"},
+                {"type":"function_call_output","call_id":"call_1","output":"ok"},
+                {"role":"user","content":[{"type":"input_text","text":"continue"}]}
+            ]
+        });
+        let analysis = analyze_response_create(&frame, ProtocolLimits::default()).unwrap();
+        assert_eq!(analysis.full_resend, FullResendSafety::Eligible);
+        let fresh =
+            fresh_replay_without_previous_response(&frame, ProtocolLimits::default()).unwrap();
+        assert!(fresh.get("previous_response_id").is_none());
+        assert_eq!(fresh["input"], frame["input"]);
+    }
+
+    #[test]
+    fn unmatched_tool_output_is_not_a_self_contained_full_resend() {
+        let frame = json!({
+            "type":"response.create",
+            "previous_response_id":"resp_old",
+            "input":[
+                {"role":"user","content":"old"},
+                {"type":"function_call_output","call_id":"missing","output":"unsafe"}
+            ]
+        });
+        let analysis = analyze_response_create(&frame, ProtocolLimits::default()).unwrap();
+        assert_eq!(
+            analysis.full_resend,
+            FullResendSafety::Refused(FullResendRefusal::UnmatchedToolOutput)
+        );
+    }
+
+    #[test]
+    fn file_backed_full_resend_is_never_replayable_on_a_fresh_account() {
+        let frame = json!({
+            "type":"response.create",
+            "previous_response_id":"resp_old",
+            "input":[
+                {"role":"user","content":"old"},
+                {"role":"user","content":[{"type":"input_file","file_id":"file_owned"}]}
+            ]
+        });
+        let analysis = analyze_response_create(&frame, ProtocolLimits::default()).unwrap();
+        assert!(analysis.has_file_references);
+        assert_eq!(
+            analysis.full_resend,
+            FullResendSafety::Refused(FullResendRefusal::FileBacked)
+        );
+    }
+
+    #[test]
+    fn safe_full_resend_allows_previous_response_miss_recovery() {
+        let frame = json!({
+            "type":"response.create",
+            "previous_response_id":"resp_old",
+            "input":[
+                {"role":"user","content":"old"},
+                {"role":"assistant","content":"answer"},
+                {"role":"user","content":"continue"}
+            ]
+        });
+        let mut state = state();
+        let turn = state.admit_response_create(&frame).unwrap();
+        let decision = state.replay_decision(
+            turn,
+            FailureKind::PreviousResponseNotFound,
+            ReplayContext::default(),
+        );
+        assert_eq!(
+            decision,
+            ReplayDecision::Eligible(ReplayMode::FreshRequestWithoutPreviousResponse)
+        );
+        state
+            .prepare_replay(
+                turn,
+                FailureKind::PreviousResponseNotFound,
+                ReplayContext::default(),
+            )
+            .unwrap();
+        assert_eq!(state.turn(turn).unwrap().previous_response_id(), None);
+        assert_eq!(
+            state.turn(turn).unwrap().original_previous_response_id(),
+            Some("resp_old")
+        );
+    }
+}

--- a/src/routing/affinity.rs
+++ b/src/routing/affinity.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fs,
+    io::Write,
     path::PathBuf,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -8,6 +9,8 @@ use std::{
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+
+const ACCOUNT_EPOCH_STORAGE_BUDGET: usize = 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ThreadKey(pub String);
@@ -23,10 +26,20 @@ pub struct Binding {
 struct Snapshot {
     version: u8,
     bindings: HashMap<String, Binding>,
+    #[serde(default)]
+    account_epochs: HashMap<String, u64>,
+}
+
+#[derive(Debug, Default)]
+struct StoreState {
+    snapshot: Snapshot,
+    generation: u64,
+    persisted_generation: u64,
 }
 
 pub struct AffinityStore {
-    inner: Mutex<Snapshot>,
+    inner: Mutex<StoreState>,
+    flush_lock: Mutex<()>,
     path: PathBuf,
     key: [u8; 32],
     max_entries: usize,
@@ -43,21 +56,33 @@ impl AffinityStore {
         idle: Duration,
     ) -> Result<Self> {
         let key = *blake3::hash(key_text.as_bytes()).as_bytes();
-        let mut snapshot = match fs::read(&path) {
-            Ok(bytes) if bytes.len() <= max_bytes => {
-                serde_json::from_slice(&bytes).context("parse affinity snapshot")?
-            }
-            Ok(_) => Snapshot::default(),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Snapshot::default(),
+        let (mut snapshot, mut dirty) = match fs::read(&path) {
+            Ok(bytes) if bytes.len() <= max_bytes.saturating_add(ACCOUNT_EPOCH_STORAGE_BUDGET) => (
+                serde_json::from_slice(&bytes).context("parse affinity snapshot")?,
+                false,
+            ),
+            Ok(_) => anyhow::bail!("affinity snapshot exceeds the hard storage limit"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => (Snapshot::default(), false),
             Err(e) => return Err(e).with_context(|| format!("read {}", path.display())),
         };
         let cutoff = now().saturating_sub(idle.as_secs());
+        let before_expiry = snapshot.bindings.len();
         snapshot
             .bindings
             .retain(|_, value| value.last_seen >= cutoff);
-        trim(&mut snapshot, max_entries, max_bytes);
+        dirty |= snapshot.bindings.len() != before_expiry;
+        dirty |= trim_stale_account_epochs(&mut snapshot, "");
+        if account_epoch_storage_bytes(&snapshot) > ACCOUNT_EPOCH_STORAGE_BUDGET {
+            anyhow::bail!("account epoch snapshot exceeds its hard storage budget")
+        }
+        dirty |= trim(&mut snapshot, max_entries, max_bytes);
         Ok(Self {
-            inner: Mutex::new(snapshot),
+            inner: Mutex::new(StoreState {
+                snapshot,
+                generation: u64::from(dirty),
+                persisted_generation: 0,
+            }),
+            flush_lock: Mutex::new(()),
             path,
             key,
             max_entries,
@@ -78,21 +103,32 @@ impl AffinityStore {
         let mut inner = self.inner.lock().await;
         let now = now();
         let expired = inner
+            .snapshot
             .bindings
             .get(&key.0)
             .is_some_and(|v| now.saturating_sub(v.last_seen) > self.idle.as_secs());
         if expired {
-            inner.bindings.remove(&key.0);
+            inner.snapshot.bindings.remove(&key.0);
+            mark_dirty(&mut inner);
             return None;
         }
-        let binding = inner.bindings.get_mut(&key.0)?;
+        let changed = inner
+            .snapshot
+            .bindings
+            .get(&key.0)
+            .is_some_and(|binding| binding.last_seen != now);
+        let binding = inner.snapshot.bindings.get_mut(&key.0)?;
         binding.last_seen = now;
-        Some(binding.clone())
+        let binding = binding.clone();
+        if changed {
+            mark_dirty(&mut inner);
+        }
+        Some(binding)
     }
 
     pub async fn put(&self, key: ThreadKey, account_id: String, generation: u64) {
         let mut inner = self.inner.lock().await;
-        inner.bindings.insert(
+        inner.snapshot.bindings.insert(
             key.0,
             Binding {
                 account_id,
@@ -100,49 +136,92 @@ impl AffinityStore {
                 account_generation: generation,
             },
         );
-        trim(&mut inner, self.max_entries, self.max_bytes);
+        trim(&mut inner.snapshot, self.max_entries, self.max_bytes);
+        mark_dirty(&mut inner);
     }
 
-    pub async fn remove(&self, key: &ThreadKey) {
-        self.inner.lock().await.bindings.remove(&key.0);
-    }
-
-    pub async fn invalidate_account(&self, account: &str) {
+    pub async fn account_epoch(&self, account: &str) -> u64 {
         self.inner
             .lock()
             .await
+            .snapshot
+            .account_epochs
+            .get(account)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub async fn remove(&self, key: &ThreadKey) {
+        let mut inner = self.inner.lock().await;
+        if inner.snapshot.bindings.remove(&key.0).is_some() {
+            mark_dirty(&mut inner);
+        }
+    }
+
+    pub async fn invalidate_account(&self, account: &str) {
+        let mut inner = self.inner.lock().await;
+        inner
+            .snapshot
             .bindings
             .retain(|_, v| v.account_id != account);
+        let epoch = inner
+            .snapshot
+            .account_epochs
+            .entry(account.to_owned())
+            .or_default();
+        *epoch = epoch.saturating_add(1);
+        trim_stale_account_epochs(&mut inner.snapshot, account);
+        mark_dirty(&mut inner);
     }
 
     pub async fn len_and_bytes(&self) -> (usize, usize) {
         let inner = self.inner.lock().await;
         (
-            inner.bindings.len(),
-            serde_json::to_vec(&*inner).map_or(0, |v| v.len()),
+            inner.snapshot.bindings.len(),
+            serde_json::to_vec(&inner.snapshot).map_or(0, |v| v.len()),
         )
     }
 
     pub async fn flush(&self) -> Result<()> {
-        let bytes = {
+        let _flush = self.flush_lock.lock().await;
+        let Some((generation, bytes)) = ({
             let mut inner = self.inner.lock().await;
-            trim(&mut inner, self.max_entries, self.max_bytes);
-            serde_json::to_vec(&*inner)?
+            if trim(&mut inner.snapshot, self.max_entries, self.max_bytes) {
+                mark_dirty(&mut inner);
+            }
+            if account_epoch_storage_bytes(&inner.snapshot) > ACCOUNT_EPOCH_STORAGE_BUDGET {
+                anyhow::bail!("account epoch snapshot exceeds its hard storage budget")
+            }
+            if inner.persisted_generation >= inner.generation {
+                None
+            } else {
+                Some((inner.generation, serde_json::to_vec(&inner.snapshot)?))
+            }
+        }) else {
+            return Ok(());
         };
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let temp = self.path.with_extension("json.tmp");
-        fs::write(&temp, bytes)?;
-        fs::rename(&temp, &self.path)?;
+        let parent = self
+            .path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        fs::create_dir_all(parent)?;
+        let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+        temp.write_all(&bytes)?;
+        temp.as_file().sync_all()?;
+        temp.persist(&self.path).map_err(|error| error.error)?;
+        let mut inner = self.inner.lock().await;
+        inner.persisted_generation = inner.persisted_generation.max(generation);
         Ok(())
     }
 }
 
-fn trim(snapshot: &mut Snapshot, max_entries: usize, max_bytes: usize) {
-    while snapshot.bindings.len() > max_entries
-        || serde_json::to_vec(snapshot).is_ok_and(|v| v.len() > max_bytes)
-    {
+fn mark_dirty(state: &mut StoreState) {
+    state.generation = state.generation.saturating_add(1);
+}
+
+fn trim(snapshot: &mut Snapshot, max_entries: usize, max_bytes: usize) -> bool {
+    let mut changed = false;
+    while snapshot.bindings.len() > max_entries || binding_storage_bytes(snapshot) > max_bytes {
         let Some(oldest) = snapshot
             .bindings
             .iter()
@@ -152,7 +231,40 @@ fn trim(snapshot: &mut Snapshot, max_entries: usize, max_bytes: usize) {
             break;
         };
         snapshot.bindings.remove(&oldest);
+        changed = true;
     }
+    changed
+}
+
+fn binding_storage_bytes(snapshot: &Snapshot) -> usize {
+    serde_json::to_vec(&snapshot.bindings).map_or(usize::MAX, |bytes| bytes.len())
+}
+
+fn account_epoch_storage_bytes(snapshot: &Snapshot) -> usize {
+    serde_json::to_vec(&snapshot.account_epochs).map_or(usize::MAX, |bytes| bytes.len())
+}
+
+fn trim_stale_account_epochs(snapshot: &mut Snapshot, preserve: &str) -> bool {
+    let mut changed = false;
+    while account_epoch_storage_bytes(snapshot) > ACCOUNT_EPOCH_STORAGE_BUDGET {
+        let removable = snapshot
+            .account_epochs
+            .keys()
+            .find(|account| {
+                account.as_str() != preserve
+                    && !snapshot
+                        .bindings
+                        .values()
+                        .any(|binding| binding.account_id == account.as_str())
+            })
+            .cloned();
+        let Some(removable) = removable else {
+            break;
+        };
+        snapshot.account_epochs.remove(&removable);
+        changed = true;
+    }
+    changed
 }
 
 fn now() -> u64 {
@@ -165,6 +277,7 @@ fn now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn persists_hashes_only_and_enforces_count_cap() {
@@ -194,5 +307,133 @@ mod tests {
         )
         .unwrap();
         assert_eq!(loaded.len_and_bytes().await.0, 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_flushes_preserve_the_latest_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        let store = Arc::new(
+            AffinityStore::load(
+                path.clone(),
+                "0123456789abcdef0123456789abcdef",
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let mut tasks = Vec::new();
+        for index in 0..32 {
+            let store = store.clone();
+            tasks.push(tokio::spawn(async move {
+                let key = store.key(&format!("thread-{index}"));
+                store.put(key, format!("account-{index}"), 0).await;
+                store.flush().await.unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        store.flush().await.unwrap();
+
+        let loaded = AffinityStore::load(
+            path,
+            "0123456789abcdef0123456789abcdef",
+            100,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        assert_eq!(loaded.len_and_bytes().await.0, 32);
+    }
+
+    #[tokio::test]
+    async fn mutation_after_flush_remains_dirty_until_next_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AffinityStore::load(
+            dir.path().join("affinity.json"),
+            "0123456789abcdef0123456789abcdef",
+            10,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        store.put(store.key("first"), "a".into(), 0).await;
+        store.flush().await.unwrap();
+        {
+            let inner = store.inner.lock().await;
+            assert_eq!(inner.persisted_generation, inner.generation);
+        }
+        store.put(store.key("second"), "b".into(), 0).await;
+        {
+            let inner = store.inner.lock().await;
+            assert!(inner.generation > inner.persisted_generation);
+        }
+        store.flush().await.unwrap();
+        let inner = store.inner.lock().await;
+        assert_eq!(inner.persisted_generation, inner.generation);
+    }
+
+    #[tokio::test]
+    async fn account_epochs_survive_restart_with_invalidation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        let store = AffinityStore::load(
+            path.clone(),
+            "0123456789abcdef0123456789abcdef",
+            100,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        let old = store.key("old");
+        let new = store.key("new");
+        store.put(old.clone(), "a".into(), 0).await;
+        store.flush().await.unwrap();
+        store.invalidate_account("a").await;
+        assert_eq!(store.account_epoch("a").await, 1);
+        store.put(new.clone(), "a".into(), 1).await;
+        store.flush().await.unwrap();
+        drop(store);
+
+        let restored = AffinityStore::load(
+            path,
+            "0123456789abcdef0123456789abcdef",
+            100,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        assert!(restored.get(&old).await.is_none());
+        assert_eq!(restored.account_epoch("a").await, 1);
+        assert_eq!(restored.get(&new).await.unwrap().account_generation, 1);
+    }
+
+    #[tokio::test]
+    async fn epoch_storage_is_outside_the_binding_byte_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        let store = AffinityStore::load(
+            path.clone(),
+            "0123456789abcdef0123456789abcdef",
+            1,
+            2,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        store.invalidate_account("account-with-an-epoch").await;
+        store.flush().await.unwrap();
+        drop(store);
+
+        let restored = AffinityStore::load(
+            path,
+            "0123456789abcdef0123456789abcdef",
+            1,
+            2,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        assert_eq!(restored.account_epoch("account-with-an-epoch").await, 1);
     }
 }

--- a/src/routing/metadata.rs
+++ b/src/routing/metadata.rs
@@ -14,13 +14,14 @@ pub enum AffinityKind {
     BodyThread,
     PreviousResponse,
     PromptCache,
+    File,
 }
 
 impl AffinityKind {
     pub fn is_hard_continuity(self) -> bool {
         matches!(
             self,
-            Self::TurnState | Self::Session | Self::PreviousResponse
+            Self::TurnState | Self::Session | Self::PreviousResponse | Self::File
         )
     }
 
@@ -31,6 +32,7 @@ impl AffinityKind {
             Self::ParentThread | Self::TurnMetadata | Self::BodyThread => "thread",
             Self::PreviousResponse => "previous-response",
             Self::PromptCache => "prompt-cache",
+            Self::File => "file",
         }
     }
 }
@@ -58,6 +60,7 @@ pub fn affinity_values(
     body_thread_id: Option<&str>,
     previous_response_id: Option<&str>,
     prompt_cache_key: Option<&str>,
+    file_ids: &[String],
 ) -> Vec<AffinityValue> {
     let mut values = Vec::new();
     push_header(
@@ -98,6 +101,9 @@ pub fn affinity_values(
     }
     if let Some(value) = prompt_cache_key {
         push(&mut values, AffinityKind::PromptCache, value.to_owned());
+    }
+    for file_id in file_ids {
+        push(&mut values, AffinityKind::File, file_id.clone());
     }
     values
 }
@@ -194,12 +200,19 @@ mod tests {
         );
 
         h.insert("x-codex-turn-state", HeaderValue::from_static("opaque"));
-        let values = affinity_values(&h, Some("body"), Some("resp_1"), Some("cache_1"));
+        let values = affinity_values(
+            &h,
+            Some("body"),
+            Some("resp_1"),
+            Some("cache_1"),
+            &["file_1".into()],
+        );
         assert_eq!(values[0].kind, AffinityKind::TurnState);
         assert!(
             values
                 .iter()
                 .any(|v| v.kind == AffinityKind::PreviousResponse)
         );
+        assert!(values.iter().any(|v| v.kind == AffinityKind::File));
     }
 }

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use tokio::sync::Mutex;
+use tracing::error;
 
 use crate::{
     config::{Config, PoolConfig},
@@ -26,7 +27,6 @@ struct AccountRuntime {
     usage: Option<u8>,
     inflight: u64,
     last_assigned: u64,
-    generation: u64,
     needs_login: bool,
     quota_until: Option<Instant>,
     avoid_until: Option<Instant>,
@@ -69,6 +69,10 @@ impl Router {
             Some(key) => self.affinity.get(key).await,
             None => None,
         };
+        let binding_epoch = match &binding {
+            Some(binding) => Some(self.affinity.account_epoch(&binding.account_id).await),
+            None => None,
+        };
         let mut accounts = self.accounts.lock().await;
         for runtime in accounts.values_mut() {
             if runtime.needs_login && runtime.avoid_until.is_some_and(|until| until <= now) {
@@ -79,7 +83,7 @@ impl Router {
             let eligible = exclude != Some(binding.account_id.as_str())
                 && pool.members.contains(&binding.account_id)
                 && accounts.get(&binding.account_id).is_some_and(|a| {
-                    a.generation == binding.account_generation
+                    binding_epoch == Some(binding.account_generation)
                         && !a.needs_login
                         && a.quota_until.is_none_or(|v| v <= now)
                 });
@@ -125,16 +129,17 @@ impl Router {
                     .cloned()
             })?;
         let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
-        let generation = {
+        {
             let a = accounts.get_mut(&selected)?;
             a.last_assigned = seq;
-            a.generation
-        };
+        }
+        drop(accounts);
         self.active
             .lock()
             .await
             .insert(pool_name.to_owned(), selected.clone());
         if let Some(key) = thread.clone() {
+            let generation = self.affinity.account_epoch(&selected).await;
             self.affinity.put(key, selected.clone(), generation).await;
         }
         Some(Selection {
@@ -151,15 +156,10 @@ impl Router {
     }
 
     pub async fn bind(&self, key: ThreadKey, account: &str) -> bool {
-        let generation = self
-            .accounts
-            .lock()
-            .await
-            .get(account)
-            .map(|runtime| runtime.generation);
-        let Some(generation) = generation else {
+        if !self.accounts.lock().await.contains_key(account) {
             return false;
-        };
+        }
+        let generation = self.affinity.account_epoch(account).await;
         self.affinity.put(key, account.to_owned(), generation).await;
         true
     }
@@ -184,6 +184,12 @@ impl Router {
             a.inflight = a.inflight.saturating_sub(1);
         }
     }
+
+    pub async fn clear_inflight(&self) {
+        for account in self.accounts.lock().await.values_mut() {
+            account.inflight = 0;
+        }
+    }
     pub async fn quota_failure(&self, account: &str, headers: &hyper::HeaderMap) {
         let delay = quota_delay(headers);
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
@@ -199,9 +205,11 @@ impl Router {
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
             a.needs_login = true;
             a.avoid_until = Some(Instant::now() + Duration::from_secs(60));
-            a.generation += 1;
         }
         self.affinity.invalidate_account(account).await;
+        if let Err(error) = self.affinity.flush().await {
+            error!(%error, account, "failed to persist account affinity invalidation");
+        }
     }
     pub async fn observe_headers(&self, account: &str, headers: &hyper::HeaderMap) {
         let candidates = [

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,523 @@
+use std::{
+    fs,
+    io::{Read, Write},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail};
+
+const LABEL: &str = "com.nicosuave.comradex";
+const READY_TIMEOUT: Duration = Duration::from_secs(8);
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(200);
+
+pub fn install(config_path: &Path, state_dir: &Path) -> Result<PathBuf> {
+    platform_check()?;
+    let config_path = fs::canonicalize(config_path)
+        .with_context(|| format!("resolve {}", config_path.display()))?;
+    let config = crate::config::Config::load(&config_path)?;
+    let listener_addresses: Vec<_> = config
+        .listeners
+        .values()
+        .map(|listener| listener.address)
+        .collect();
+    if listener_addresses.iter().any(|address| address.port() == 0) {
+        bail!("service installation requires fixed non-zero listener ports")
+    }
+    let executable = fs::canonicalize(std::env::current_exe()?)
+        .context("resolve current Comradex executable")?;
+    let plist_path = plist_path()?;
+    let parent = plist_path
+        .parent()
+        .context("LaunchAgents path has no parent")?;
+    fs::create_dir_all(parent)?;
+    fs::create_dir_all(state_dir)?;
+    let state_dir =
+        fs::canonicalize(state_dir).with_context(|| format!("resolve {}", state_dir.display()))?;
+    let stdout = state_dir.join("service.stdout.log");
+    let stderr = state_dir.join("service.stderr.log");
+    let working_directory = config_path.parent().unwrap_or(Path::new("/"));
+    let service_nonce = format!("{:032x}", rand::random::<u128>());
+    let plist = render_plist(
+        &executable,
+        &config_path,
+        working_directory,
+        &stdout,
+        &stderr,
+        &service_nonce,
+    );
+    let mut candidate = tempfile::NamedTempFile::new_in(parent)?;
+    candidate.write_all(plist.as_bytes())?;
+    candidate.as_file().sync_all()?;
+    validate_plist(candidate.path())?;
+
+    let previous = match fs::read(&plist_path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).with_context(|| format!("read {}", plist_path.display())),
+    };
+    let domain = launchctl_domain();
+    let was_loaded = is_loaded(&domain)?;
+    if was_loaded && previous.is_none() {
+        bail!(
+            "LaunchAgent is loaded but {} is missing; refusing a replacement that cannot be rolled back",
+            plist_path.display()
+        )
+    }
+    replace_plist_transaction(
+        &plist_path,
+        candidate,
+        previous.as_deref(),
+        was_loaded,
+        || stop_if_loaded(&domain),
+        |path| {
+            bootstrap(&domain, path)?;
+            wait_until_ready(
+                &domain,
+                &listener_addresses,
+                Some(&service_nonce),
+                READY_TIMEOUT,
+            )
+        },
+        |path| {
+            bootstrap(&domain, path)?;
+            wait_until_ready(&domain, &[], None, READY_TIMEOUT)
+        },
+    )?;
+    Ok(plist_path)
+}
+
+fn render_plist(
+    executable: &Path,
+    config_path: &Path,
+    working_directory: &Path,
+    stdout: &Path,
+    stderr: &Path,
+    service_nonce: &str,
+) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{executable}</string>
+    <string>--config</string><string>{config}</string>
+    <string>serve</string>
+  </array>
+  <key>WorkingDirectory</key><string>{working_directory}</string>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>ProcessType</key><string>Background</string>
+  <key>EnvironmentVariables</key>
+  <dict><key>COMRADEX_SERVICE_NONCE</key><string>{service_nonce}</string></dict>
+  <key>StandardOutPath</key><string>{stdout}</string>
+  <key>StandardErrorPath</key><string>{stderr}</string>
+</dict>
+</plist>
+"#,
+        label = LABEL,
+        executable = xml(executable),
+        config = xml(config_path),
+        working_directory = xml(working_directory),
+        stdout = xml(stdout),
+        stderr = xml(stderr),
+        service_nonce = service_nonce,
+    )
+}
+
+fn bootstrap(domain: &str, plist_path: &Path) -> Result<()> {
+    let status = Command::new("launchctl")
+        .args(["bootstrap", domain])
+        .arg(plist_path)
+        .status()
+        .context("launch launchctl bootstrap")?;
+    if !status.success() {
+        bail!("launchctl bootstrap exited with {status}")
+    }
+    Ok(())
+}
+
+fn replace_plist_transaction<Stop, StartNew, StartPrevious>(
+    plist_path: &Path,
+    candidate: tempfile::NamedTempFile,
+    previous: Option<&[u8]>,
+    was_loaded: bool,
+    mut stop: Stop,
+    mut start_new: StartNew,
+    mut start_previous: StartPrevious,
+) -> Result<()>
+where
+    Stop: FnMut() -> Result<()>,
+    StartNew: FnMut(&Path) -> Result<()>,
+    StartPrevious: FnMut(&Path) -> Result<()>,
+{
+    if was_loaded {
+        stop()?;
+    }
+    if let Err(error) = candidate.persist(plist_path) {
+        let replace_error =
+            anyhow::Error::new(error.error).context(format!("replace {}", plist_path.display()));
+        if was_loaded && let Err(rollback_error) = start_previous(plist_path) {
+            bail!("{replace_error:#}; restoring previous service failed: {rollback_error:#}")
+        }
+        return Err(replace_error);
+    }
+    let Err(start_error) = start_new(plist_path) else {
+        return Ok(());
+    };
+
+    let rollback_result = stop()
+        .and_then(|()| match previous {
+            Some(bytes) => atomic_write(plist_path, bytes),
+            None => match fs::remove_file(plist_path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error.into()),
+            },
+        })
+        .and_then(|()| {
+            if was_loaded {
+                start_previous(plist_path)
+            } else {
+                Ok(())
+            }
+        });
+    match rollback_result {
+        Ok(()) => {
+            Err(start_error.context("replacement LaunchAgent failed; previous service restored"))
+        }
+        Err(rollback_error) => {
+            bail!(
+                "replacement LaunchAgent failed: {start_error:#}; rollback failed: {rollback_error:#}"
+            )
+        }
+    }
+}
+
+pub fn uninstall() -> Result<Option<PathBuf>> {
+    platform_check()?;
+    let plist_path = plist_path()?;
+    let domain = launchctl_domain();
+    if is_loaded(&domain)? {
+        bootout(&domain)?;
+    }
+    if plist_path.exists() {
+        fs::remove_file(&plist_path)?;
+        Ok(Some(plist_path))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn status() -> Result<bool> {
+    platform_check()?;
+    is_running(&launchctl_domain())
+}
+
+fn is_loaded(domain: &str) -> Result<bool> {
+    Ok(launchctl_print(domain)?.is_some())
+}
+
+fn is_running(domain: &str) -> Result<bool> {
+    Ok(launchctl_print(domain)?.is_some_and(|output| launchctl_output_is_running(&output)))
+}
+
+fn launchctl_print(domain: &str) -> Result<Option<String>> {
+    let output = Command::new("launchctl")
+        .args(["print", &format!("{domain}/{LABEL}")])
+        .stderr(Stdio::null())
+        .output()
+        .context("launch launchctl print")?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()))
+}
+
+fn launchctl_output_is_running(output: &str) -> bool {
+    let running = output.lines().any(|line| line.trim() == "state = running");
+    let has_pid = output.lines().any(|line| {
+        line.trim()
+            .strip_prefix("pid = ")
+            .and_then(|pid| pid.parse::<u32>().ok())
+            .is_some_and(|pid| pid > 0)
+    });
+    running && has_pid
+}
+
+fn wait_until_ready(
+    domain: &str,
+    listeners: &[SocketAddr],
+    service_nonce: Option<&str>,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if is_running(domain)? && listeners_ready(listeners, service_nonce) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            let targets = listeners
+                .iter()
+                .filter(|address| address.port() != 0)
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            if targets.is_empty() {
+                bail!("LaunchAgent did not reach a running state within {timeout:?}")
+            }
+            bail!("LaunchAgent did not become ready on {targets} within {timeout:?}")
+        }
+        thread::sleep(READY_POLL_INTERVAL);
+    }
+}
+
+fn listeners_ready(listeners: &[SocketAddr], service_nonce: Option<&str>) -> bool {
+    listeners
+        .iter()
+        .all(|address| service_nonce.is_some_and(|nonce| listener_ready(*address, nonce)))
+}
+
+fn listener_ready(address: SocketAddr, service_nonce: &str) -> bool {
+    let address = probe_address(address);
+    let Ok(mut stream) = TcpStream::connect_timeout(&address, CONNECT_TIMEOUT) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(CONNECT_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(CONNECT_TIMEOUT));
+    let request = format!(
+        "GET /__comradex_health/{service_nonce} HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n"
+    );
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = Vec::new();
+    if stream.take(8 * 1024).read_to_end(&mut response).is_err() {
+        return false;
+    }
+    let response = String::from_utf8_lossy(&response);
+    response.starts_with("HTTP/1.1 200") && response.contains("\"status\":\"ok\"")
+}
+
+fn probe_address(mut address: SocketAddr) -> SocketAddr {
+    if address.ip().is_unspecified() {
+        address.set_ip(match address.ip() {
+            IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        });
+    }
+    address
+}
+
+fn bootout(domain: &str) -> Result<()> {
+    let status = Command::new("launchctl")
+        .args(["bootout", &format!("{domain}/{LABEL}")])
+        .status()
+        .context("launch launchctl bootout")?;
+    if !status.success() {
+        bail!("launchctl bootout exited with {status}")
+    }
+    Ok(())
+}
+
+fn stop_if_loaded(domain: &str) -> Result<()> {
+    if is_loaded(domain)? {
+        bootout(domain)?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn launchctl_domain() -> String {
+    format!("gui/{}", unsafe { libc::geteuid() })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn launchctl_domain() -> String {
+    String::new()
+}
+
+fn plist_path() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home)
+        .join("Library/LaunchAgents")
+        .join(format!("{LABEL}.plist")))
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path.parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+    temp.write_all(bytes)?;
+    temp.as_file().sync_all()?;
+    temp.persist(path).map_err(|error| error.error)?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn validate_plist(path: &Path) -> Result<()> {
+    let status = Command::new("/usr/bin/plutil")
+        .args(["-lint", "--"])
+        .arg(path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("launch plutil")?;
+    if !status.success() {
+        bail!("generated LaunchAgent plist is invalid")
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn validate_plist(_path: &Path) -> Result<()> {
+    bail!("plist validation is available on macOS only")
+}
+
+fn xml(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(target_os = "macos")]
+fn platform_check() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_check() -> Result<()> {
+    bail!("service management currently supports macOS LaunchAgents only")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn xml_escapes_paths() {
+        assert_eq!(xml(Path::new("a&<b>\"c'")), "a&amp;&lt;b&gt;&quot;c&apos;");
+    }
+
+    #[test]
+    fn failed_replacement_restores_previous_plist_and_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let plist_path = dir.path().join("service.plist");
+        fs::write(&plist_path, b"old").unwrap();
+        let mut candidate = tempfile::NamedTempFile::new_in(dir.path()).unwrap();
+        candidate.write_all(b"new").unwrap();
+        candidate.as_file().sync_all().unwrap();
+        let stops = Cell::new(0);
+        let new_starts = Cell::new(0);
+        let previous_starts = Cell::new(0);
+
+        let result = replace_plist_transaction(
+            &plist_path,
+            candidate,
+            Some(b"old"),
+            true,
+            || {
+                stops.set(stops.get() + 1);
+                Ok(())
+            },
+            |path| {
+                new_starts.set(new_starts.get() + 1);
+                if fs::read(path)? == b"new" {
+                    bail!("simulated bootstrap failure")
+                }
+                Ok(())
+            },
+            |path| {
+                previous_starts.set(previous_starts.get() + 1);
+                assert_eq!(fs::read(path)?, b"old");
+                Ok(())
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(fs::read(&plist_path).unwrap(), b"old");
+        assert_eq!(stops.get(), 2);
+        assert_eq!(new_starts.get(), 1);
+        assert_eq!(previous_starts.get(), 1);
+    }
+
+    #[test]
+    fn launchctl_running_state_requires_a_pid() {
+        assert!(launchctl_output_is_running("state = running\n\tpid = 42\n"));
+        assert!(!launchctl_output_is_running("state = running\n"));
+        assert!(!launchctl_output_is_running(
+            "state = waiting\n\tpid = 42\n"
+        ));
+    }
+
+    #[test]
+    fn listener_probe_handles_wildcard_addresses() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let wildcard: SocketAddr = format!("0.0.0.0:{}", listener.local_addr().unwrap().port())
+            .parse()
+            .unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let length = stream.read(&mut request).unwrap();
+            assert!(
+                String::from_utf8_lossy(&request[..length])
+                    .contains("/__comradex_health/test-nonce")
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+                )
+                .unwrap();
+        });
+        assert!(listeners_ready(&[wildcard], Some("test-nonce")));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn listener_probe_rejects_an_unrelated_service() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\nConnection: close\r\n\r\nnot found",
+                )
+                .unwrap();
+        });
+        assert!(!listeners_ready(&[address], Some("test-nonce")));
+        server.join().unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn rendered_plist_passes_system_validation() {
+        let dir = tempfile::tempdir().unwrap();
+        let plist = render_plist(
+            Path::new("/tmp/comradex&binary"),
+            Path::new("/tmp/config<comradex>.toml"),
+            Path::new("/tmp"),
+            Path::new("/tmp/stdout.log"),
+            Path::new("/tmp/stderr.log"),
+            "test-nonce",
+        );
+        let mut file = tempfile::NamedTempFile::new_in(dir.path()).unwrap();
+        file.write_all(plist.as_bytes()).unwrap();
+        file.as_file().sync_all().unwrap();
+        validate_plist(file.path()).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- add raw, HTTP bridge, and frame-aware direct Responses WebSocket modes while keeping raw as the default
- add codex-lb-inspired per-turn continuity, replay, authentication recovery, multiplexing, and file ownership routing
- add OpenCodex-inspired bounded SSE-to-WebSocket bridging with cancellation, backpressure, and error framing
- add durable account epochs, symlink-safe idempotent Codex configuration installation, and a macOS LaunchAgent installer with process-specific readiness checks
- track and drain proxy tasks before final state snapshots; leave OpenCodex removal outside Comradex

## Review basis

The HTTP bridge was adversarially compared with OpenCodex, the direct WebSocket path with codex-lb, and the persistence/service path with the existing OpenCodex and dotfiles setup. Follow-up passes were repeated until the scoped reviews had no remaining findings.

## Verification

- cargo test --all-targets: 79 passed
- cargo clippy --all-targets -- -D warnings
- cargo fmt and git diff --check

No live Codex requests or service installation were run, so verification did not consume account usage.