### PR TITLE
Harden upstream progress and credential expiry

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -41,6 +41,9 @@ pub const PROACTIVE_REFRESH_INTERVAL_SECONDS: u64 = 60;
 /// or keep the next scheduled sweep waiting indefinitely.
 pub const PROACTIVE_REFRESH_ACCOUNT_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_REFRESH_RESPONSE_BYTES: usize = 1024 * 1024;
+const DEFAULT_OAUTH_EXPIRES_IN_SECONDS: u64 = 60 * 60;
+const MAX_OAUTH_EXPIRES_IN_SECONDS: u64 = 24 * 60 * 60;
+const ACCESS_TOKEN_EXPIRES_AT_KEY: &str = "comradex_access_token_expires_at";
 
 type AuthClient = Client<HttpsConnector<HttpConnector>, Full<Bytes>>;
 
@@ -295,12 +298,26 @@ impl Resolver {
             bail!("OAuth refresh failed with HTTP {status} ({code})")
         }
         let refreshed: Value = serde_json::from_slice(&bytes).context("parse OAuth refresh")?;
+        let access_token = refreshed
+            .get("access_token")
+            .and_then(Value::as_str)
+            .filter(|token| !token.is_empty())
+            .context("OAuth refresh response has no access token")?;
+        let expires_at = now.saturating_add(validated_expires_in(&refreshed));
         let tokens = document
             .value
             .get_mut("tokens")
             .and_then(Value::as_object_mut)
             .context("Codex auth tokens are not an object")?;
