### PR TITLE
Add automated binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            arch: x86_64
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            arch: arm64
+            runner: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Verify release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          test "${tag_version}" = "${manifest_version}"
+      - name: Build
+        run: cargo build --locked --release --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          artifact="comradex-${version}-macos-${{ matrix.arch }}.tar.gz"
+          tar -C target/${{ matrix.target }}/release -czf "${artifact}" comradex
+          shasum -a 256 "${artifact}" > "${artifact}.sha256"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: comradex-macos-${{ matrix.arch }}
+          path: |
+            comradex-*.tar.gz
+            comradex-*.sha256
+
+  build-linux:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Verify release version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+          test "${tag_version}" = "${manifest_version}"
+      - name: Build
+        run: cargo build --locked --release --target ${{ matrix.target }}
+      - name: Package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          artifact="comradex-${version}-linux-${{ matrix.arch }}.tar.gz"
+          tar -C target/${{ matrix.target }}/release -czf "${artifact}" comradex
+          sha256sum "${artifact}" > "${artifact}.sha256"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: comradex-linux-${{ matrix.arch }}
+          path: |
+            comradex-*.tar.gz
+            comradex-*.sha256
+
+  release:
+    needs: [build-macos, build-linux]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          files: artifacts/*
+
+  update-homebrew:
+    needs: release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger homebrew-tap update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          gh api --method POST repos/nicosuave/homebrew-tap/dispatches \
+            -f event_type=update-formula \
+            -F "client_payload[formula]=comradex" \
+            -F "client_payload[version]=${version}" \
+            -F "client_payload[repo]=nicosuave/comradex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,27 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A bounded, sticky account-pool router for native Codex traffic"
+repository = "https://github.com/nicosuave/comradex"
+homepage = "https://github.com/nicosuave/comradex"
+readme = "README.md"
+keywords = ["codex", "proxy", "load-balancer", "cli"]
+categories = ["command-line-utilities", "network-programming"]
+
+[package.metadata.binstall]
+bin-dir = "{ bin }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-macos-arm64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-macos-x86_64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-linux-arm64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-linux-x86_64.tar.gz"
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ The current implementation intentionally supports only native Codex traffic. It 
 
 ## Quick start
 
+Install the latest release with Homebrew:
+
+```sh
+brew install nicosuave/tap/comradex
+```
+
+Or install a prebuilt release with cargo-binstall directly from GitHub:
+
+```sh
+cargo binstall --git https://github.com/nicosuave/comradex comradex
+```
+
+Then create and validate a configuration:
+
+```sh
+comradex init
+comradex check
+comradex serve
+```
+
+To build from source instead:
+
 ```sh
 git clone git@github.com:nicosuave/comradex.git
 cd comradex


### PR DESCRIPTION
## Summary

- build native macOS and Linux binaries for arm64 and x86_64 from semver tags
- publish archives and SHA256 files to GitHub Releases
- trigger the existing Homebrew tap updater after a successful release
- add cargo-binstall metadata and installation docs

## Distribution

Homebrew uses nicosuave/homebrew-tap#1. Merge that PR first, then this PR. A later `v0.1.0` tag will create the first release and replace the formula placeholders with real checksums.

`cargo binstall --git https://github.com/nicosuave/comradex comradex` installs from the same release assets without requiring a crates.io publication. Normal `cargo binstall comradex` can be enabled later by publishing the crate.

## Validation

- `cargo fmt --check`
- `cargo clippy --bins --locked -- -D warnings`
- `cargo publish --dry-run --allow-dirty`
- workflow YAML parse
- `git diff --check`

The usage-consuming test suite was intentionally skipped.