### PR TITLE
Track current Codex protocol state

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -800,13 +800,26 @@ impl App {
 
     async fn handle_http_replay_with_routing_anchor(
         &self,
-        inbound_headers: hyper::HeaderMap,
+        mut inbound_headers: hyper::HeaderMap,
         method: Method,
         listener: &ListenerConfig,
-        path: String,
+        mut path: String,
         mut replay: ReplayBody,
         routing_previous_response_id: Option<String>,
     ) -> Result<Response<ProxyBody>> {
+        let legacy_compact = method == Method::POST && is_legacy_compact_path(&path);
+        if legacy_compact {
+            let bytes = replay.into_bytes().await?;
+            let bytes = rewrite_legacy_compact_request(&bytes)?;
+            replay = ReplayBody::from_bytes(
+                bytes,
+                self.config.proxy.max_request_bytes,
+                self.config.proxy.max_spool_bytes,
+                self.stats.clone(),
+            )?;
+            path = responses_path_for_legacy_compact(&path);
+            mark_compaction_request(&mut inbound_headers)?;
+        }
         if replay.file_ids_overflow() {
             return Ok(error_response(
                 StatusCode::PAYLOAD_TOO_LARGE,
@@ -1046,6 +1059,9 @@ impl App {
                             selected = alternate;
                             continue;
                         }
+                    }
+                    if status.is_success() && legacy_compact {
+                        return map_legacy_compact_response(response).await;
                     }
                     request_lease.disarm();
                     return Ok(map_http_response_leased(
@@ -3102,6 +3118,169 @@ fn is_native_responses(path: &str) -> bool {
     )
 }
 
+fn is_legacy_compact_path(path: &str) -> bool {
+    path.split('?').next() == Some("/responses/compact")
+}
+
+fn responses_path_for_legacy_compact(path: &str) -> String {
+    path.strip_prefix("/responses/compact")
+        .map(|suffix| format!("/responses{suffix}"))
+        .unwrap_or_else(|| path.to_owned())
+}
+
+fn rewrite_legacy_compact_request(bytes: &[u8]) -> Result<bytes::Bytes> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(bytes).context("parse legacy compact request")?;
+    let object = value
+        .as_object_mut()
+        .context("legacy compact request must be a JSON object")?;
+    object.insert("stream".into(), serde_json::Value::Bool(true));
+    object.insert("store".into(), serde_json::Value::Bool(false));
+    object.remove("text");
+    object.remove("tools");
+    object.remove("tool_choice");
+    let input = object
+        .get_mut("input")
+        .and_then(serde_json::Value::as_array_mut)
+        .context("legacy compact request input must be an array")?;
+    if !input.last().is_some_and(|item| {
+        item.get("type").and_then(serde_json::Value::as_str) == Some("compaction_trigger")
+    }) {
+        input.push(serde_json::json!({"type":"compaction_trigger"}));
+    }
+    Ok(bytes::Bytes::from(serde_json::to_vec(&value)?))
+}
+
+fn mark_compaction_request(headers: &mut hyper::HeaderMap) -> Result<()> {
+    let mut metadata = headers
+        .get("x-codex-turn-metadata")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(value).ok()
+        })
+        .unwrap_or_default();
+    metadata.insert(
+        "request_kind".into(),
+        serde_json::Value::String("compaction".into()),
+    );
+    headers.insert(
+        "x-codex-turn-metadata",
+        serde_json::to_string(&metadata)?.parse()?,
+    );
+    headers.remove(CONTENT_LENGTH);
+    Ok(())
+}
+
+async fn map_legacy_compact_response(response: Response<Incoming>) -> Result<Response<ProxyBody>> {
+    let (mut parts, mut body) = response.into_parts();
+    let mut decoder = SseDecoder::default();
+    let mut created_id = None;
+    let mut completed = None;
+    let mut output = Vec::<(usize, serde_json::Value)>::new();
+    let mut received = 0usize;
+    while let Some(frame) = body.frame().await {
+        let frame = frame.context("read compact response")?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        received = received
+            .checked_add(data.len())
+            .context("compact response length overflow")?;
+        if received > RESPONSES_JSON_RESPONSE_LIMIT {
+            anyhow::bail!("compact response exceeds safety limit")
+        }
+        for event in decoder.push(&data)? {
+            capture_legacy_compact_event(event.value, &mut created_id, &mut completed, &mut output);
+        }
+    }
+    for event in decoder.finish()? {
+        capture_legacy_compact_event(event.value, &mut created_id, &mut completed, &mut output);
+    }
+    let completed = completed.context("compact stream ended without a terminal response")?;
+    output.sort_by_key(|(index, _)| *index);
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "object".into(),
+        serde_json::Value::String("response.compact".into()),
+    );
+    payload.insert(
+        "id".into(),
+        completed
+            .get("id")
+            .cloned()
+            .or_else(|| created_id.map(serde_json::Value::String))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    payload.insert(
+        "status".into(),
+        completed
+            .get("status")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::String("completed".into())),
+    );
+    if !output.is_empty() {
+        payload.insert(
+            "output".into(),
+            serde_json::Value::Array(output.into_iter().map(|(_, item)| item).collect()),
+        );
+    } else if let Some(items) = completed
+        .get("output")
+        .filter(|value| value.as_array().is_some_and(|items| !items.is_empty()))
+    {
+        payload.insert("output".into(), items.clone());
+    }
+    for key in ["usage", "error"] {
+        if let Some(value) = completed.get(key).filter(|value| !value.is_null()) {
+            payload.insert(key.into(), value.clone());
+        }
+    }
+    let bytes = bytes::Bytes::from(serde_json::to_vec(&payload)?);
+    headers::strip_hop_by_hop(&mut parts.headers);
+    parts.headers.remove("content-encoding");
+    parts
+        .headers
+        .insert(CONTENT_TYPE, "application/json".parse()?);
+    parts.headers.insert(CONTENT_LENGTH, bytes.len().into());
+    Ok(Response::from_parts(parts, bytes_body(bytes)))
+}
+
+fn capture_legacy_compact_event(
+    event: serde_json::Value,
+    created_id: &mut Option<String>,
+    completed: &mut Option<serde_json::Value>,
+    output: &mut Vec<(usize, serde_json::Value)>,
+) {
+    match event.get("type").and_then(serde_json::Value::as_str) {
+        Some("response.created") => {
+            if let Some(id) = event
+                .get("response")
+                .and_then(|response| response.get("id"))
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty())
+            {
+                *created_id = Some(id.to_owned());
+            }
+        }
+        Some("response.output_item.done") => {
+            if let Some(item) = event.get("item").filter(|item| item.is_object()) {
+                let index = event
+                    .get("output_index")
+                    .and_then(serde_json::Value::as_u64)
+                    .and_then(|index| usize::try_from(index).ok())
+                    .unwrap_or(output.len());
+                output.push((index, item.clone()));
+            }
+        }
+        Some("response.completed" | "response.failed" | "response.incomplete") => {
+            *completed = event
+                .get("response")
+                .filter(|value| value.is_object())
+                .cloned();
+        }
+        _ => {}
+    }
+}
+
 fn is_file_create(method: &Method, path: &str) -> bool {
     *method == Method::POST && path.split('?').next() == Some("/files")
 }