-        for key in ["id_token", "access_token", "refresh_token"] {
+        tokens.insert(
+            "access_token".to_owned(),
+            Value::String(access_token.to_owned()),
+        );
+        tokens.insert(
+            ACCESS_TOKEN_EXPIRES_AT_KEY.to_owned(),
+            Value::Number(expires_at.into()),
+        );
+        for key in ["id_token", "refresh_token"] {
             if let Some(value) = refreshed.get(key).and_then(Value::as_str) {
                 tokens.insert(key.to_owned(), Value::String(value.to_owned()));
             }
@@ -392,10 +409,36 @@ fn access_token_needs_refresh(value: &Value) -> bool {
 fn access_token_needs_refresh_at(value: &Value, now: u64) -> bool {
     let token = lookup(value, &["tokens", "access_token"])
         .or_else(|| lookup(value, &["tokens", "accessToken"]));
-    let Some(expiration) = token.and_then(jwt_expiration) else {
+    let Some(token) = token else {
+        // Top-level API keys and legacy non-managed credential shapes are not refresh candidates.
         return false;
     };
+    let jwt_expiration = jwt_expiration(token);
+    let fallback_value = value
+        .get("tokens")
+        .and_then(|tokens| tokens.get(ACCESS_TOKEN_EXPIRES_AT_KEY));
+    let fallback_expiration = fallback_value
+        .and_then(Value::as_u64)
+        .filter(|expiration| *expiration <= now.saturating_add(MAX_OAUTH_EXPIRES_IN_SECONDS));
+    let expiration = match (jwt_expiration, fallback_expiration) {
+        (Some(jwt), Some(fallback)) => jwt.min(fallback),
+        (Some(jwt), None) => jwt,
+        (None, Some(fallback)) => fallback,
+        // A persisted but malformed fallback came from a Comradex refresh and must fail closed.
+        (None, None) if fallback_value.is_some() => return true,
+        // Preserve compatibility with existing opaque managed credentials. Every successful
+        // Comradex refresh writes the bounded fallback, so only legacy/external tokens reach here.
+        (None, None) => return false,
+    };
     expiration <= now.saturating_add(REFRESH_WINDOW_SECONDS)
+}
+
+fn validated_expires_in(response: &Value) -> u64 {
+    response
+        .get("expires_in")
+        .and_then(Value::as_u64)
+        .filter(|seconds| (1..=MAX_OAUTH_EXPIRES_IN_SECONDS).contains(seconds))
+        .unwrap_or(DEFAULT_OAUTH_EXPIRES_IN_SECONDS)
 }
 
 fn jwt_expiration(token: &str) -> Option<u64> {
@@ -570,6 +613,99 @@ mod tests {
         let boundary = json!({ "tokens": { "access_token": jwt(now + 300, "boundary") } });
         assert!(!access_token_needs_refresh_at(&outside, now));
         assert!(access_token_needs_refresh_at(&boundary, now));
+    }
+
+    #[test]
+    fn missing_or_untrusted_managed_expiry_is_never_indefinitely_fresh() {
+        let now = 1_000_000;
+        for value in [
+            json!({
+                "tokens": {
+                    "access_token": "opaque-token",
+                    ACCESS_TOKEN_EXPIRES_AT_KEY: "not-a-timestamp"
+                }
+            }),
+            json!({
+                "tokens": {
+                    "access_token": "opaque-token",
+                    ACCESS_TOKEN_EXPIRES_AT_KEY: u64::MAX
+                }
+            }),
+        ] {
+            assert!(access_token_needs_refresh_at(&value, now));
+        }
+
+        let legacy_opaque = json!({ "tokens": { "access_token": "opaque-token" } });
+        assert!(!access_token_needs_refresh_at(&legacy_opaque, now));
+
+        let far_future_jwt = json!({
+            "tokens": {
+                "access_token": jwt(u64::MAX, "far-future"),
+                "refresh_token": "test-refresh-token"
+            }
+        });
+        assert!(!access_token_needs_refresh_at(&far_future_jwt, now));
+
+        let bounded = json!({
+            "tokens": {
+                "access_token": "opaque-token",
+                ACCESS_TOKEN_EXPIRES_AT_KEY: now + 3_600
+            }
+        });
+        assert!(!access_token_needs_refresh_at(&bounded, now));
+        assert!(access_token_needs_refresh_at(&bounded, now + 3_300));
+    }
+
+    #[test]
+    fn oauth_expires_in_is_strictly_bounded() {
+        assert_eq!(validated_expires_in(&json!({ "expires_in": 7_200 })), 7_200);
+        for response in [
+            json!({}),
+            json!({ "expires_in": "3600" }),
+            json!({ "expires_in": -1 }),
+            json!({ "expires_in": 0 }),
+            json!({ "expires_in": MAX_OAUTH_EXPIRES_IN_SECONDS + 1 }),
+        ] {
+            assert_eq!(
+                validated_expires_in(&response),
+                DEFAULT_OAUTH_EXPIRES_IN_SECONDS
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn refreshed_opaque_access_token_gets_bounded_fallback_expiry() {
+        let now = 1_000_000;
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        write_managed_auth(&home, &jwt(now + 60, "stale"));
+        let refresh_url = serve_refresh_response(
+            "200 OK",
+            json!({
+                "access_token": "opaque-replacement",
+                "refresh_token": "replacement-refresh-token",
+                "expires_in": u64::MAX
+            }),
+        )
+        .await;
+        let resolver = test_resolver(&[&home], refresh_url);
+        let account = AccountConfig::CodexHome { path: home.clone() };
+
+        assert_eq!(
+            resolver.proactive_refresh_at(&account, now).await.unwrap(),
+            Some(ProactiveRefresh::Refreshed)
+        );
+        let written: Value =
+            serde_json::from_slice(&fs::read(home.join("auth.json")).unwrap()).unwrap();
+        assert_eq!(
+            written["tokens"][ACCESS_TOKEN_EXPIRES_AT_KEY],
+            now + DEFAULT_OAUTH_EXPIRES_IN_SECONDS
+        );
+        assert!(!access_token_needs_refresh_at(&written, now));
+        assert!(access_token_needs_refresh_at(
+            &written,
+            now + DEFAULT_OAUTH_EXPIRES_IN_SECONDS - REFRESH_WINDOW_SECONDS
+        ));
     }
 
     #[tokio::test]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -73,6 +73,7 @@ const SSE_DECODE_SLICE_BYTES: usize = 64 * 1024;
 const MAX_QUEUED_DIRECT_CREATES: usize = 64;
 pub(super) const RESPONSES_MISSING_CREATED_TIMEOUT: Duration = Duration::from_secs(240);
 pub(super) const RESPONSES_UPSTREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const RESPONSES_DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const HTTP_BRIDGE_MAX_MATERIALIZED_ITEMS: usize = 4_096;
 
 fn is_direct_hard_continuity(kind: metadata::AffinityKind) -> bool {
@@ -198,6 +199,7 @@ struct HttpBridgeCapture {
     output: Vec<serde_json::Value>,
     delivered_event: bool,
     response_created: bool,
+    progress_events: u64,
 }
 
 #[derive(Debug)]
@@ -231,8 +233,12 @@ impl HttpBridgeLivenessFailure {
 
 impl HttpBridgeCapture {
     fn observe(&mut self, event: &serde_json::Value) {
-        if event.get("type").and_then(serde_json::Value::as_str) == Some("response.created") {
+        let event_type = event.get("type").and_then(serde_json::Value::as_str);
+        if event_type == Some("response.created") {
             self.response_created = true;
+        }
+        if self.response_created && event_type.is_some() {
+            self.progress_events = self.progress_events.saturating_add(1);
         }
         if let Some(response_id) = event
             .get("response")
@@ -279,6 +285,28 @@ async fn wait_for_optional_deadline(deadline: Option<tokio::time::Instant>) {
     match deadline {
         Some(deadline) => tokio::time::sleep_until(deadline).await,
         None => std::future::pending::<()>().await,
+    }
+}
+
+fn earliest_turn_deadline(
+    deadlines: &HashMap<TurnId, tokio::time::Instant>,
+) -> Option<(TurnId, tokio::time::Instant)> {
+    deadlines
+        .iter()
+        .min_by_key(|(_, deadline)| **deadline)
+        .map(|(turn_id, deadline)| (*turn_id, *deadline))
+}
+
+fn refresh_turn_deadlines<'a>(
+    deadlines: &mut HashMap<TurnId, tokio::time::Instant>,
+    turn_ids: impl IntoIterator<Item = &'a TurnId>,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    for turn_id in turn_ids {
+        if let Some(current) = deadlines.get_mut(turn_id) {
+            *current = deadline;
+        }
     }
 }
 
@@ -1754,6 +1782,24 @@ impl App {
         inbound_headers: &hyper::HeaderMap,
         clear_session_state: bool,
     ) -> Result<DirectUpstream> {
+        self.connect_direct_upstream_with_timeout(
+            account,
+            path,
+            inbound_headers,
+            clear_session_state,
+            RESPONSES_DIRECT_CONNECT_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn connect_direct_upstream_with_timeout(
+        &self,
+        account: &str,
+        path: &str,
+        inbound_headers: &hyper::HeaderMap,
+        clear_session_state: bool,
+        connect_timeout: Duration,
+    ) -> Result<DirectUpstream> {
         for attempt in 0..2 {
             let uri = self.upstream_uri(path, false)?;
             let mut upstream_req = Request::builder()
@@ -1772,11 +1818,21 @@ impl App {
                 .await?;
             apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
             self.router.begin(account).await;
-            let mut response = match self.upgrade_client.request(upstream_req).await {
-                Ok(response) => response,
-                Err(error) => {
+            let connect_deadline = tokio::time::Instant::now() + connect_timeout;
+            let mut response = match tokio::time::timeout_at(
+                connect_deadline,
+                self.upgrade_client.request(upstream_req),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(error)) => {
                     self.router.end(account).await;
                     return Err(error.into());
+                }
+                Err(_) => {
+                    self.router.end(account).await;
+                    anyhow::bail!("upstream WebSocket handshake response timed out")
                 }
             };
             if response.status() == StatusCode::SWITCHING_PROTOCOLS {
@@ -1784,9 +1840,11 @@ impl App {
                     self.router.end(account).await;
                     anyhow::bail!("upstream selected an unoffered WebSocket subprotocol")
                 }
-                let upgrade = hyper::upgrade::on(&mut response).await;
+                let upgrade =
+                    tokio::time::timeout_at(connect_deadline, hyper::upgrade::on(&mut response))
+                        .await;
                 match upgrade {
-                    Ok(upgraded) => {
+                    Ok(Ok(upgraded)) => {
                         return Ok(DirectUpstream {
                             socket: WebSocketStream::from_raw_socket(
                                 TokioIo::new(upgraded),
@@ -1797,9 +1855,13 @@ impl App {
                             credentials,
                         });
                     }
-                    Err(error) => {
+                    Ok(Err(error)) => {
                         self.router.end(account).await;
                         return Err(error.into());
+                    }
+                    Err(_) => {
+                        self.router.end(account).await;
+                        anyhow::bail!("upstream WebSocket protocol upgrade timed out")
                     }
                 }
             }
@@ -1854,9 +1916,10 @@ impl App {
         let mut turns = HashMap::<TurnId, DirectTurn>::new();
         let mut awaiting_response_created: Option<TurnId> = None;
         let mut missing_created_deadline: Option<tokio::time::Instant> = None;
-        let mut upstream_idle_deadline: Option<tokio::time::Instant> = None;
+        let mut upstream_idle_deadlines = HashMap::<TurnId, tokio::time::Instant>::new();
         let mut queued_creates = VecDeque::<Message>::new();
         loop {
+            let earliest_idle_deadline = earliest_turn_deadline(&upstream_idle_deadlines);
             let queued_message = if awaiting_response_created.is_none() {
                 queued_creates.pop_front()
             } else {
@@ -1882,10 +1945,10 @@ impl App {
                         .await?;
                     awaiting_response_created = None;
                     missing_created_deadline = None;
-                    upstream_idle_deadline = None;
+                    upstream_idle_deadlines.clear();
                     if close_downstream { break; }
                 }
-                _ = wait_for_optional_deadline(upstream_idle_deadline) => {
+                _ = wait_for_optional_deadline(earliest_idle_deadline.map(|(_, deadline)| deadline)) => {
                     let close_downstream = self
                         .recover_or_settle_direct_end(
                             &mut protocol,
@@ -1903,7 +1966,7 @@ impl App {
                         .await?;
                     awaiting_response_created = None;
                     missing_created_deadline = None;
-                    upstream_idle_deadline = None;
+                    upstream_idle_deadlines.clear();
                     if close_downstream { break; }
                 }
                 client_message = async {
@@ -2020,11 +2083,6 @@ impl App {
                 upstream_message = upstream.next() => {
                     match upstream_message {
                         Some(Ok(message)) => {
-                            if upstream_idle_deadline.is_some() {
-                                upstream_idle_deadline = Some(
-                                    tokio::time::Instant::now() + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
-                                );
-                            }
                             if let Message::Close(frame) = &message {
                                 let end = UpstreamEnd::Close {
                                     code: frame.as_ref().map_or(1005, |frame| u16::from(frame.code)),
@@ -2058,7 +2116,7 @@ impl App {
                                             + RESPONSES_MISSING_CREATED_TIMEOUT,
                                     );
                                 }
-                                upstream_idle_deadline = None;
+                                upstream_idle_deadlines.clear();
                                 if close_downstream {
                                     break;
                                 }
@@ -2120,7 +2178,7 @@ impl App {
                                         tokio::time::Instant::now()
                                             + RESPONSES_MISSING_CREATED_TIMEOUT,
                                     );
-                                    upstream_idle_deadline = None;
+                                    upstream_idle_deadlines.clear();
                                     continue;
                                 }
                             } else if failure.kind != FailureKind::None {
@@ -2163,9 +2221,7 @@ impl App {
                                         .await?;
                                     let _ = protocol.settle(turn_id, Settlement::Failed);
                                     turns.remove(&turn_id);
-                                }
-                                if protocol.pending_len() == 0 {
-                                    upstream_idle_deadline = None;
+                                    upstream_idle_deadlines.remove(&turn_id);
                                 }
                                 continue;
                             }
@@ -2185,7 +2241,8 @@ impl App {
                                     if awaiting_response_created == Some(*turn_id) {
                                         awaiting_response_created = None;
                                         missing_created_deadline = None;
-                                        upstream_idle_deadline = Some(
+                                        upstream_idle_deadlines.insert(
+                                            *turn_id,
                                             tokio::time::Instant::now()
                                                 + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
                                         );
@@ -2210,6 +2267,11 @@ impl App {
                                     }
                                 }
                             }
+                            refresh_turn_deadlines(
+                                &mut upstream_idle_deadlines,
+                                &association.turn_ids,
+                                RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                            );
                             client.send(message).await?;
                             for turn_id in &association.turn_ids {
                                 protocol
@@ -2227,9 +2289,7 @@ impl App {
                                         .settle(turn_id, settlement)
                                         .map_err(|error| anyhow::anyhow!("settle direct turn: {error:?}"))?;
                                     turns.remove(&turn_id);
-                                }
-                                if protocol.pending_len() == 0 {
-                                    upstream_idle_deadline = None;
+                                    upstream_idle_deadlines.remove(&turn_id);
                                 }
                             }
                         }
@@ -2260,7 +2320,7 @@ impl App {
                                         + RESPONSES_MISSING_CREATED_TIMEOUT,
                                 );
                             }
-                            upstream_idle_deadline = None;
+                            upstream_idle_deadlines.clear();
                             if close_downstream {
                                 return Err(error.into());
                             }
@@ -2292,7 +2352,7 @@ impl App {
                                         + RESPONSES_MISSING_CREATED_TIMEOUT,
                                 );
                             }
-                            upstream_idle_deadline = None;
+                            upstream_idle_deadlines.clear();
                             if close_downstream {
                                 break;
                             }
@@ -3628,6 +3688,7 @@ async fn pump_http_response_to_websocket(
         output: Vec::new(),
         delivered_event: false,
         response_created: false,
+        progress_events: 0,
     };
     let mut liveness = None;
     let result: Result<()> = async {
@@ -3720,9 +3781,16 @@ async fn pump_http_response_to_websocket(
                 return Ok(());
             }
         }
+        let mut upstream_idle_deadline = capture
+            .response_created
+            .then(|| tokio::time::Instant::now() + upstream_idle_timeout);
         loop {
             let next_frame = if capture.response_created {
-                tokio::time::timeout(upstream_idle_timeout, body.frame()).await
+                tokio::time::timeout_at(
+                    upstream_idle_deadline.expect("created response has idle deadline"),
+                    body.frame(),
+                )
+                .await
             } else {
                 tokio::time::timeout_at(response_created_deadline, body.frame()).await
             };
@@ -3742,6 +3810,7 @@ async fn pump_http_response_to_websocket(
             let Ok(data) = frame.into_data() else {
                 continue;
             };
+            let progress_events = capture.progress_events;
             if send_sse_data(
                 &mut decoder,
                 &data,
@@ -3754,6 +3823,10 @@ async fn pump_http_response_to_websocket(
             .await?
             {
                 return Ok(());
+            }
+            if capture.progress_events != progress_events {
+                upstream_idle_deadline =
+                    Some(tokio::time::Instant::now() + upstream_idle_timeout);
             }
         }
         if send_protocol_events(
@@ -4185,12 +4258,20 @@ mod tests {
     fn direct_test_app(
         dir: &std::path::Path,
     ) -> (Arc<App>, ListenerConfig, Arc<Router>, Arc<Stats>) {
+        direct_test_app_with_upstream(dir, ProxyConfig::default().upstream)
+    }
+
+    fn direct_test_app_with_upstream(
+        dir: &std::path::Path,
+        upstream: String,
+    ) -> (Arc<App>, ListenerConfig, Arc<Router>, Arc<Stats>) {
         let listener = ListenerConfig {
             address: "127.0.0.1:0".parse().unwrap(),
             pool: "default".into(),
         };
         let config = Arc::new(Config {
             proxy: ProxyConfig {
+                upstream,
                 responses_websocket_mode: ResponsesWebsocketMode::Direct,
                 installation_secret: "0123456789abcdef".into(),
                 affinity_key: "0123456789abcdef0123456789abcdef".into(),
@@ -4415,7 +4496,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn http_bridge_created_switches_to_per_frame_idle_watchdog() {
+    async fn http_bridge_created_starts_semantic_progress_watchdog() {
         let dir = tempfile::tempdir().unwrap();
         let app = bridge_admission_test_app(dir.path(), 1, 500);
         let (response, _body_sender) = pending_sse_response(
@@ -4437,6 +4518,98 @@ mod tests {
         assert!(failure.delivered_event);
         let (_, message) = receiver.recv().await.unwrap();
         assert!(message.into_text().unwrap().contains("response.created"));
+    }
+
+    #[tokio::test]
+    async fn http_bridge_heartbeats_do_not_refresh_idle_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (response, body_sender) = pending_sse_response(
+            b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_watchdog\"}}\n\n",
+        );
+        let heartbeat_task = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                if body_sender
+                    .send(Ok(Frame::data(Bytes::from_static(b": keepalive\n\n"))))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        let (failure, _) = tokio::time::timeout(
+            Duration::from_millis(150),
+            pump_with_test_watchdogs(
+                &app,
+                response,
+                Duration::from_secs(1),
+                Duration::from_millis(30),
+            ),
+        )
+        .await
+        .expect("SSE heartbeats must not keep a stalled response alive");
+        heartbeat_task.abort();
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::UpstreamIdle)
+        );
+    }
+
+    #[test]
+    fn direct_progress_refreshes_only_associated_turn_deadlines() {
+        let mut protocol = ProtocolState::new(ProtocolLimits::default()).unwrap();
+        let first = protocol
+            .admit_response_create(&serde_json::json!({"type":"response.create","input":[]}))
+            .unwrap();
+        let second = protocol
+            .admit_response_create(&serde_json::json!({"type":"response.create","input":[]}))
+            .unwrap();
+        let original = tokio::time::Instant::now() + Duration::from_secs(1);
+        let mut deadlines = HashMap::from([(first, original), (second, original)]);
+
+        refresh_turn_deadlines(&mut deadlines, [&second], Duration::from_secs(30));
+
+        assert_eq!(deadlines[&first], original);
+        assert!(deadlines[&second] > original);
+        assert_eq!(earliest_turn_deadline(&deadlines).unwrap().0, first);
+    }
+
+    #[tokio::test]
+    async fn direct_reconnect_handshake_response_is_bounded() {
+        let dir = tempfile::tempdir().unwrap();
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let stalled_server = tokio::spawn(async move {
+            let (_stream, _) = upstream.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let (app, _, _, _) = direct_test_app_with_upstream(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+        );
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(AUTHORIZATION, "Bearer caller-token".parse().unwrap());
+
+        let error = match app
+            .connect_direct_upstream_with_timeout(
+                "a",
+                "/v1/responses",
+                &headers,
+                true,
+                Duration::from_millis(30),
+            )
+            .await
+        {
+            Ok(_) => panic!("stalled upstream handshake unexpectedly connected"),
+            Err(error) => error,
+        };
+        stalled_server.abort();
+
+        assert!(format!("{error:#}").contains("handshake response timed out"));
     }
 
     #[tokio::test]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -71,6 +71,8 @@ const BRIDGE_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const UNKNOWN_CONTENT_SNIFF_BYTES: usize = 4 * 1024;
 const SSE_DECODE_SLICE_BYTES: usize = 64 * 1024;
 const MAX_QUEUED_DIRECT_CREATES: usize = 64;
+pub(super) const RESPONSES_MISSING_CREATED_TIMEOUT: Duration = Duration::from_secs(240);
+pub(super) const RESPONSES_UPSTREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 const HTTP_BRIDGE_MAX_MATERIALIZED_ITEMS: usize = 4_096;
 
 fn is_direct_hard_continuity(kind: metadata::AffinityKind) -> bool {
@@ -195,16 +197,43 @@ struct HttpBridgeCapture {
     response_id: Option<String>,
     output: Vec<serde_json::Value>,
     delivered_event: bool,
+    response_created: bool,
 }
 
 #[derive(Debug)]
 struct HttpBridgePumpFailure {
     error: anyhow::Error,
     delivered_event: bool,
+    liveness: Option<HttpBridgeLivenessFailure>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpBridgeLivenessFailure {
+    MissingResponseCreated,
+    UpstreamIdle,
+}
+
+impl HttpBridgeLivenessFailure {
+    fn code(self) -> &'static str {
+        match self {
+            Self::MissingResponseCreated => "missing_response_created_timeout",
+            Self::UpstreamIdle => "upstream_idle_timeout",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::MissingResponseCreated => "upstream did not create the response before timeout",
+            Self::UpstreamIdle => "upstream response stream became idle before completion",
+        }
+    }
 }
 
 impl HttpBridgeCapture {
     fn observe(&mut self, event: &serde_json::Value) {
+        if event.get("type").and_then(serde_json::Value::as_str) == Some("response.created") {
+            self.response_created = true;
+        }
         if let Some(response_id) = event
             .get("response")
             .and_then(|response| response.get("id"))
@@ -243,6 +272,13 @@ impl TrackedTask {
             self.abort.abort();
             let _ = (&mut self.done).await;
         }
+    }
+}
+
+async fn wait_for_optional_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
     }
 }
 
@@ -1451,6 +1487,8 @@ impl App {
                     active_turn = self
                         .spawn_tracked_task(async move {
                             let _turn_guard = turn_guard;
+                            let dispatch_deadline =
+                                tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT;
                             let _http_permit = match app.http_slots.clone().try_acquire_owned() {
                                 Ok(permit) => permit,
                                 Err(_) => {
@@ -1480,18 +1518,20 @@ impl App {
                                     return;
                                 }
                             };
-                            match app
-                                .handle_http_replay_with_routing_anchor(
+                            match tokio::time::timeout_at(
+                                dispatch_deadline,
+                                app.handle_http_replay_with_routing_anchor(
                                     headers,
                                     Method::POST,
                                     &listener,
                                     path,
                                     replay,
                                     routing_previous_response_id,
-                                )
-                                .await
+                                ),
+                            )
+                            .await
                             {
-                                Ok(response) => {
+                                Ok(Ok(response)) => {
                                     let close_for_inbound_auth = response.status()
                                         == StatusCode::UNAUTHORIZED
                                         && response
@@ -1509,6 +1549,8 @@ impl App {
                                         &app,
                                         request_input,
                                         &continuation,
+                                        dispatch_deadline,
+                                        RESPONSES_UPSTREAM_IDLE_TIMEOUT,
                                     )
                                     .await;
                                     if close_for_inbound_auth {
@@ -1527,6 +1569,14 @@ impl App {
                                         return;
                                     }
                                     if let Err(failure) = pump_result {
+                                        if let Some(liveness) = failure.liveness {
+                                            send_ws_nonretryable_liveness_error(
+                                                &outbound,
+                                                liveness,
+                                            )
+                                            .await;
+                                            return;
+                                        }
                                         if failure
                                             .error
                                             .to_string()
@@ -1558,9 +1608,16 @@ impl App {
                                         }
                                     }
                                 }
-                                Err(error) => {
+                                Ok(Err(error)) => {
                                     send_ws_error(&outbound, "proxy_error", &error.to_string())
                                         .await;
+                                }
+                                Err(_) => {
+                                    send_ws_nonretryable_liveness_error(
+                                        &outbound,
+                                        HttpBridgeLivenessFailure::MissingResponseCreated,
+                                    )
+                                    .await;
                                 }
                             }
                         })
@@ -1796,6 +1853,8 @@ impl App {
             .map_err(|error| anyhow::anyhow!("invalid direct protocol limits: {error:?}"))?;
         let mut turns = HashMap::<TurnId, DirectTurn>::new();
         let mut awaiting_response_created: Option<TurnId> = None;
+        let mut missing_created_deadline: Option<tokio::time::Instant> = None;
+        let mut upstream_idle_deadline: Option<tokio::time::Instant> = None;
         let mut queued_creates = VecDeque::<Message>::new();
         loop {
             let queued_message = if awaiting_response_created.is_none() {
@@ -1805,6 +1864,48 @@ impl App {
             };
             tokio::select! {
                 biased;
+                _ = wait_for_optional_deadline(missing_created_deadline) => {
+                    let close_downstream = self
+                        .recover_or_settle_direct_end(
+                            &mut protocol,
+                            &mut turns,
+                            &mut client,
+                            &mut upstream,
+                            &mut upstream_credentials,
+                            &listener,
+                            &path,
+                            &headers,
+                            &mut account,
+                            &mut lease,
+                            UpstreamEnd::MissingResponseCreatedTimeout,
+                        )
+                        .await?;
+                    awaiting_response_created = None;
+                    missing_created_deadline = None;
+                    upstream_idle_deadline = None;
+                    if close_downstream { break; }
+                }
+                _ = wait_for_optional_deadline(upstream_idle_deadline) => {
+                    let close_downstream = self
+                        .recover_or_settle_direct_end(
+                            &mut protocol,
+                            &mut turns,
+                            &mut client,
+                            &mut upstream,
+                            &mut upstream_credentials,
+                            &listener,
+                            &path,
+                            &headers,
+                            &mut account,
+                            &mut lease,
+                            UpstreamEnd::UpstreamIdleTimeout,
+                        )
+                        .await?;
+                    awaiting_response_created = None;
+                    missing_created_deadline = None;
+                    upstream_idle_deadline = None;
+                    if close_downstream { break; }
+                }
                 client_message = async {
                     match queued_message {
                         Some(message) => Some(Ok(message)),
@@ -1901,6 +2002,9 @@ impl App {
                             };
                             upstream.send(client_message.clone()).await?;
                             awaiting_response_created = Some(turn_id);
+                            missing_created_deadline = Some(
+                                tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT,
+                            );
                             turns.insert(turn_id, DirectTurn {
                                 route,
                                 request: client_message,
@@ -1916,6 +2020,11 @@ impl App {
                 upstream_message = upstream.next() => {
                     match upstream_message {
                         Some(Ok(message)) => {
+                            if upstream_idle_deadline.is_some() {
+                                upstream_idle_deadline = Some(
+                                    tokio::time::Instant::now() + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                                );
+                            }
                             if let Message::Close(frame) = &message {
                                 let end = UpstreamEnd::Close {
                                     code: frame.as_ref().map_or(1005, |frame| u16::from(frame.code)),
@@ -1939,7 +2048,17 @@ impl App {
                                     .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
                                 {
                                     awaiting_response_created = None;
+                                    missing_created_deadline = None;
+                                } else if awaiting_response_created.is_some() {
+                                    // A recoverable pre-acceptance close may replace the upstream
+                                    // and replay the one safe turn. Its acknowledgement gets a new
+                                    // full deadline on the replacement generation.
+                                    missing_created_deadline = Some(
+                                        tokio::time::Instant::now()
+                                            + RESPONSES_MISSING_CREATED_TIMEOUT,
+                                    );
                                 }
+                                upstream_idle_deadline = None;
                                 if close_downstream {
                                     break;
                                 }
@@ -1997,6 +2116,11 @@ impl App {
                                     lease.replace(account.clone()).await;
                                     upstream = replacement.socket;
                                     upstream_credentials = replacement.credentials;
+                                    missing_created_deadline = Some(
+                                        tokio::time::Instant::now()
+                                            + RESPONSES_MISSING_CREATED_TIMEOUT,
+                                    );
+                                    upstream_idle_deadline = None;
                                     continue;
                                 }
                             } else if failure.kind != FailureKind::None {
@@ -2024,6 +2148,7 @@ impl App {
                                 for turn_id in association.turn_ids {
                                     if awaiting_response_created == Some(turn_id) {
                                         awaiting_response_created = None;
+                                        missing_created_deadline = None;
                                     }
                                     let response_id = protocol
                                         .turn(turn_id)
@@ -2038,6 +2163,9 @@ impl App {
                                         .await?;
                                     let _ = protocol.settle(turn_id, Settlement::Failed);
                                     turns.remove(&turn_id);
+                                }
+                                if protocol.pending_len() == 0 {
+                                    upstream_idle_deadline = None;
                                 }
                                 continue;
                             }
@@ -2056,6 +2184,11 @@ impl App {
                                 for turn_id in &association.turn_ids {
                                     if awaiting_response_created == Some(*turn_id) {
                                         awaiting_response_created = None;
+                                        missing_created_deadline = None;
+                                        upstream_idle_deadline = Some(
+                                            tokio::time::Instant::now()
+                                                + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                                        );
                                     }
                                     if let Some(turn) = turns.get(turn_id) {
                                         for key in &turn.route.soft_keys {
@@ -2088,11 +2221,15 @@ impl App {
                                 for turn_id in association.turn_ids {
                                     if awaiting_response_created == Some(turn_id) {
                                         awaiting_response_created = None;
+                                        missing_created_deadline = None;
                                     }
                                     protocol
                                         .settle(turn_id, settlement)
                                         .map_err(|error| anyhow::anyhow!("settle direct turn: {error:?}"))?;
                                     turns.remove(&turn_id);
+                                }
+                                if protocol.pending_len() == 0 {
+                                    upstream_idle_deadline = None;
                                 }
                             }
                         }
@@ -2116,7 +2253,14 @@ impl App {
                                 .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
                             {
                                 awaiting_response_created = None;
+                                missing_created_deadline = None;
+                            } else if awaiting_response_created.is_some() {
+                                missing_created_deadline = Some(
+                                    tokio::time::Instant::now()
+                                        + RESPONSES_MISSING_CREATED_TIMEOUT,
+                                );
                             }
+                            upstream_idle_deadline = None;
                             if close_downstream {
                                 return Err(error.into());
                             }
@@ -2141,7 +2285,14 @@ impl App {
                                 .is_some_and(|turn_id| protocol.turn(turn_id).is_none())
                             {
                                 awaiting_response_created = None;
+                                missing_created_deadline = None;
+                            } else if awaiting_response_created.is_some() {
+                                missing_created_deadline = Some(
+                                    tokio::time::Instant::now()
+                                        + RESPONSES_MISSING_CREATED_TIMEOUT,
+                                );
                             }
+                            upstream_idle_deadline = None;
                             if close_downstream {
                                 break;
                             }
@@ -2326,7 +2477,14 @@ impl App {
         lease: &mut DirectAccountLease,
         end: UpstreamEnd,
     ) -> Result<bool> {
-        if protocol.pending_len() == 1 && !matches!(end, UpstreamEnd::Close { code: 1000 }) {
+        let watchdog = matches!(
+            end,
+            UpstreamEnd::MissingResponseCreatedTimeout | UpstreamEnd::UpstreamIdleTimeout
+        );
+        if protocol.pending_len() == 1
+            && !watchdog
+            && !matches!(end, UpstreamEnd::Close { code: 1000 })
+        {
             let turn_id = protocol.pending().next().expect("one pending").id();
             if let Some((replacement, replacement_account)) = self
                 .try_replay_direct_turn(
@@ -2372,12 +2530,26 @@ impl App {
                     let _ = protocol.settle(action.turn_id, Settlement::RejectedInput);
                 }
                 TurnEndDisposition::StreamIncomplete => {
+                    let (code, message) = match end {
+                        UpstreamEnd::MissingResponseCreatedTimeout => (
+                            "missing_response_created_timeout",
+                            "upstream did not acknowledge response.create before the safety deadline",
+                        ),
+                        UpstreamEnd::UpstreamIdleTimeout => (
+                            "upstream_idle_timeout",
+                            "upstream response made no progress before the safety deadline",
+                        ),
+                        _ => (
+                            "stream_incomplete",
+                            "upstream stream ended before a terminal event",
+                        ),
+                    };
                     let payload = serde_json::json!({
                         "type":"response.failed",
                         "response":{
                             "id":response_id,
                             "status":"failed",
-                            "error":{"type":"server_error","code":"stream_incomplete","message":"upstream stream ended before a terminal event"}
+                            "error":{"type":"server_error","code":code,"message":message,"retryable":false}
                         }
                     });
                     client
@@ -2431,11 +2603,10 @@ impl App {
         path: String,
         live_call_id: Option<String>,
     ) -> Result<Response<ProxyBody>> {
-        let permit = self
-            .upgrade_slots
-            .clone()
-            .try_acquire_owned()
-            .context("WebSocket limit reached")?;
+        let permit = match self.upgrade_slots.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => return Ok(upgrade_capacity_response()),
+        };
         let inbound_headers = req.headers().clone();
         let pool = self.pool(listener)?;
         let forced_live = live_call_id.is_some();
@@ -3198,6 +3369,20 @@ fn bridge_capacity_response() -> Response<ProxyBody> {
         .expect("static bridge capacity response")
 }
 
+fn upgrade_capacity_response() -> Response<ProxyBody> {
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .header(CONTENT_TYPE, "application/json")
+        .header("retry-after", "5")
+        .body(json_body(serde_json::json!({
+            "error": {
+                "type": "at_capacity",
+                "message": "WebSocket capacity reached; retry later"
+            }
+        })))
+        .expect("static upgrade capacity response")
+}
+
 async fn wait_for_bridge_idle_timeout(
     activity: Arc<BridgeSessionActivity>,
     changed: Arc<Notify>,
@@ -3277,6 +3462,26 @@ async fn send_ws_error(outbound: &BridgeSender, kind: &str, message: &str) {
     })
     .to_string();
     let _ = outbound.send(Message::Text(payload.into())).await;
+}
+
+async fn send_ws_nonretryable_liveness_error(
+    outbound: &BridgeSender,
+    failure: HttpBridgeLivenessFailure,
+) {
+    let payload = serde_json::json!({
+        "type": "error",
+        "status": StatusCode::GATEWAY_TIMEOUT.as_u16(),
+        "error": {
+            "type": "upstream_timeout",
+            "code": failure.code(),
+            "message": failure.message(),
+            "retryable": false
+        },
+        "headers": {},
+    });
+    let _ = outbound
+        .send(Message::Text(payload.to_string().into()))
+        .await;
 }
 
 async fn send_direct_error(
@@ -3414,13 +3619,17 @@ async fn pump_http_response_to_websocket(
     app: &Arc<App>,
     request_input: Vec<serde_json::Value>,
     continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+    response_created_deadline: tokio::time::Instant,
+    upstream_idle_timeout: Duration,
 ) -> std::result::Result<(), HttpBridgePumpFailure> {
     let mut capture = HttpBridgeCapture {
         input: request_input,
         response_id: None,
         output: Vec::new(),
         delivered_event: false,
+        response_created: false,
     };
+    let mut liveness = None;
     let result: Result<()> = async {
     let status = response.status();
     let response_headers = response.headers().clone();
@@ -3436,7 +3645,18 @@ async fn pump_http_response_to_websocket(
         .get::<SelectedAccount>()
         .map(|selected| selected.0.clone());
     if !status.is_success() {
-        let bytes = collect_proxy_body(&mut body, FILE_CREATE_RESPONSE_LIMIT).await?;
+        let bytes = match tokio::time::timeout_at(
+            response_created_deadline,
+            collect_proxy_body(&mut body, FILE_CREATE_RESPONSE_LIMIT),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(_) => {
+                liveness = Some(HttpBridgeLivenessFailure::MissingResponseCreated);
+                anyhow::bail!("missing response.created watchdog expired")
+            }
+        };
         let parsed = serde_json::from_slice::<serde_json::Value>(&bytes).ok();
         let error = parsed
             .as_ref()
@@ -3471,8 +3691,18 @@ async fn pump_http_response_to_websocket(
     // headers; trusting those headers can turn a valid terminal response into
     // a retryable protocol failure. The header is only the fallback when the
     // prefix remains undecidable.
-    let (body_kind, initial_chunks) =
-        sniff_unknown_responses_body(&mut body, header_kind).await?;
+    let (body_kind, initial_chunks) = match tokio::time::timeout_at(
+        response_created_deadline,
+        sniff_unknown_responses_body(&mut body, header_kind),
+    )
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            liveness = Some(HttpBridgeLivenessFailure::MissingResponseCreated);
+            anyhow::bail!("missing response.created watchdog expired")
+        }
+    };
     if body_kind == SniffedBodyKind::Sse {
         let mut decoder = SseDecoder::default();
         for data in initial_chunks {
@@ -3490,7 +3720,24 @@ async fn pump_http_response_to_websocket(
                 return Ok(());
             }
         }
-        while let Some(frame) = body.frame().await {
+        loop {
+            let next_frame = if capture.response_created {
+                tokio::time::timeout(upstream_idle_timeout, body.frame()).await
+            } else {
+                tokio::time::timeout_at(response_created_deadline, body.frame()).await
+            };
+            let frame = match next_frame {
+                Ok(Some(frame)) => frame,
+                Ok(None) => break,
+                Err(_) => {
+                    liveness = Some(if capture.response_created {
+                        HttpBridgeLivenessFailure::UpstreamIdle
+                    } else {
+                        HttpBridgeLivenessFailure::MissingResponseCreated
+                    });
+                    anyhow::bail!("Responses upstream liveness watchdog expired")
+                }
+            };
             let frame = frame?;
             let Ok(data) = frame.into_data() else {
                 continue;
@@ -3523,9 +3770,22 @@ async fn pump_http_response_to_websocket(
         }
         anyhow::bail!("upstream SSE ended without a terminal event")
     }
-    let bytes =
-        collect_proxy_body_with_initial(&mut body, initial_chunks, RESPONSES_JSON_RESPONSE_LIMIT)
-            .await?;
+    let bytes = match tokio::time::timeout_at(
+        response_created_deadline,
+        collect_proxy_body_with_initial(
+            &mut body,
+            initial_chunks,
+            RESPONSES_JSON_RESPONSE_LIMIT,
+        ),
+    )
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            liveness = Some(HttpBridgeLivenessFailure::MissingResponseCreated);
+            anyhow::bail!("missing response.created watchdog expired")
+        }
+    };
     let value: serde_json::Value = match serde_json::from_slice(&bytes) {
         Ok(value) => value,
         Err(json_error) if header_kind == SniffedBodyKind::Json => {
@@ -3557,6 +3817,7 @@ async fn pump_http_response_to_websocket(
     result.map_err(|error| HttpBridgePumpFailure {
         error,
         delivered_event: capture.delivered_event,
+        liveness,
     })
 }
 
@@ -3911,6 +4172,16 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn websocket_capacity_is_typed_service_unavailable() {
+        let response = upgrade_capacity_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()["retry-after"], "5");
+        let body = response.into_body().collect().await.unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body.to_bytes()).unwrap();
+        assert_eq!(payload["error"]["type"], "at_capacity");
+    }
+
     fn direct_test_app(
         dir: &std::path::Path,
     ) -> (Arc<App>, ListenerConfig, Arc<Router>, Arc<Stats>) {
@@ -3995,6 +4266,56 @@ mod tests {
         App::new(config, router, Arc::new(Stats::default())).unwrap()
     }
 
+    fn pending_sse_response(
+        initial: &'static [u8],
+    ) -> (
+        Response<ProxyBody>,
+        mpsc::Sender<std::io::Result<Frame<Bytes>>>,
+    ) {
+        let (sender, receiver) = mpsc::channel(2);
+        sender
+            .try_send(Ok(Frame::data(Bytes::from_static(initial))))
+            .unwrap();
+        let stream = futures_util::stream::unfold(receiver, |mut receiver| async move {
+            receiver.recv().await.map(|item| (item, receiver))
+        });
+        let body = BodyExt::boxed(http_body_util::StreamBody::new(stream));
+        (
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "text/event-stream")
+                .body(body)
+                .unwrap(),
+            sender,
+        )
+    }
+
+    async fn pump_with_test_watchdogs(
+        app: &Arc<App>,
+        response: Response<ProxyBody>,
+        created_after: Duration,
+        idle_for: Duration,
+    ) -> (HttpBridgePumpFailure, mpsc::Receiver<(u64, Message)>) {
+        let (sender, receiver) = mpsc::channel(8);
+        let outbound = BridgeSender {
+            sender,
+            generation: 1,
+        };
+        let continuation = Arc::new(StdMutex::new(None));
+        let failure = pump_http_response_to_websocket(
+            response,
+            &outbound,
+            app,
+            Vec::new(),
+            &continuation,
+            tokio::time::Instant::now() + created_after,
+            idle_for,
+        )
+        .await
+        .unwrap_err();
+        (failure, receiver)
+    }
+
     #[tokio::test]
     async fn bridge_capacity_evicts_lru_idle_session_without_using_upgrade_slots() {
         let dir = tempfile::tempdir().unwrap();
@@ -4016,6 +4337,175 @@ mod tests {
         assert_ne!(first.id, second.id);
         assert_eq!(app.bridge_sessions.lock().await.len(), 1);
         app.finish_bridge_session(second.id).await;
+    }
+
+    #[tokio::test]
+    async fn http_bridge_comments_do_not_disarm_missing_created_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (response, _body_sender) = pending_sse_response(b": keepalive\n\n");
+
+        let (failure, receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_millis(30),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::MissingResponseCreated)
+        );
+        assert!(!failure.delivered_event);
+        assert!(receiver.is_empty());
+    }
+
+    #[tokio::test]
+    async fn http_bridge_prelude_does_not_disarm_missing_created_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (response, _body_sender) =
+            pending_sse_response(b"data: {\"type\":\"response.queued\",\"sequence_number\":0}\n\n");
+
+        let (failure, mut receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_millis(30),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::MissingResponseCreated)
+        );
+        assert!(failure.delivered_event);
+        let (_, message) = receiver.recv().await.unwrap();
+        assert!(message.into_text().unwrap().contains("response.queued"));
+    }
+
+    #[tokio::test]
+    async fn http_bridge_response_metadata_is_visible_but_does_not_disarm_created_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (response, _body_sender) = pending_sse_response(
+            b"data: {\"type\":\"response.metadata\",\"sequence_number\":7,\"response\":{\"metadata\":{\"trace\":\"opaque\"}}}\n\n",
+        );
+
+        let (failure, mut receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_millis(30),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::MissingResponseCreated)
+        );
+        assert!(failure.delivered_event);
+        let (_, message) = receiver.recv().await.unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_str(message.into_text().unwrap().as_ref()).unwrap();
+        assert_eq!(payload["type"], "response.metadata");
+        assert_eq!(payload["sequence_number"], 7);
+        assert_eq!(payload["response"]["metadata"]["trace"], "opaque");
+    }
+
+    #[tokio::test]
+    async fn http_bridge_created_switches_to_per_frame_idle_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (response, _body_sender) = pending_sse_response(
+            b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_watchdog\"}}\n\n",
+        );
+
+        let (failure, mut receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_secs(1),
+            Duration::from_millis(30),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::UpstreamIdle)
+        );
+        assert!(failure.delivered_event);
+        let (_, message) = receiver.recv().await.unwrap();
+        assert!(message.into_text().unwrap().contains("response.created"));
+    }
+
+    #[tokio::test]
+    async fn http_bridge_partial_json_cannot_bypass_missing_created_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (mut response, _body_sender) = pending_sse_response(b"{\"response\":");
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/json".parse().unwrap());
+
+        let (failure, receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_millis(30),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::MissingResponseCreated)
+        );
+        assert!(!failure.delivered_event);
+        assert!(receiver.is_empty());
+    }
+
+    #[tokio::test]
+    async fn http_bridge_error_body_cannot_bypass_missing_created_watchdog() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let (mut response, _body_sender) = pending_sse_response(b"{\"error\":");
+        *response.status_mut() = StatusCode::BAD_GATEWAY;
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/json".parse().unwrap());
+
+        let (failure, receiver) = pump_with_test_watchdogs(
+            &app,
+            response,
+            Duration::from_millis(30),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(
+            failure.liveness,
+            Some(HttpBridgeLivenessFailure::MissingResponseCreated)
+        );
+        assert!(!failure.delivered_event);
+        assert!(receiver.is_empty());
+    }
+
+    #[tokio::test]
+    async fn http_bridge_liveness_error_is_typed_and_nonretryable() {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let outbound = BridgeSender {
+            sender,
+            generation: 7,
+        };
+        send_ws_nonretryable_liveness_error(&outbound, HttpBridgeLivenessFailure::UpstreamIdle)
+            .await;
+        let (generation, message) = receiver.recv().await.unwrap();
+        assert_eq!(generation, 7);
+        let payload: serde_json::Value =
+            serde_json::from_str(message.into_text().unwrap().as_ref()).unwrap();
+        assert_eq!(payload["status"], 504);
+        assert_eq!(payload["error"]["code"], "upstream_idle_timeout");
+        assert_eq!(payload["error"]["retryable"], false);
     }
 
     #[tokio::test]
@@ -4974,6 +5464,109 @@ mod tests {
             }
         });
         (address, task)
+    }
+
+    async fn spawn_metadata_websocket_upstream()
+    -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let service = service_fn(move |mut req: Request<Incoming>| async move {
+                let key = req.headers()[SEC_WEBSOCKET_KEY].as_bytes();
+                let accept = tokio_tungstenite::tungstenite::handshake::derive_accept_key(key);
+                let upgrade = hyper::upgrade::on(&mut req);
+                tokio::spawn(async move {
+                    let upgraded = upgrade.await.unwrap();
+                    let mut websocket = WebSocketStream::from_raw_socket(
+                        TokioIo::new(upgraded),
+                        Role::Server,
+                        None,
+                    )
+                    .await;
+                    assert!(matches!(websocket.next().await, Some(Ok(Message::Text(_)))));
+                    for payload in [
+                        serde_json::json!({
+                            "type":"response.metadata",
+                            "sequence_number":7,
+                            "response":{"metadata":{"trace":"opaque"}}
+                        }),
+                        serde_json::json!({
+                            "type":"response.created",
+                            "sequence_number":8,
+                            "response":{"id":"resp_metadata","status":"in_progress"}
+                        }),
+                        serde_json::json!({
+                            "type":"response.completed",
+                            "sequence_number":9,
+                            "response":{"id":"resp_metadata","status":"completed"}
+                        }),
+                    ] {
+                        websocket
+                            .send(Message::Text(payload.to_string().into()))
+                            .await
+                            .unwrap();
+                    }
+                });
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .status(StatusCode::SWITCHING_PROTOCOLS)
+                        .header(CONNECTION, "Upgrade")
+                        .header(UPGRADE, "websocket")
+                        .header(SEC_WEBSOCKET_ACCEPT, accept)
+                        .body(Full::new(Bytes::new()))
+                        .unwrap(),
+                )
+            });
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .with_upgrades()
+                .await;
+        });
+        (address, task)
+    }
+
+    #[tokio::test]
+    async fn direct_mode_passes_response_metadata_before_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let (upstream_addr, upstream_task) = spawn_metadata_websocket_upstream().await;
+        let (proxy_addr, proxy_task) = start_caller_proxy(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+            ResponsesWebsocketMode::Direct,
+        )
+        .await;
+        let mut websocket = connect_test_websocket(proxy_addr).await;
+        websocket
+            .send(Message::Text(
+                serde_json::json!({"type":"response.create","input":[]})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+
+        for (expected_type, expected_sequence) in [
+            ("response.metadata", 7),
+            ("response.created", 8),
+            ("response.completed", 9),
+        ] {
+            let payload: serde_json::Value = serde_json::from_str(
+                websocket
+                    .next()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .into_text()
+                    .unwrap()
+                    .as_ref(),
+            )
+            .unwrap();
+            assert_eq!(payload["type"], expected_type);
+            assert_eq!(payload["sequence_number"], expected_sequence);
+        }
+        proxy_task.abort();
+        upstream_task.abort();
     }
 
     #[tokio::test]

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -327,6 +327,8 @@ pub enum UpstreamEnd {
     Close { code: u16 },
     Eof,
     TransportError { process_wide: bool },
+    MissingResponseCreatedTimeout,
+    UpstreamIdleTimeout,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -705,6 +707,10 @@ impl ProtocolState {
 
     pub fn classify_upstream_end(&self, end: UpstreamEnd) -> UpstreamEndPlan {
         let process_wide = matches!(end, UpstreamEnd::TransportError { process_wide: true });
+        let watchdog = matches!(
+            end,
+            UpstreamEnd::MissingResponseCreatedTimeout | UpstreamEnd::UpstreamIdleTimeout
+        );
         let clean = matches!(end, UpstreamEnd::Close { code: 1000 });
         let turns: Vec<_> = self
             .pending
@@ -741,7 +747,7 @@ impl ProtocolState {
         UpstreamEndPlan {
             turns,
             downstream,
-            penalize_account: has_incomplete && !process_wide,
+            penalize_account: has_incomplete && !process_wide && !watchdog,
             process_wide,
         }
     }
@@ -1332,6 +1338,39 @@ mod tests {
     }
 
     #[test]
+    fn response_metadata_is_visible_and_sequenced_without_marking_created() {
+        let mut state = state();
+        let turn = state
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        let metadata = json!({
+            "type":"response.metadata",
+            "sequence_number":7,
+            "response":{"metadata":{"trace":"opaque"}}
+        });
+
+        let association = state.observe_upstream_event(&metadata, None).unwrap();
+        assert_eq!(association.turn_ids, [turn]);
+        assert_eq!(association.event_type.as_deref(), Some("response.metadata"));
+        let pending = state.turn(turn).unwrap();
+        assert!(!pending.response_created());
+        assert_eq!(pending.response_event_count(), 1);
+        assert!(!pending.downstream_visible());
+
+        state.mark_downstream_delivered(turn, &metadata).unwrap();
+        let pending = state.turn(turn).unwrap();
+        assert!(pending.downstream_visible());
+        assert_eq!(
+            pending.last_visible_sequence(),
+            Some(SequenceNumber::Signed(7))
+        );
+        assert!(matches!(
+            state.replay_decision(turn, FailureKind::Transient, ReplayContext::default()),
+            ReplayDecision::Refused(ReplayRefusal::FiniteSequenceVisible)
+        ));
+    }
+
+    #[test]
     fn replay_requires_a_single_previsible_unsettled_turn() {
         let mut state = state();
         let turn = state
@@ -1619,6 +1658,29 @@ mod tests {
         let plan = state.classify_upstream_end(UpstreamEnd::TransportError { process_wide: true });
         assert!(plan.process_wide);
         assert!(!plan.penalize_account);
+    }
+
+    #[test]
+    fn watchdog_timeouts_are_account_neutral_and_never_imply_clean_rejection() {
+        for end in [
+            UpstreamEnd::MissingResponseCreatedTimeout,
+            UpstreamEnd::UpstreamIdleTimeout,
+        ] {
+            let mut state = state();
+            let turn = state
+                .admit_response_create(&create(json!("hello")))
+                .unwrap();
+            let plan = state.classify_upstream_end(end);
+            assert_eq!(
+                plan.turns,
+                [TurnEndAction {
+                    turn_id: turn,
+                    disposition: TurnEndDisposition::StreamIncomplete,
+                }]
+            );
+            assert!(!plan.penalize_account);
+            assert_eq!(plan.downstream, DownstreamEndAction::KeepOpen);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Ends stalled upstream requests without replaying ambiguous work, validates refreshed credential expiry, and preserves newer response metadata events.\n\nCapacity exhaustion now returns a typed 503 with Retry-After instead of a generic gateway failure.