### PR TITLE
Publish signed macOS releases locally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,50 +9,6 @@ permissions:
   contents: write
 
 jobs:
-  build-macos:
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-apple-darwin
-            arch: x86_64
-            runner: macos-15-intel
-          - target: aarch64-apple-darwin
-            arch: arm64
-            runner: macos-15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
-      - name: Verify release version
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag_version="${GITHUB_REF_NAME#v}"
-          manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
-          test "${tag_version}" = "${manifest_version}"
-      - name: Build
-        run: cargo build --locked --release --target ${{ matrix.target }}
-      - name: Package
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          artifact="comradex-${version}-macos-${{ matrix.arch }}.tar.gz"
-          tar -C target/${{ matrix.target }}/release -czf "${artifact}" comradex
-          shasum -a 256 "${artifact}" > "${artifact}.sha256"
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: comradex-macos-${{ matrix.arch }}
-          path: |
-            comradex-*.tar.gz
-            comradex-*.sha256
-
   build-linux:
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -98,7 +54,7 @@ jobs:
             comradex-*.sha256
 
   release:
-    needs: [build-macos, build-linux]
+    needs: build-linux
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts
@@ -111,19 +67,3 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/*
-
-  update-homebrew:
-    needs: release
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Trigger homebrew-tap update
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          gh api --method POST repos/nicosuave/homebrew-tap/dispatches \
-            -f event_type=update-formula \
-            -F "client_payload[formula]=comradex" \
-            -F "client_payload[version]=${version}" \
-            -F "client_payload[repo]=nicosuave/comradex"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository instructions
+
+## macOS releases
+
+- Build, Developer ID-sign, and notarize macOS release artifacts on the maintainer's Mac with `scripts/release_macos_local.sh`.
+- Do not export Apple signing certificates or notarization credentials to GitHub Actions secrets unless the maintainer explicitly changes this policy.
+- GitHub Actions builds and publishes the Linux artifacts. Wait for that release workflow to create the GitHub release before running the local macOS release script.
+- The local script uploads both macOS architectures, verifies the Homebrew tap update workflow, and retries once if GitHub's release-asset CDN is not ready.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ docker run --rm -it -v comradex-review-auth:/root/.codex comradex-review login -
 
 Running against the real Codex backend requires account authentication and should mount the configuration, state, and account directories explicitly. Isolated account homes must be writable if the daemon is expected to rotate OAuth credentials; run the container with the host account directories' numeric UID/GID rather than weakening their `0600` permissions.
 
+## Releasing
+
+GitHub Actions builds and publishes the Linux artifacts after a version tag is pushed. macOS artifacts are built locally so the Developer ID certificate and Apple notarization credentials remain in the maintainer's Keychain rather than GitHub secrets.
+
+After the tagged Linux release workflow succeeds, publish both signed and notarized macOS architectures and update the Homebrew tap with:
+
+```sh
+scripts/release_macos_local.sh 0.9.3
+```
+
+The script requires the tag to point at `HEAD`, refuses uncommitted Rust source changes, uses the first local Developer ID Application identity, and uses the `sidequery-notarization` Keychain profile by default. Override those with `CODESIGN_IDENTITY` or `NOTARY_PROFILE` when necessary. It replaces the matching macOS GitHub release assets, waits for the Homebrew update workflow, and retries that update once if GitHub's asset CDN has not settled.
+
 ## Status and statistics
 
 ```sh

--- a/scripts/release_macos_local.sh
+++ b/scripts/release_macos_local.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+version="${1:-$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)}"
+tag="v${version}"
+notary_profile="${NOTARY_PROFILE:-sidequery-notarization}"
+artifacts="$root/target/local-release/$tag"
+
+manifest_version="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n 1)"
+if [[ "$version" != "$manifest_version" ]]; then
+  echo "Requested $version but Cargo.toml is $manifest_version" >&2
+  exit 1
+fi
+if ! git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+  echo "Missing local tag $tag" >&2
+  exit 1
+fi
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "$tag^{commit}")" ]]; then
+  echo "HEAD must be the commit tagged $tag" >&2
+  exit 1
+fi
+if ! git diff --quiet -- Cargo.toml Cargo.lock src; then
+  echo "Refusing to release with uncommitted source changes" >&2
+  exit 1
+fi
+if ! gh release view "$tag" >/dev/null 2>&1; then
+  echo "GitHub release $tag does not exist yet; wait for the Linux release workflow" >&2
+  exit 1
+fi
+
+identity="${CODESIGN_IDENTITY:-}"
+if [[ -z "$identity" ]]; then
+  identity="$(security find-identity -v -p codesigning | sed -n 's/.*"\(Developer ID Application:.*\)"/\1/p' | head -n 1)"
+fi
+if [[ -z "$identity" ]]; then
+  echo "No Developer ID Application identity found in the local Keychain" >&2
+  exit 1
+fi
+xcrun notarytool history --keychain-profile "$notary_profile" --output-format json >/dev/null
+
+mkdir -p "$artifacts"
+
+build_package_notarize() {
+  local target="$1"
+  local arch="$2"
+  local executable="$root/target/$target/release/comradex"
+  local artifact="comradex-${version}-macos-${arch}.tar.gz"
+  local notary_zip="$artifacts/comradex-${version}-macos-${arch}-notarization.zip"
+
+  cargo build --locked --release --target "$target"
+  codesign --force --options runtime --timestamp \
+    --sign "$identity" \
+    --identifier com.nicosuave.comradex \
+    "$executable"
+  codesign --verify --strict --verbose=2 "$executable"
+
+  ditto -c -k --keepParent "$executable" "$notary_zip"
+  xcrun notarytool submit "$notary_zip" \
+    --keychain-profile "$notary_profile" \
+    --wait
+
+  tar -C "$(dirname "$executable")" -czf "$artifacts/$artifact" comradex
+  (cd "$artifacts" && shasum -a 256 "$artifact" > "$artifact.sha256")
+  rm -f "$notary_zip"
+}
+
+build_package_notarize aarch64-apple-darwin arm64
+build_package_notarize x86_64-apple-darwin x86_64
+
+gh release upload "$tag" \
+  "$artifacts/comradex-${version}-macos-arm64.tar.gz" \
+  "$artifacts/comradex-${version}-macos-arm64.tar.gz.sha256" \
+  "$artifacts/comradex-${version}-macos-x86_64.tar.gz" \
+  "$artifacts/comradex-${version}-macos-x86_64.tar.gz.sha256" \
+  --clobber
+
+update_homebrew() {
+  local previous_run new_run
+  previous_run="$(gh run list -R nicosuave/homebrew-tap --limit 1 --json databaseId --jq '.[0].databaseId')"
+  gh api --method POST repos/nicosuave/homebrew-tap/dispatches \
+    -f event_type=update-formula \
+    -F "client_payload[formula]=comradex" \
+    -F "client_payload[version]=$version" \
+    -F "client_payload[repo]=nicosuave/comradex"
+
+  new_run=""
+  for _ in {1..15}; do
+    new_run="$(gh run list -R nicosuave/homebrew-tap --limit 1 --json databaseId --jq '.[0].databaseId')"
+    [[ -n "$new_run" && "$new_run" != "$previous_run" ]] && break
+    sleep 2
+  done
+  if [[ -z "$new_run" || "$new_run" == "$previous_run" ]]; then
+    echo "Timed out waiting for the Homebrew update workflow" >&2
+    return 1
+  fi
+  gh run watch "$new_run" -R nicosuave/homebrew-tap --exit-status
+}
+
+if ! update_homebrew; then
+  echo "Homebrew update failed; retrying after GitHub's asset CDN settles" >&2
+  sleep 10
+  update_homebrew
+fi
+
+echo "Published signed and notarized macOS assets for $tag"


### PR DESCRIPTION
## Summary
- keep Apple Developer ID and notarization credentials in the maintainer's local Keychain
- add a local release script that builds, signs, notarizes, and uploads both macOS architectures
- leave Linux release builds in GitHub Actions and update Homebrew only after local macOS assets are available
- document the release procedure for humans and future agents

## Context
The v0.9.2 Homebrew binary was linker/ad-hoc signed and macOS killed its LaunchAgent before startup with a launch constraint violation. The v0.9.2 macOS assets have already been republished locally with accepted Apple notarizations and the Homebrew formula now references their new checksums.

## Verification
- cargo test --locked (159 passed)
- bash -n scripts/release_macos_local.sh
- release workflow YAML parse
- git diff --check
- Homebrew reinstall from the republished v0.9.2 artifact
- LaunchAgent healthy on 127.0.0.1:10100