@@ -4850,6 +5029,37 @@ mod tests {
         assert!(!is_safe_codex_quota_header("x-codex-turn-metadata"));
     }
 
+    #[test]
+    fn rewrites_legacy_compact_request_for_current_responses_protocol() {
+        let bytes = rewrite_legacy_compact_request(
+            br#"{"input":[{"type":"message","content":"hello"}],"store":true,"stream":false,"tools":[]}"#,
+        )
+        .unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["stream"], true);
+        assert_eq!(value["store"], false);
+        assert!(value.get("tools").is_none());
+        assert_eq!(
+            value["input"].as_array().unwrap().last().unwrap()["type"],
+            "compaction_trigger"
+        );
+        assert_eq!(
+            responses_path_for_legacy_compact("/responses/compact?test=1"),
+            "/responses?test=1"
+        );
+
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert(
+            "x-codex-turn-metadata",
+            r#"{"thread_id":"task"}"#.parse().unwrap(),
+        );
+        mark_compaction_request(&mut headers).unwrap();
+        let metadata: serde_json::Value =
+            serde_json::from_str(headers["x-codex-turn-metadata"].to_str().unwrap()).unwrap();
+        assert_eq!(metadata["thread_id"], "task");
+        assert_eq!(metadata["request_kind"], "compaction");
+    }
+
     #[tokio::test]
     async fn direct_fresh_frame_rotates_off_exhausted_socket_account() {
         let dir = tempfile::tempdir().unwrap();
@@ -4961,7 +5171,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replays_exact_body_once_and_commits_alternate_affinity() {
+    async fn translates_legacy_compact_and_commits_alternate_affinity() {
         let dir = tempfile::tempdir().unwrap();
         let seen = Arc::new(Mutex::new(Vec::<Seen>::new()));
         let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -4999,7 +5209,15 @@ mod tests {
                                     .status(StatusCode::OK)
                                     .header(CONTENT_TYPE, "text/event-stream")
                                     .header("x-codex-turn-state", "opaque-state")
-                                    .body(Full::new(Bytes::from_static(b"data: ok\n\n")))
+                                    .body(Full::new(Bytes::from_static(
+                                        br#"data: {"type":"response.created","response":{"id":"resp_compact","status":"in_progress"}}
+
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"cmp_1","type":"compaction","encrypted_content":"ciphertext"}}
+
+data: {"type":"response.completed","response":{"id":"resp_compact","status":"completed","output":[],"usage":{"input_tokens":12}}}
+
+"#,
+                                    )))
                                     .unwrap()
                             };
                             Ok::<_, Infallible>(response)
@@ -5071,7 +5289,7 @@ mod tests {
         let client: TestClient<HttpConnector, Full<Bytes>> =
             TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
         let payload = Bytes::from_static(
-            br#"{"client_metadata":{"thread_id":"same-thread"},"input":"byte-identical"}"#,
+            br#"{"client_metadata":{"thread_id":"same-thread"},"input":[{"type":"message","content":"byte-identical"}]}"#,
         );
         for _ in 0..2 {
             let request = Request::builder()
@@ -5085,10 +5303,12 @@ mod tests {
             let response = client.request(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             assert_eq!(response.headers()["x-codex-turn-state"], "opaque-state");
-            assert_eq!(
-                response.into_body().collect().await.unwrap().to_bytes(),
-                "data: ok\n\n"
-            );
+            let body = response.into_body().collect().await.unwrap().to_bytes();
+            let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(body["object"], "response.compact");
+            assert_eq!(body["id"], "resp_compact");
+            assert_eq!(body["output"][0]["type"], "compaction");
+            assert_eq!(body["output"][0]["encrypted_content"], "ciphertext");
         }
 
         let calls = seen.lock().unwrap().clone();
@@ -5096,12 +5316,20 @@ mod tests {
         assert_eq!(calls[0].authorization, "Bearer token-a");
         assert_eq!(calls[1].authorization, "Bearer token-b");
         assert_eq!(calls[2].authorization, "Bearer token-b");
-        assert!(calls.iter().all(|v| v.body == payload));
         assert!(
             calls
                 .iter()
-                .all(|v| v.path == "/backend-api/codex/responses/compact?test=1")
+                .all(|v| v.path == "/backend-api/codex/responses?test=1")
         );
+        for call in calls {
+            let body: serde_json::Value = serde_json::from_slice(&call.body).unwrap();
+            assert_eq!(body["stream"], true);
+            assert_eq!(body["store"], false);
+            assert_eq!(
+                body["input"].as_array().unwrap().last().unwrap()["type"],
+                "compaction_trigger"
+            );
+        }
 
         proxy_task.abort();
         upstream_task.abort();
@@ -5152,7 +5380,9 @@ mod tests {
                 "http://{proxy_addr}/0123456789abcdef/v1/responses/compact"
             ))
             .header(AUTHORIZATION, "Bearer caller-token")
-            .body(Full::new(Bytes::from_static(br#"{"input":"compact"}"#)))
+            .body(Full::new(Bytes::from_static(
+                br#"{"input":[{"type":"message","content":"compact"}]}"#,
+            )))
             .unwrap();
         let response = client.request(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
@@ -5188,7 +5418,9 @@ mod tests {
                 "http://{proxy_addr}/0123456789abcdef/v1/responses/compact"
             ))
             .header(AUTHORIZATION, "Bearer caller-token")
-            .body(Full::new(Bytes::from_static(br#"{"input":"compact"}"#)))
+            .body(Full::new(Bytes::from_static(
+                br#"{"input":[{"type":"message","content":"compact"}]}"#,
+            )))
             .unwrap();
         let response = client.request(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_GATEWAY);

--- a/src/proxy/replay_body.rs
+++ b/src/proxy/replay_body.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File as StdFile,
-    io::Write,
+    io::{Read, Write},
     sync::{Arc, atomic::Ordering},
 };
 
@@ -389,6 +389,38 @@ impl ReplayBody {
 
     pub fn file_ids_overflow(&self) -> bool {
         self.file_ids_overflow
+    }
+
+    /// Materialize a replay body for protocol translation while releasing its
+    /// spool reservation. Callers can construct a replacement `ReplayBody`
+    /// without temporarily double-counting the request against the global
+    /// spool limit.
+    pub async fn into_bytes(mut self) -> Result<Bytes> {
+        let storage = std::mem::replace(&mut self.storage, Storage::Memory(Bytes::new()));
+        let bytes = match storage {
+            Storage::Memory(bytes) => bytes,
+            Storage::Files(mut files) => {
+                let mut file = files
+                    .get_mut(0)
+                    .and_then(Option::take)
+                    .context("replay body has no materializable spool")?;
+                let expected = self.len;
+                Bytes::from(
+                    tokio::task::spawn_blocking(move || {
+                        let mut bytes = Vec::with_capacity(expected);
+                        file.read_to_end(&mut bytes)?;
+                        Ok::<_, std::io::Error>(bytes)
+                    })
+                    .await
+                    .context("join replay materialization")??,
+                )
+            }
+        };
+        self.stats
+            .active_spool_bytes
+            .fetch_sub(self.len, Ordering::AcqRel);
+        self.len = 0;
+        Ok(bytes)
     }
 
     pub fn body(&mut self, attempt: usize) -> Result<ProxyBody> {

--- a/src/routing/metadata.rs
+++ b/src/routing/metadata.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AffinityKind {
     TurnState,
+    ThreadHeader,
     Session,
     ParentThread,
     TurnMetadata,
@@ -27,7 +28,7 @@ impl AffinityKind {
     /// session and cache hints that can survive across conversations.
     pub fn soft_routing_priority(self) -> Option<u8> {
         match self {
-            Self::BodyThread => Some(0),
+            Self::ThreadHeader | Self::BodyThread => Some(0),
             Self::ParentThread | Self::TurnMetadata => Some(1),
             Self::Session => Some(2),
             Self::PromptCache => Some(3),
@@ -39,7 +40,9 @@ impl AffinityKind {
         match self {
             Self::TurnState => "turn-state",
             Self::Session => "session",
-            Self::ParentThread | Self::TurnMetadata | Self::BodyThread => "thread",
+            Self::ThreadHeader | Self::ParentThread | Self::TurnMetadata | Self::BodyThread => {
+                "thread"
+            }
             Self::PreviousResponse => "previous-response",
             Self::PromptCache => "prompt-cache",
             Self::File => "file",
@@ -60,7 +63,8 @@ impl AffinityValue {
 }
 
 pub fn thread_id(headers: &HeaderMap, body: Option<&[u8]>) -> Option<String> {
-    header(headers, "x-codex-parent-thread-id")
+    header(headers, "thread-id")
+        .or_else(|| header(headers, "x-codex-parent-thread-id"))
         .or_else(|| header_json(headers, "x-codex-turn-metadata", "thread_id"))
         .or_else(|| body.and_then(body_thread_id))
 }
@@ -84,12 +88,17 @@ pub fn affinity_values(
         "session-id",
         "x-codex-session-id",
         "x-codex-conversation-id",
-        "thread-id",
     ] {
         if push_header(&mut values, headers, name, AffinityKind::Session) {
             break;
         }
     }
+    push_header(
+        &mut values,
+        headers,
+        "thread-id",
+        AffinityKind::ThreadHeader,
+    );
     push_header(
         &mut values,
         headers,
@@ -200,13 +209,15 @@ mod tests {
             HeaderValue::from_static(r#"{"thread_id":"root"}"#),
         );
         assert_eq!(thread_id(&h, None).as_deref(), Some("root"));
+        h.insert("thread-id", HeaderValue::from_static("task"));
+        assert_eq!(thread_id(&h, None).as_deref(), Some("task"));
         h.insert(
             "x-codex-parent-thread-id",
             HeaderValue::from_static("parent"),
         );
         assert_eq!(
             thread_id(&h, Some(br#"{"client_metadata":{"thread_id":"body"}}"#)).as_deref(),
-            Some("parent")
+            Some("task")
         );
 
         h.insert("x-codex-turn-state", HeaderValue::from_static("opaque"));
@@ -233,6 +244,35 @@ mod tests {
         assert!(
             AffinityKind::Session.soft_routing_priority()
                 < AffinityKind::PromptCache.soft_routing_priority()
+        );
+    }
+
+    #[test]
+    fn keeps_process_session_and_task_thread_as_distinct_affinity_keys() {
+        let mut headers = HeaderMap::new();
+        headers.insert("session-id", HeaderValue::from_static("agent-tree"));
+        headers.insert("thread-id", HeaderValue::from_static("child-task"));
+
+        let values = affinity_values(&headers, None, None, Some("agent-tree"), &[]);
+
+        assert!(values.iter().any(|value| {
+            value.kind == AffinityKind::Session && value.namespaced() == "session:agent-tree"
+        }));
+        assert!(values.iter().any(|value| {
+            value.kind == AffinityKind::ThreadHeader && value.namespaced() == "thread:child-task"
+        }));
+        assert_eq!(
+            values
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .kind
+                        .soft_routing_priority()
+                        .map(|priority| (priority, value.namespaced()))
+                })
+                .min_by_key(|(priority, _)| *priority)
+                .map(|(_, value)| value),
+            Some("thread:child-task".to_owned())
         );
     }
 }

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -31,8 +31,24 @@ struct AccountRuntime {
     needs_login: bool,
     needs_login_retry_at: Option<Instant>,
     quota_until: Option<Instant>,
+    quota_evidence: Option<QuotaEvidence>,
     avoid_until: Option<Instant>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum QuotaWindow {
+    Primary,
+    Secondary,
+    Tertiary,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WindowEvidence {
+    used_percent: Option<f32>,
+    reset_at: Option<DateTime<Utc>>,
+}
+
+type QuotaEvidence = HashMap<QuotaWindow, WindowEvidence>;
 
 pub struct Router {
     pub affinity: Arc<AffinityStore>,
@@ -230,9 +246,12 @@ impl Router {
         }
     }
     pub async fn quota_failure(&self, account: &str, headers: &hyper::HeaderMap) {
-        let delay = quota_delay(headers);
+        let now = Utc::now();
+        let delay = quota_delay_at(headers, now);
+        let evidence = quota_evidence(headers, now);
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
             a.quota_until = Some(Instant::now() + delay);
+            a.quota_evidence = (!evidence.is_empty()).then_some(evidence);
         }
     }
     pub async fn soft_failure(&self, account: &str) {
@@ -276,6 +295,7 @@ impl Router {
         }
     }
     pub async fn observe_headers(&self, account: &str, headers: &hyper::HeaderMap) {
+        let observed_evidence = quota_evidence(headers, Utc::now());
         let candidates = [
             "x-codex-primary-used-percent",
             "x-ratelimit-primary-used-percent",
@@ -288,8 +308,17 @@ impl Router {
             .filter_map(|name| headers.get(*name)?.to_str().ok()?.parse::<f32>().ok())
             .max_by(|left, right| left.total_cmp(right))
             .map(|v| v.clamp(0.0, 100.0) as u8);
-        if let (Some(usage), Some(a)) = (usage, self.accounts.lock().await.get_mut(account)) {
-            a.usage = Some(usage);
+        if let Some(a) = self.accounts.lock().await.get_mut(account) {
+            if let Some(usage) = usage {
+                a.usage = Some(usage);
+            }
+            if a.quota_evidence
+                .as_ref()
+                .is_some_and(|blocked| quota_reset_confirmed(blocked, &observed_evidence))
+            {
+                a.quota_until = None;
+                a.quota_evidence = None;
+            }
         }
     }
     pub async fn record_count(&self) -> usize {
@@ -297,8 +326,75 @@ impl Router {
     }
 }
 
-fn quota_delay(headers: &hyper::HeaderMap) -> Duration {
-    quota_delay_at(headers, Utc::now())
+fn quota_evidence(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> QuotaEvidence {
+    [
+        (QuotaWindow::Primary, "primary"),
+        (QuotaWindow::Secondary, "secondary"),
+        (QuotaWindow::Tertiary, "tertiary"),
+    ]
+    .into_iter()
+    .filter_map(|(window, name)| {
+        let used_percent = [
+            format!("x-codex-{name}-used-percent"),
+            format!("x-ratelimit-{name}-used-percent"),
+        ]
+        .into_iter()
+        .filter_map(|header| {
+            headers
+                .get(&header)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.trim().parse::<f32>().ok())
+        })
+        .max_by(|left, right| left.total_cmp(right));
+        let reset_at = ["x-codex", "x-ratelimit"]
+            .into_iter()
+            .filter_map(|prefix| {
+                let absolute = format!("{prefix}-{name}-reset-at");
+                let relative = format!("{prefix}-{name}-reset-after-seconds");
+                headers
+                    .get(&absolute)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_reset_at)
+                    .or_else(|| {
+                        headers
+                            .get(&relative)
+                            .and_then(|value| value.to_str().ok())
+                            .and_then(|value| value.trim().parse::<i64>().ok())
+                            .and_then(|seconds| {
+                                now.checked_add_signed(chrono::Duration::seconds(seconds))
+                            })
+                    })
+            })
+            .max();
+        (used_percent.is_some() || reset_at.is_some()).then_some((
+            window,
+            WindowEvidence {
+                used_percent,
+                reset_at,
+            },
+        ))
+    })
+    .collect()
+}
+
+fn quota_reset_confirmed(blocked: &QuotaEvidence, observed: &QuotaEvidence) -> bool {
+    blocked.iter().any(|(window, before)| {
+        let Some(after) = observed.get(window) else {
+            return false;
+        };
+        let usage_recovered = match (before.used_percent, after.used_percent) {
+            (Some(before), Some(after)) => after < before,
+            (None, Some(after)) => after < 100.0,
+            _ => false,
+        };
+        let reset_advanced = match (before.reset_at, after.reset_at) {
+            (Some(before), Some(after)) => {
+                after.signed_duration_since(before) > chrono::Duration::seconds(60)
+            }
+            _ => false,
+        };
+        usage_recovered && reset_advanced
+    })
 }
 
 fn quota_delay_at(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> Duration {
@@ -514,6 +610,91 @@ mod tests {
                 .account_id,
             second.account_id
         );
+    }
+
+    #[tokio::test]
+    async fn authoritative_new_quota_window_clears_stale_cooldown() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = config(dir.path());
+        cfg.pools.get_mut("default").unwrap().members = vec!["a".into()];
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity);
+        let pool = &cfg.pools["default"];
+        let mut blocked = HeaderMap::new();
+        blocked.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("100"),
+        );
+        blocked.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("2099-01-01T00:00:00Z"),
+        );
+        router.quota_failure("a", &blocked).await;
+        assert!(router.select("default", pool, None, None).await.is_none());
+
+        let mut reset = HeaderMap::new();
+        reset.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("3"),
+        );
+        reset.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("2099-02-01T00:00:00Z"),
+        );
+        router.observe_headers("a", &reset).await;
+
+        assert!(router.select("default", pool, None, None).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn usage_alone_does_not_clear_quota_cooldown() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = config(dir.path());
+        cfg.pools.get_mut("default").unwrap().members = vec!["a".into()];
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity);
+        let pool = &cfg.pools["default"];
+        let mut blocked = HeaderMap::new();
+        blocked.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("100"),
+        );
+        blocked.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("2099-01-01T00:00:00Z"),
+        );
+        router.quota_failure("a", &blocked).await;
+
+        let mut ambiguous = HeaderMap::new();
+        ambiguous.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("3"),
+        );
+        ambiguous.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("2099-01-01T00:00:00Z"),
+        );
+        router.observe_headers("a", &ambiguous).await;
+
+        assert!(router.select("default", pool, None, None).await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- route the current `thread-id` independently from the process-wide `session-id`, so sibling Codex tasks do not share one soft affinity key
- translate legacy `/responses/compact` requests to the current streamed `/responses` compaction protocol and fold the SSE result back into the legacy JSON response shape
- clear a stale quota cooldown only when later headers prove that the same quota window advanced and its usage dropped

## Why

Recent Codex protocol changes made `session-id` an agent-tree identifier, retired the dedicated compact endpoint, and exposed cases where a future cooldown can outlive an authoritative quota reset. The previous behavior could co-locate distinct tasks incorrectly, return 404 for legacy compaction calls, or leave recovered accounts unavailable.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (180 tests passed: 174 library + 6 binary)
