### PR TITLE
Add live account preference switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,14 @@ Use these commands to inspect or remove accounts:
 ```sh
 comradex account list
 comradex account login personal_2
+comradex account prefer personal_2
+comradex account prefer --clear
 comradex account remove personal_2
 ```
 
 `account list` shows each account's login state. `account remove` removes it from the configuration and every pool but keeps its credential directory unless `--purge` is passed.
+
+`account prefer <name>` immediately makes that account the first choice for new, unbound work in the default pool. Use `--pool <name>` for another pool and `--clear` to restore automatic selection. The daemon applies the change through an authenticated, user-only Unix socket and persists it in `comradex.toml`; it does not restart, interrupt active turns, or move sticky conversations. An unavailable, quota-limited, or over-threshold preferred account is skipped by the normal quota-aware fallback. If the daemon is not running, the preference is saved and takes effect on its next start.
 
 The equivalent manual configuration is:
 
@@ -242,4 +246,4 @@ comradex status
 comradex status --json
 ```
 
-`status` summarizes the configuration, LaunchAgent, Codex wiring, accounts, and live traffic. `--json` prints the bounded local `stats.json` snapshot written by the daemon. When running from source, use `cargo run -- status`. There is deliberately no credentialed admin HTTP endpoint.
+`status` summarizes the configuration, LaunchAgent, Codex wiring, accounts, per-pool preferred and active accounts, and live traffic. While the daemon is running, routing status comes directly from its authenticated local control socket; the bounded `stats.json` snapshot is the fallback and is also updated periodically. `--json` prints that snapshot with the latest live routing state. When running from source, use `cargo run -- status`. There is deliberately no credentialed admin HTTP endpoint.

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -71,9 +71,49 @@ pub fn remove_account(text: &str, name: &str) -> Result<(String, Option<String>)
                 members.retain(|member| member.as_str() != Some(name));
                 members.fmt();
             }
+            if pool.get("preferred").and_then(Item::as_str) == Some(name) {
+                pool.as_table_like_mut()
+                    .expect("pool was already accessed as a table")
+                    .remove("preferred");
+            }
         }
     }
     Ok((doc.to_string(), home))
+}
+
+/// Set or clear the preferred account for a pool while preserving surrounding formatting.
+pub fn set_preferred_account(text: &str, pool_name: &str, account: Option<&str>) -> Result<String> {
+    if let Some(account) = account {
+        validate_name(account)?;
+    }
+    let mut doc: DocumentMut = text.parse().context("parse comradex.toml")?;
+    let pool = doc
+        .get_mut("pools")
+        .and_then(Item::as_table_like_mut)
+        .and_then(|pools| pools.get_mut(pool_name))
+        .with_context(|| format!("unknown pool {pool_name}"))?
+        .as_table_like_mut()
+        .with_context(|| format!("pool {pool_name} is not a table"))?;
+    match account {
+        Some(account) => {
+            let is_member = pool
+                .get("members")
+                .and_then(Item::as_array)
+                .is_some_and(|members| {
+                    members
+                        .iter()
+                        .any(|member| member.as_str() == Some(account))
+                });
+            if !is_member {
+                bail!("account {account} is not a member of pool {pool_name}")
+            }
+            pool.insert("preferred", value(account));
+        }
+        None => {
+            pool.remove("preferred");
+        }
+    }
+    Ok(doc.to_string())
 }
 
 #[cfg(test)]
@@ -140,5 +180,24 @@ kind = "inbound"
                 .to_string()
                 .contains("unknown account")
         );
+    }
+
+    #[test]
+    fn preferred_account_is_set_cleared_and_removed_with_the_account() {
+        let added = add_account(TEMPLATE, "work2", "default").unwrap();
+        let preferred = set_preferred_account(&added, "default", Some("work2")).unwrap();
+        assert!(preferred.contains("preferred = \"work2\""));
+
+        let cleared = set_preferred_account(&preferred, "default", None).unwrap();
+        assert!(!cleared.contains("preferred"));
+
+        let (removed, _) = remove_account(&preferred, "work2").unwrap();
+        assert!(!removed.contains("preferred"));
+    }
+
+    #[test]
+    fn preferred_account_must_belong_to_the_pool() {
+        let error = set_preferred_account(TEMPLATE, "default", Some("missing")).unwrap_err();
+        assert!(error.to_string().contains("not a member"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,6 +146,10 @@ pub struct ListenerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
     pub members: Vec<String>,
+    /// Account preferred for fresh, unbound work. Sticky conversations and hard ownership
+    /// always take precedence, and an unhealthy or quota-limited account is skipped.
+    #[serde(default)]
+    pub preferred: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -303,6 +307,15 @@ impl Config {
         if self.listeners.is_empty() {
             bail!("at least one listener is required")
         }
+        for (pool_name, pool) in &self.pools {
+            if let Some(preferred) = &pool.preferred
+                && !pool.members.contains(preferred)
+            {
+                bail!(
+                    "pool {pool_name} prefers account {preferred}, which is not one of its members"
+                )
+            }
+        }
         for (name, listener) in &self.listeners {
             let pool = self.pools.get(&listener.pool).with_context(|| {
                 format!("listener {name} references missing pool {}", listener.pool)
@@ -322,6 +335,25 @@ impl Config {
     pub fn snapshot_interval(&self) -> Duration {
         Duration::from_secs(self.proxy.snapshot_interval_seconds.max(1))
     }
+}
+
+/// Atomically replace a configuration file only after the full loader accepts the candidate.
+/// The temporary file lives beside the target so relative paths resolve from the same directory.
+pub fn write_validated(path: &Path, text: &str) -> Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let mut temp = tempfile::Builder::new()
+        .suffix(".toml")
+        .tempfile_in(parent)?;
+    temp.write_all(text.as_bytes())?;
+    temp.as_file().sync_all()?;
+    Config::load(temp.path()).context("validate updated configuration")?;
+    if let Ok(metadata) = fs::metadata(path) {
+        temp.as_file().set_permissions(metadata.permissions())?;
+    }
+    temp.persist(path).map_err(|error| error.error)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -414,6 +446,19 @@ kind = "inbound"
                 .unwrap()
                 .join("accounts/managed")
         );
+    }
+
+    #[test]
+    fn preferred_account_must_be_a_pool_member() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("comradex.toml");
+        let text = config_text(None).replace(
+            "members = [\"caller\"]",
+            "members = [\"caller\"]\npreferred = \"missing\"",
+        );
+        fs::write(&path, text).unwrap();
+        let error = Config::load(&path).unwrap_err();
+        assert!(error.to_string().contains("not one of its members"));
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,0 +1,422 @@
+//! Authenticated local control channel for routing changes that must not restart the daemon.
+
+use std::{
+    fs,
+    io::{BufRead, BufReader, Read, Write},
+    os::unix::{
+        fs::{FileTypeExt, PermissionsExt},
+        net::UnixStream as StdUnixStream,
+    },
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader as AsyncBufReader},
+    net::{UnixListener, UnixStream},
+    sync::Mutex,
+};
+use tracing::warn;
+
+use crate::{
+    accounts,
+    config::{self, Config},
+    routing::{Router, RoutingSnapshot},
+};
+
+const SOCKET_NAME: &str = "control.sock";
+const MAX_MESSAGE_BYTES: usize = 16 * 1024;
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+enum Request {
+    SetPreferred {
+        secret: String,
+        pool: String,
+        account: Option<String>,
+    },
+    RoutingStatus {
+        secret: String,
+    },
+}
+
+impl Request {
+    fn secret(&self) -> &str {
+        match self {
+            Self::SetPreferred { secret, .. } | Self::RoutingStatus { secret } => secret,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Response {
+    ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    routing: Option<RoutingSnapshot>,
+}
+
+struct SocketGuard(PathBuf);
+
+impl Drop for SocketGuard {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.0)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(path = %self.0.display(), %error, "failed to remove control socket");
+        }
+    }
+}
+
+pub struct ControlServer {
+    listener: UnixListener,
+    _guard: SocketGuard,
+    config_path: PathBuf,
+    config: Arc<Config>,
+    router: Arc<Router>,
+    edit_lock: Arc<Mutex<()>>,
+}
+
+pub fn socket_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(SOCKET_NAME)
+}
+
+impl ControlServer {
+    pub fn bind(
+        state_dir: &Path,
+        config_path: PathBuf,
+        config: Arc<Config>,
+        router: Arc<Router>,
+    ) -> Result<Self> {
+        let path = socket_path(state_dir);
+        remove_stale_socket(&path)?;
+        let listener = UnixListener::bind(&path)
+            .with_context(|| format!("bind control socket {}", path.display()))?;
+        let guard = SocketGuard(path.clone());
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("secure control socket {}", path.display()))?;
+        Ok(Self {
+            listener,
+            _guard: guard,
+            config_path,
+            config,
+            router,
+            edit_lock: Arc::new(Mutex::new(())),
+        })
+    }
+
+    pub async fn run(self) -> Result<()> {
+        loop {
+            let (stream, _) = self.listener.accept().await?;
+            let config_path = self.config_path.clone();
+            let config = self.config.clone();
+            let router = self.router.clone();
+            let edit_lock = self.edit_lock.clone();
+            tokio::spawn(async move {
+                if let Err(error) = handle(stream, config_path, config, router, edit_lock).await {
+                    warn!(%error, "control request failed");
+                }
+            });
+        }
+    }
+}
+
+fn remove_stale_socket(path: &Path) -> Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error).with_context(|| format!("inspect {}", path.display())),
+    };
+    if !metadata.file_type().is_socket() {
+        bail!(
+            "refusing to replace non-socket control path {}",
+            path.display()
+        )
+    }
+    if StdUnixStream::connect(path).is_ok() {
+        bail!(
+            "another Comradex daemon is already listening at {}",
+            path.display()
+        )
+    }
+    fs::remove_file(path).with_context(|| format!("remove stale socket {}", path.display()))
+}
+
+async fn handle(
+    stream: UnixStream,
+    config_path: PathBuf,
+    config: Arc<Config>,
+    router: Arc<Router>,
+    edit_lock: Arc<Mutex<()>>,
+) -> Result<()> {
+    let (reader, mut writer) = stream.into_split();
+    let mut reader = AsyncBufReader::new(reader).take((MAX_MESSAGE_BYTES + 1) as u64);
+    let mut bytes = Vec::new();
+    let read = tokio::time::timeout(CLIENT_TIMEOUT, reader.read_until(b'\n', &mut bytes))
+        .await
+        .context("control request timed out")?
+        .context("read control request")?;
+    let response = if read == 0 || bytes.len() > MAX_MESSAGE_BYTES || !bytes.ends_with(b"\n") {
+        Response {
+            ok: false,
+            error: Some("invalid control request framing".into()),
+            routing: None,
+        }
+    } else {
+        match serde_json::from_slice::<Request>(&bytes) {
+            Ok(request) => process(request, &config_path, &config, &router, &edit_lock).await,
+            Err(error) => Response {
+                ok: false,
+                error: Some(format!("invalid control request: {error}")),
+                routing: None,
+            },
+        }
+    };
+    let mut encoded = serde_json::to_vec(&response)?;
+    encoded.push(b'\n');
+    writer.write_all(&encoded).await?;
+    writer.shutdown().await?;
+    Ok(())
+}
+
+async fn process(
+    request: Request,
+    config_path: &Path,
+    config: &Config,
+    router: &Router,
+    edit_lock: &Mutex<()>,
+) -> Response {
+    if !secrets_equal(request.secret(), &config.proxy.installation_secret) {
+        return Response {
+            ok: false,
+            error: Some("unauthorized".into()),
+            routing: None,
+        };
+    }
+    let result: Result<RoutingSnapshot> = async {
+        match request {
+            Request::RoutingStatus { .. } => {}
+            Request::SetPreferred { pool, account, .. } => {
+                let pool_config = config
+                    .pools
+                    .get(&pool)
+                    .with_context(|| format!("unknown pool {pool}"))?;
+                if let Some(account) = &account
+                    && !pool_config.members.contains(account)
+                {
+                    bail!("account {account} is not a member of pool {pool}")
+                }
+                let _guard = edit_lock.lock().await;
+                let text = fs::read_to_string(config_path)
+                    .with_context(|| format!("read {}", config_path.display()))?;
+                let updated = accounts::set_preferred_account(&text, &pool, account.as_deref())?;
+                config::write_validated(config_path, &updated)?;
+                router.set_preferred(&pool, account).await;
+            }
+        }
+        Ok(router.routing_snapshot().await)
+    }
+    .await;
+    match result {
+        Ok(routing) => Response {
+            ok: true,
+            error: None,
+            routing: Some(routing),
+        },
+        Err(error) => Response {
+            ok: false,
+            error: Some(format!("{error:#}")),
+            routing: None,
+        },
+    }
+}
+
+fn secrets_equal(left: &str, right: &str) -> bool {
+    let left = left.as_bytes();
+    let right = right.as_bytes();
+    let mut difference = left.len() ^ right.len();
+    for index in 0..left.len().max(right.len()) {
+        difference |= usize::from(*left.get(index).unwrap_or(&0) ^ *right.get(index).unwrap_or(&0));
+    }
+    difference == 0
+}
+
+pub fn set_preferred(
+    state_dir: &Path,
+    secret: &str,
+    pool: &str,
+    account: Option<&str>,
+) -> Result<RoutingSnapshot> {
+    send(
+        state_dir,
+        &Request::SetPreferred {
+            secret: secret.to_owned(),
+            pool: pool.to_owned(),
+            account: account.map(str::to_owned),
+        },
+    )
+}
+
+pub fn routing_status(state_dir: &Path, secret: &str) -> Result<RoutingSnapshot> {
+    send(
+        state_dir,
+        &Request::RoutingStatus {
+            secret: secret.to_owned(),
+        },
+    )
+}
+
+fn send(state_dir: &Path, request: &Request) -> Result<RoutingSnapshot> {
+    let path = socket_path(state_dir);
+    let mut stream = StdUnixStream::connect(&path)
+        .with_context(|| format!("connect to running daemon at {}", path.display()))?;
+    stream.set_read_timeout(Some(CLIENT_TIMEOUT))?;
+    stream.set_write_timeout(Some(CLIENT_TIMEOUT))?;
+    serde_json::to_writer(&mut stream, request)?;
+    stream.write_all(b"\n")?;
+    let mut line = String::new();
+    BufReader::new(stream)
+        .take(MAX_MESSAGE_BYTES as u64)
+        .read_line(&mut line)?;
+    let response: Response = serde_json::from_str(&line).context("decode control response")?;
+    if !response.ok {
+        bail!(
+            response
+                .error
+                .unwrap_or_else(|| "control request failed".into())
+        )
+    }
+    response
+        .routing
+        .context("control response omitted routing status")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routing::AffinityStore;
+
+    #[test]
+    fn constant_time_comparison_handles_different_lengths() {
+        assert!(secrets_equal("secret", "secret"));
+        assert!(!secrets_equal("secret", "secrex"));
+        assert!(!secrets_equal("secret", "secret-longer"));
+    }
+
+    #[tokio::test]
+    async fn live_switch_is_authenticated_persisted_and_visible() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("comradex.toml");
+        fs::write(
+            &config_path,
+            r#"[proxy]
+installation_secret = "0123456789abcdef"
+affinity_key = "0123456789abcdef0123456789abcdef"
+state_dir = "state"
+
+[listeners.default]
+address = "127.0.0.1:10100"
+pool = "default"
+
+[pools.default]
+members = ["a", "b"]
+
+[accounts.a]
+kind = "inbound"
+
+[accounts.b]
+kind = "inbound"
+"#,
+        )
+        .unwrap();
+        let config = Arc::new(Config::load(&config_path).unwrap());
+        let state_dir = config.proxy.state_dir.clone().unwrap();
+        fs::create_dir_all(&state_dir).unwrap();
+        let affinity = Arc::new(
+            AffinityStore::load(
+                state_dir.join("affinity.json"),
+                &config.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Arc::new(Router::new(&config, affinity));
+        let server = ControlServer::bind(
+            &state_dir,
+            config_path.clone(),
+            config.clone(),
+            router.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            fs::metadata(socket_path(&state_dir))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        let task = tokio::spawn(server.run());
+
+        let state = state_dir.clone();
+        let unauthorized = tokio::task::spawn_blocking(move || {
+            set_preferred(&state, "wrong-secret", "default", Some("b"))
+        })
+        .await
+        .unwrap();
+        assert!(
+            unauthorized
+                .unwrap_err()
+                .to_string()
+                .contains("unauthorized")
+        );
+
+        let state = state_dir.clone();
+        let routing = tokio::task::spawn_blocking(move || {
+            set_preferred(&state, "0123456789abcdef", "default", Some("b"))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(routing.preferred_accounts["default"], "b");
+        assert!(!routing.active_accounts.contains_key("default"));
+        assert!(
+            fs::read_to_string(&config_path)
+                .unwrap()
+                .contains("preferred = \"b\"")
+        );
+        assert_eq!(
+            router.routing_snapshot().await.preferred_accounts["default"],
+            "b"
+        );
+
+        let selected = router
+            .select(
+                "default",
+                &config.pools["default"],
+                Some(router.affinity.key("fresh")),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(selected.account_id, "b");
+        let state = state_dir.clone();
+        let routing =
+            tokio::task::spawn_blocking(move || routing_status(&state, "0123456789abcdef"))
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(routing.active_accounts["default"], "b");
+
+        task.abort();
+        let _ = task.await;
+        assert!(!socket_path(&state_dir).exists());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod auth_lock;
 pub mod codex_process;
 pub mod config;
+pub mod control;
 pub mod install;
 pub mod proxy;
 pub mod routing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use comradex::{
     auth_lock::HomeAuthLock,
     codex_process::{self, ProcessControl, SystemProcesses},
     config::Config,
-    install,
+    control, install,
     proxy::App,
     routing::{AffinityStore, Router},
     service,
@@ -89,6 +89,17 @@ enum AccountCommand {
     },
     /// List configured accounts and their sign-in state
     List,
+    /// Prefer an account for new work without interrupting active turns
+    #[command(alias = "switch")]
+    Prefer {
+        /// Account to prefer; omit when using --clear
+        name: Option<String>,
+        #[arg(long, default_value = "default")]
+        pool: String,
+        /// Return the pool to automatic account selection
+        #[arg(long, conflicts_with = "name", required_unless_present = "name")]
+        clear: bool,
+    },
     /// Sign an account in through the official Codex device flow
     Login { name: String },
     /// Remove an account from the configuration and all pools
@@ -242,6 +253,8 @@ kind = "inbound"
 }
 
 async fn serve(path: &Path) -> Result<()> {
+    let config_path =
+        fs::canonicalize(path).with_context(|| format!("resolve config {}", path.display()))?;
     let config = Arc::new(load_config(path)?);
     let state = state_dir(&config);
     fs::create_dir_all(&state)?;
@@ -254,6 +267,9 @@ async fn serve(path: &Path) -> Result<()> {
     )?);
     let router = Arc::new(Router::new(&config, affinity));
     let stats = Arc::new(Stats::default());
+    let control_server =
+        control::ControlServer::bind(&state, config_path, config.clone(), router.clone())?;
+    let mut control_task = tokio::spawn(control_server.run());
     let app = App::new(config.clone(), router.clone(), stats.clone())?;
     let mut tasks = tokio::task::JoinSet::new();
     for (name, listener) in config.listeners.clone() {
@@ -310,11 +326,22 @@ async fn serve(path: &Path) -> Result<()> {
                 Some(Err(error)) => error.into(),
                 None => anyhow::anyhow!("all listeners exited unexpectedly"),
             })
+        },
+        control = &mut control_task => {
+            Some(match control {
+                Ok(Ok(())) => anyhow::anyhow!("control server exited unexpectedly"),
+                Ok(Err(error)) => error.context("control server failed"),
+                Err(error) => error.into(),
+            })
         }
     };
     info!("shutting down");
     background.abort();
     let _ = background.await;
+    if !control_task.is_finished() {
+        control_task.abort();
+        let _ = control_task.await;
+    }
     refresh_background.abort();
     let _ = refresh_background.await;
     tasks.abort_all();
@@ -391,9 +418,13 @@ fn install_config(config_path: &Path, codex_config: &Path, listener_name: &str) 
 fn status(config_path: &Path, json: bool) -> Result<()> {
     let config = load_config(config_path)?;
     let state = state_dir(&config);
-    let snapshot = fs::read(state.join("stats.json"))
+    let mut snapshot = fs::read(state.join("stats.json"))
         .ok()
         .and_then(|bytes| serde_json::from_slice::<comradex::state::StatsSnapshot>(&bytes).ok());
+    let live_routing = control::routing_status(&state, &config.proxy.installation_secret).ok();
+    if let (Some(snapshot), Some(routing)) = (&mut snapshot, &live_routing) {
+        snapshot.routing = routing.clone();
+    }
     if json {
         let snapshot = snapshot.context("daemon has not written stats yet")?;
         println!("{}", serde_json::to_string_pretty(&snapshot)?);
@@ -439,6 +470,22 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
             format!("pool {}", pools.join(", "))
         };
         println!("  {name:width$}  {:24}  {pools}", account_state(account));
+    }
+
+    let routing = live_routing
+        .as_ref()
+        .or_else(|| snapshot.as_ref().map(|snapshot| &snapshot.routing));
+    println!("\npools");
+    let width = config.pools.keys().map(String::len).max().unwrap_or(0);
+    for (name, pool) in &config.pools {
+        let preferred = routing
+            .and_then(|routing| routing.preferred_accounts.get(name))
+            .or(pool.preferred.as_ref())
+            .map_or("automatic", String::as_str);
+        let active = routing
+            .and_then(|routing| routing.active_accounts.get(name))
+            .map_or("no fresh work yet", String::as_str);
+        println!("  {name:width$}  preferred {preferred}, active {active}");
     }
 
     println!("\ntraffic");
@@ -523,6 +570,59 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
             Ok(())
         }
         AccountCommand::Login { name } => login(config_path, &name),
+        AccountCommand::Prefer { name, pool, clear } => {
+            debug_assert!(name.is_some() || clear);
+            let config = load_config(config_path)?;
+            let pool_config = config
+                .pools
+                .get(&pool)
+                .with_context(|| format!("unknown pool {pool}"))?;
+            if let Some(name) = &name
+                && !pool_config.members.contains(name)
+            {
+                bail!("account {name} is not a member of pool {pool}")
+            }
+            match control::set_preferred(
+                &state_dir(&config),
+                &config.proxy.installation_secret,
+                &pool,
+                name.as_deref(),
+            ) {
+                Ok(routing) => {
+                    match name {
+                        Some(name) => println!(
+                            "pool {pool} now prefers {name} for new work; active turns were not interrupted"
+                        ),
+                        None => println!(
+                            "pool {pool} now selects accounts automatically; active turns were not interrupted"
+                        ),
+                    }
+                    if let Some(active) = routing.active_accounts.get(&pool) {
+                        println!("active account for fresh work: {active}");
+                    }
+                    Ok(())
+                }
+                Err(_control_error) if !control::socket_path(&state_dir(&config)).exists() => {
+                    let text = fs::read_to_string(config_path)
+                        .with_context(|| format!("read {}", config_path.display()))?;
+                    let updated =
+                        comradex::accounts::set_preferred_account(&text, &pool, name.as_deref())?;
+                    write_config_validated(config_path, &updated)?;
+                    match name {
+                        Some(name) => println!(
+                            "saved {name} as the preferred account for pool {pool}; it will apply when the daemon starts"
+                        ),
+                        None => println!(
+                            "saved automatic selection for pool {pool}; it will apply when the daemon starts"
+                        ),
+                    }
+                    Ok(())
+                }
+                Err(control_error) => Err(control_error).context(
+                    "live routing request did not complete; check `comradex status` before retrying",
+                ),
+            }
+        }
         AccountCommand::List => {
             let config = load_config(config_path)?;
             let width = config.accounts.keys().map(String::len).max().unwrap_or(0);
@@ -580,18 +680,7 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
 /// candidate is written next to the config so relative paths resolve
 /// identically, validated with Config::load, then swapped into place.
 fn write_config_validated(config_path: &Path, text: &str) -> Result<()> {
-    let parent = config_path.parent().unwrap_or(Path::new("."));
-    let mut temp = tempfile::Builder::new()
-        .suffix(".toml")
-        .tempfile_in(parent)?;
-    std::io::Write::write_all(&mut temp, text.as_bytes())?;
-    temp.as_file().sync_all()?;
-    Config::load(temp.path()).context("validate updated configuration")?;
-    if let Ok(metadata) = fs::metadata(config_path) {
-        temp.as_file().set_permissions(metadata.permissions())?;
-    }
-    temp.persist(config_path).map_err(|error| error.error)?;
-    Ok(())
+    comradex::config::write_validated(config_path, text)
 }
 
 /// Bounce the daemon after a config change when it is installed as a service;
@@ -761,5 +850,36 @@ mod tests {
         .unwrap();
         assert_eq!(path, PathBuf::from("/Users/example/.codex/config.toml"));
         assert!(default_codex_config_path(None, None).is_err());
+    }
+
+    #[test]
+    fn account_prefer_cli_accepts_an_account_or_clear_but_not_both() {
+        let cli =
+            Cli::try_parse_from(["comradex", "account", "prefer", "work", "--pool", "p"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Account {
+                command: AccountCommand::Prefer {
+                    name: Some(name),
+                    pool,
+                    clear: false,
+                },
+            } if name == "work" && pool == "p"
+        ));
+
+        let cli = Cli::try_parse_from(["comradex", "account", "prefer", "--clear"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Account {
+                command: AccountCommand::Prefer {
+                    name: None,
+                    pool,
+                    clear: true,
+                },
+            } if pool == "default"
+        ));
+
+        assert!(Cli::try_parse_from(["comradex", "account", "prefer", "work", "--clear"]).is_err());
+        assert!(Cli::try_parse_from(["comradex", "account", "prefer"]).is_err());
     }
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -4427,6 +4427,7 @@ mod tests {
                     "default".into(),
                     PoolConfig {
                         members: vec!["managed".into()],
+                        preferred: None,
                     },
                 )]),
                 accounts: BTreeMap::from([(
@@ -4492,6 +4493,7 @@ mod tests {
                 "default".into(),
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -4538,6 +4540,7 @@ mod tests {
                 "default".into(),
                 PoolConfig {
                     members: vec!["caller".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),
@@ -5295,6 +5298,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 "default".into(),
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -5460,6 +5464,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                     "default",
                     &PoolConfig {
                         members: vec!["caller".into()],
+                        preferred: None,
                     },
                     None,
                     None,
@@ -5555,6 +5560,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 "default".into(),
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -5650,6 +5656,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 "default".into(),
                 PoolConfig {
                     members: vec!["caller".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),
@@ -5713,6 +5720,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 "default".into(),
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -5768,6 +5776,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 "default".into(),
                 PoolConfig {
                     members: vec!["managed".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([(

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -4,4 +4,4 @@ pub mod metadata;
 pub mod router;
 
 pub use affinity::{AffinityStore, ThreadKey};
-pub use router::{Router, Selection};
+pub use router::{Router, RoutingSnapshot, Selection};

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -8,6 +8,7 @@ use std::{
 };
 
 use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::error;
 
@@ -21,6 +22,14 @@ pub struct Selection {
     pub account_id: String,
     pub bound: bool,
     pub thread: Option<ThreadKey>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingSnapshot {
+    #[serde(default)]
+    pub preferred_accounts: BTreeMap<String, String>,
+    #[serde(default)]
+    pub active_accounts: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Default)]
@@ -53,6 +62,7 @@ type QuotaEvidence = HashMap<QuotaWindow, WindowEvidence>;
 pub struct Router {
     pub affinity: Arc<AffinityStore>,
     accounts: Mutex<HashMap<String, AccountRuntime>>,
+    preferred: Mutex<HashMap<String, String>>,
     active: Mutex<HashMap<String, String>>,
     sequence: AtomicU64,
     switch_at: u8,
@@ -67,6 +77,18 @@ impl Router {
                     .accounts
                     .keys()
                     .map(|k| (k.clone(), AccountRuntime::default()))
+                    .collect(),
+            ),
+            preferred: Mutex::new(
+                config
+                    .pools
+                    .iter()
+                    .filter_map(|(pool, config)| {
+                        config
+                            .preferred
+                            .as_ref()
+                            .map(|account| (pool.clone(), account.clone()))
+                    })
                     .collect(),
             ),
             active: Mutex::new(HashMap::new()),
@@ -144,6 +166,7 @@ impl Router {
                 });
             }
         }
+        let configured_preferred = self.preferred.lock().await.get(pool_name).cloned();
         let active_id = self.active.lock().await.get(pool_name).cloned();
         let eligible = |id: &str| {
             exclude != Some(id)
@@ -159,13 +182,17 @@ impl Router {
                 .and_then(|account| account.usage)
                 .is_none_or(|usage| usage < self.switch_at)
         };
-        let selected = preferred
-            .filter(|id| {
-                pool.members.iter().any(|member| member == *id)
-                    && eligible(id)
-                    && below_switch_at(id)
+        let selected = configured_preferred
+            .filter(|id| pool.members.contains(id) && eligible(id) && below_switch_at(id))
+            .or_else(|| {
+                preferred
+                    .filter(|id| {
+                        pool.members.iter().any(|member| member == *id)
+                            && eligible(id)
+                            && below_switch_at(id)
+                    })
+                    .map(str::to_owned)
             })
-            .map(str::to_owned)
             .or_else(|| {
                 active_id
                     .filter(|id| pool.members.contains(id) && eligible(id) && below_switch_at(id))
@@ -204,6 +231,39 @@ impl Router {
             bound: false,
             thread,
         })
+    }
+
+    /// Change the preferred account used for new work without disturbing bindings or in-flight
+    /// requests. The caller validates pool membership before invoking this method.
+    pub async fn set_preferred(&self, pool: &str, account: Option<String>) {
+        let mut preferred = self.preferred.lock().await;
+        match account {
+            Some(account) => {
+                preferred.insert(pool.to_owned(), account);
+            }
+            None => {
+                preferred.remove(pool);
+            }
+        }
+    }
+
+    pub async fn routing_snapshot(&self) -> RoutingSnapshot {
+        RoutingSnapshot {
+            preferred_accounts: self
+                .preferred
+                .lock()
+                .await
+                .iter()
+                .map(|(pool, account)| (pool.clone(), account.clone()))
+                .collect(),
+            active_accounts: self
+                .active
+                .lock()
+                .await
+                .iter()
+                .map(|(pool, account)| (pool.clone(), account.clone()))
+                .collect(),
+        }
     }
 
     pub async fn begin(&self, account: &str) {
@@ -520,6 +580,7 @@ mod tests {
                 "default".into(),
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
+                    preferred: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -568,6 +629,74 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(fresh.account_id, "b");
+    }
+
+    #[tokio::test]
+    async fn live_preference_changes_fresh_work_without_rebinding_existing_threads() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = config(dir.path());
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity.clone());
+        let pool = &cfg.pools["default"];
+        let existing_key = affinity.key("existing");
+        let existing = router
+            .select("default", pool, Some(existing_key.clone()), None)
+            .await
+            .unwrap();
+        assert_eq!(existing.account_id, "a");
+
+        router.set_preferred("default", Some("b".to_owned())).await;
+
+        let bound = router
+            .select("default", pool, Some(existing_key), None)
+            .await
+            .unwrap();
+        assert_eq!(bound.account_id, "a");
+        assert!(bound.bound);
+        let fresh = router
+            .select("default", pool, Some(affinity.key("fresh")), None)
+            .await
+            .unwrap();
+        assert_eq!(fresh.account_id, "b");
+        assert!(!fresh.bound);
+        assert_eq!(
+            router.routing_snapshot().await,
+            RoutingSnapshot {
+                preferred_accounts: BTreeMap::from([("default".into(), "b".into())]),
+                active_accounts: BTreeMap::from([("default".into(), "b".into())]),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn configured_preference_wins_over_reused_transport_preference() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = config(dir.path());
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity);
+        let pool = &cfg.pools["default"];
+        router.set_preferred("default", Some("b".to_owned())).await;
+
+        let selected = router.select_preferred("default", pool, "a").await.unwrap();
+        assert_eq!(selected.account_id, "b");
     }
 
     #[tokio::test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::routing::Router;
+use crate::routing::{Router, RoutingSnapshot};
 
 #[derive(Default)]
 pub struct Stats {
@@ -36,6 +36,8 @@ pub struct StatsSnapshot {
     pub active_spool_bytes: usize,
     pub quota_records: usize,
     pub health_records: usize,
+    #[serde(default)]
+    pub routing: RoutingSnapshot,
     pub refresh_inflight: usize,
     #[serde(default)]
     pub refresh_scheduler_ticks: u64,
@@ -57,6 +59,7 @@ impl Stats {
     pub async fn write(&self, path: PathBuf, router: &Arc<Router>) -> Result<()> {
         let (affinity_entries, affinity_bytes) = router.affinity.len_and_bytes().await;
         let records = router.record_count().await;
+        let routing = router.routing_snapshot().await;
         let snapshot = StatsSnapshot {
             inflight_http: self.inflight_http.load(Ordering::Relaxed),
             open_upgrades: self.open_upgrades.load(Ordering::Relaxed),
@@ -65,6 +68,7 @@ impl Stats {
             active_spool_bytes: self.active_spool_bytes.load(Ordering::Relaxed),
             quota_records: records,
             health_records: records,
+            routing,
             refresh_inflight: self.refresh_inflight.load(Ordering::Relaxed),
             refresh_scheduler_ticks: self.refresh_scheduler_ticks.load(Ordering::Relaxed),
             refresh_accounts_checked: self.refresh_accounts_checked.load(Ordering::Relaxed),


### PR DESCRIPTION
Adds a persistent per-pool account preference and an account prefer CLI command.\n\nThe running daemon applies changes through an authenticated user-only Unix socket, so active turns and sticky conversations remain untouched. Quota-aware fallback still skips unavailable or over-threshold preferred accounts, and status reports both preferred and actually active accounts.