### PR TITLE
Release 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comradex"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comradex"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A bounded, sticky account-pool router for native Codex traffic"


### PR DESCRIPTION
## What changed

- bump ComradeX from 0.9.2 to 0.9.3
- publish the upstream-liveness watchdogs, credential-expiry hardening, current Codex protocol tracking, and hardened local macOS release validation already merged to `main`

## Why

The published 0.9.2 binary can leave upstream Responses requests waiting indefinitely, causing the Codex UI to time out. The liveness fixes are merged but not present in any published release.

## Validation

- `cargo test --locked` (180 tests passed: 174 library + 6 binary)