### PR TITLE
Default Responses WebSockets to HTTP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Requests up to 256 KiB are replayed from memory by default; larger requests use 
 
 Select behavior with `proxy.responses_websocket_mode`:
 
-- `raw` is the default and preserves the original handshake-pinned byte relay. One account owns the socket, and Comradex does not inspect its frames.
-- `http_bridge` accepts downstream WebSocket frames and sends each `response.create` through the account-aware HTTP/SSE pipeline. It supersedes an older in-flight turn when a new create arrives and converts bounded, validated SSE or JSON lifecycle events back into WebSocket text frames.
+- `raw` preserves the original handshake-pinned byte relay. One account owns the socket, and Comradex does not inspect its frames.
+- `http_bridge` is the default. It accepts downstream WebSocket frames and sends each `response.create` through the account-aware HTTP/SSE pipeline. It supersedes an older in-flight turn when a new create arrives and converts bounded, validated SSE or JSON lifecycle events back into WebSocket text frames.
 - `direct` keeps upstream WebSocket transport while routing and tracking each `response.create` frame independently. It supports multiplexed, out-of-order turns, reconnects only before visible output, refreshes an expired credential on the same account before considering one alternate, and can remove a stale `previous_response_id` only when the request contains a verified self-contained full resend. If safe internal replay is unavailable, it preserves Codex's canonical `previous_response_not_found` retry classifier while removing account-scoped details.
 
 Direct mode uses the explicit refresh-then-alternate sequence above. Live Voice upgrades are separate from these modes and remain raw, call-bound relays.

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,8 +46,8 @@ fn default_flush_seconds() -> u64 {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponsesWebsocketMode {
-    #[default]
     Raw,
+    #[default]
     HttpBridge,
     Direct,
 }
@@ -102,7 +102,7 @@ impl Default for ProxyConfig {
             switch_at: default_switch(),
             max_inflight: default_inflight(),
             max_upgrades: default_upgrades(),
-            responses_websocket_mode: ResponsesWebsocketMode::Raw,
+            responses_websocket_mode: ResponsesWebsocketMode::HttpBridge,
             replay_memory_bytes: default_replay_memory(),
             max_request_bytes: default_request_limit(),
             max_spool_bytes: default_global_spool(),
@@ -220,6 +220,18 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn responses_websocket_mode_defaults_to_http_bridge() {
+        assert_eq!(
+            ResponsesWebsocketMode::default(),
+            ResponsesWebsocketMode::HttpBridge
+        );
+        assert_eq!(
+            ProxyConfig::default().responses_websocket_mode,
+            ResponsesWebsocketMode::HttpBridge
+        );
+    }
 
     fn config_text(state_dir: Option<&str>) -> String {
         let state_dir = state_dir

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ upstream = "https://chatgpt.com/backend-api/codex"
 switch_at = 80
 max_inflight = 64
 max_upgrades = 32
-responses_websocket_mode = "raw"
+responses_websocket_mode = "http_bridge"
 installation_secret = "{}"
 affinity_key = "{}"
 


### PR DESCRIPTION
## Summary

- make `http_bridge` the default Responses WebSocket mode for deserialized and programmatic proxy configuration
- generate new `comradex.toml` files with `responses_websocket_mode = "http_bridge"`
- update the routing documentation and add regression coverage for the default

## Why

Raw mode pins an entire WebSocket connection to one account and cannot apply frame-level account routing or file-ownership checks. HTTP bridge mode sends each `response.create` through Comradex's account-aware HTTP/SSE pipeline, making the safer routing behavior the out-of-box experience while leaving raw and direct modes available explicitly.

## Impact

New configurations and configurations that omit `proxy.responses_websocket_mode` now use HTTP bridge mode. Existing configurations with an explicit mode remain unchanged.

## Validation

- `cargo fmt --check`
- `cargo test` (98 passed)
- `git diff --check`
