### PR TITLE
Align outbound TLS transports with Codex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,25 +102,25 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.43.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "pkg-config",
 ]
 
 [[package]]
@@ -259,6 +259,7 @@ name = "comradex"
 version = "0.9.6"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "base64",
  "blake3",
  "bytes",
@@ -268,11 +269,18 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "libc",
+ "md-5",
+ "native-tls",
  "rand",
+ "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -288,6 +296,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -350,10 +368,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -388,6 +426,30 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -591,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
@@ -601,10 +663,27 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -613,18 +692,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -652,6 +736,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +848,12 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -713,6 +907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,10 +937,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -751,6 +967,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -784,10 +1017,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -813,6 +1089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +1105,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -919,6 +1210,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,7 +1259,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -947,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -962,14 +1293,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -990,7 +1321,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -998,6 +1329,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -1016,12 +1353,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1090,10 +1440,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1148,6 +1521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,13 +1561,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1224,6 +1644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1679,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1338,6 +1778,45 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -1443,15 +1922,39 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1464,6 +1967,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1509,6 +2018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +2057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1589,6 +2118,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -1712,6 +2252,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,10 +2301,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-linux-x8
 
 [dependencies]
 anyhow = "1"
+aws-lc-rs = "=1.16.2"
 base64 = "0.22"
 blake3 = "1"
 bytes = "1"
@@ -36,10 +37,14 @@ clap = { version = "4", features = ["derive"] }
 futures-util = "0.3"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
-hyper-rustls = { version = "0.27", features = ["http1", "http2", "webpki-roots"] }
+hyper-rustls = { version = "=0.27.7", features = ["http1", "http2", "webpki-roots"] }
+hyper-tls = "=0.6.0"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "server", "tokio"] }
 libc = "0.2"
+native-tls = "=0.2.14"
 rand = "0.9"
+rustls = { version = "=0.23.36", default-features = false, features = ["aws_lc_rs", "std"] }
+rustls-native-certs = "=0.8.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
@@ -50,6 +55,11 @@ toml = "0.9"
 toml_edit = "0.23"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+md-5 = "0.10"
+reqwest = "=0.12.28"
+sha2 = "0.10"
 
 [profile.release]
 lto = "thin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod proxy;
 pub mod routing;
 pub mod service;
 pub mod state;
+mod transport;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -30,7 +30,8 @@ use hyper::{
     },
     service::service_fn,
 };
-use hyper_rustls::HttpsConnector;
+use hyper_rustls::HttpsConnector as RustlsHttpsConnector;
+use hyper_tls::HttpsConnector as NativeHttpsConnector;
 use hyper_util::{
     client::legacy::{Client, connect::HttpConnector},
     rt::{TokioExecutor, TokioIo},
@@ -56,6 +57,7 @@ use crate::{
         metadata,
     },
     state::Stats,
+    transport::{codex_http_connector, codex_websocket_connector},
 };
 use replay_body::{ProxyBody, ReplayBody, bytes_body, empty_body, incoming_body, json_body};
 use sse::{ProtocolEvent, SseDecoder, responses_json_events};
@@ -85,7 +87,8 @@ fn is_direct_hard_continuity(kind: metadata::AffinityKind) -> bool {
     )
 }
 
-type HttpClient = Client<HttpsConnector<HttpConnector>, ProxyBody>;
+type HttpClient = Client<NativeHttpsConnector<HttpConnector>, ProxyBody>;
+type UpgradeHttpClient = Client<RustlsHttpsConnector<HttpConnector>, ProxyBody>;
 type UpgradedWebSocket = WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>;
 
 struct WebSocketFrameRoute {
@@ -453,7 +456,7 @@ pub struct App {
     config: Arc<Config>,
     router: Arc<Router>,
     client: HttpClient,
-    upgrade_client: HttpClient,
+    upgrade_client: UpgradeHttpClient,
     stats: Arc<Stats>,
     http_slots: Arc<Semaphore>,
     upgrade_slots: Arc<Semaphore>,
@@ -486,17 +489,8 @@ impl App {
     }
 
     fn build(config: Arc<Config>, router: Arc<Router>, stats: Arc<Stats>) -> Result<Arc<Self>> {
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .enable_http2()
-            .build();
-        let upgrade_https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
+        let https = codex_http_connector()?;
+        let upgrade_https = codex_websocket_connector()?;
         let client = Client::builder(TokioExecutor::new()).build(https);
         let upgrade_client = Client::builder(TokioExecutor::new()).build(upgrade_https);
         let state_dir = config.proxy.state_dir.clone().unwrap_or_else(|| ".".into());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use hyper_rustls::HttpsConnector as RustlsHttpsConnector;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
-use rustls::{ClientConfig, RootCertStore};
+use rustls::{ClientConfig, RootCertStore, pki_types::CertificateDer};
 
 /// Builds the same transport-default TLS shape used by Codex's reqwest 0.12 client.
 ///
@@ -39,10 +39,22 @@ fn codex_websocket_tls_config() -> Result<ClientConfig> {
     let builder = ClientConfig::builder_with_provider(Arc::new(provider))
         .with_safe_default_protocol_versions()
         .context("select Codex Rustls protocol versions")?;
-    let mut roots = RootCertStore::empty();
     let native = rustls_native_certs::load_native_certs();
-    roots.add_parsable_certificates(native.certs);
+    let roots = root_store_from_native_certs(native.certs, native.errors.len())?;
     Ok(builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+fn root_store_from_native_certs(
+    certs: Vec<CertificateDer<'static>>,
+    load_error_count: usize,
+) -> Result<RootCertStore> {
+    let mut roots = RootCertStore::empty();
+    let (valid_count, invalid_count) = roots.add_parsable_certificates(certs);
+    ensure!(
+        valid_count > 0,
+        "load platform TLS roots: no usable certificates ({load_error_count} load errors, {invalid_count} parse errors)"
+    );
+    Ok(roots)
 }
 
 #[cfg(test)]
@@ -56,7 +68,50 @@ mod tests {
     use sha2::Sha256;
     use tokio::{io::AsyncReadExt, net::TcpListener};
 
-    use super::{codex_http_connector, codex_websocket_connector};
+    use rustls::pki_types::CertificateDer;
+
+    use super::{codex_http_connector, codex_websocket_connector, root_store_from_native_certs};
+
+    #[test]
+    fn websocket_root_store_rejects_no_native_certificates() {
+        let error = root_store_from_native_certs(Vec::new(), 2).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "load platform TLS roots: no usable certificates (2 load errors, 0 parse errors)"
+        );
+    }
+
+    #[test]
+    fn websocket_root_store_rejects_only_unparsable_certificates() {
+        let error = root_store_from_native_certs(
+            vec![CertificateDer::from(vec![0xde, 0xad, 0xbe, 0xef])],
+            0,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "load platform TLS roots: no usable certificates (0 load errors, 1 parse errors)"
+        );
+    }
+
+    #[test]
+    fn websocket_root_store_tolerates_bad_certificates_when_a_root_is_usable() {
+        let native = rustls_native_certs::load_native_certs();
+        let valid = native
+            .certs
+            .into_iter()
+            .find(|cert| {
+                let mut roots = rustls::RootCertStore::empty();
+                roots.add(cert.clone()).is_ok()
+            })
+            .expect("test platform should provide at least one usable TLS root");
+        let roots = root_store_from_native_certs(
+            vec![CertificateDer::from(vec![0xde, 0xad, 0xbe, 0xef]), valid],
+            1,
+        )
+        .unwrap();
+        assert_eq!(roots.len(), 1);
+    }
 
     #[derive(Debug, PartialEq, Eq)]
     struct ClientHelloProfile {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,374 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use hyper_rustls::HttpsConnector as RustlsHttpsConnector;
+use hyper_tls::HttpsConnector;
+use hyper_util::client::legacy::connect::HttpConnector;
+use rustls::{ClientConfig, RootCertStore};
+
+/// Builds the same transport-default TLS shape used by Codex's reqwest 0.12 client.
+///
+/// In Codex 0.149.0 the normal Responses HTTP path uses `native-tls` without
+/// reqwest's optional `native-tls-alpn` feature. Constructing the connector
+/// explicitly keeps that no-ALPN ClientHello while allowing Hyper to continue
+/// streaming request and response bodies without materializing them.
+pub(crate) fn codex_http_connector() -> Result<HttpsConnector<HttpConnector>> {
+    let mut http = HttpConnector::new();
+    http.enforce_http(false);
+    let tls = native_tls::TlsConnector::builder()
+        .build()
+        .context("build transport-default native TLS connector")?;
+    Ok(HttpsConnector::from((http, tls.into())))
+}
+
+/// Builds the explicit Rustls transport used by Codex Responses WebSockets.
+///
+/// Codex uses AWS-LC, platform roots, and no ALPN for this HTTP/1.1 upgrade
+/// path. `enable_http1` deliberately preserves the empty ALPN list.
+pub(crate) fn codex_websocket_connector() -> Result<RustlsHttpsConnector<HttpConnector>> {
+    let config = codex_websocket_tls_config()?;
+    Ok(hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(config)
+        .https_or_http()
+        .enable_http1()
+        .build())
+}
+
+fn codex_websocket_tls_config() -> Result<ClientConfig> {
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    let builder = ClientConfig::builder_with_provider(Arc::new(provider))
+        .with_safe_default_protocol_versions()
+        .context("select Codex Rustls protocol versions")?;
+    let mut roots = RootCertStore::empty();
+    let native = rustls_native_certs::load_native_certs();
+    roots.add_parsable_certificates(native.certs);
+    Ok(builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use http_body_util::Empty;
+    use hyper::{Request, body::Bytes};
+    use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+    use md5::{Digest as _, Md5};
+    use sha2::Sha256;
+    use tokio::{io::AsyncReadExt, net::TcpListener};
+
+    use super::{codex_http_connector, codex_websocket_connector};
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct ClientHelloProfile {
+        legacy_version: u16,
+        ciphers: Vec<u16>,
+        extensions: Vec<u16>,
+        supported_groups: Vec<u16>,
+        point_formats: Vec<u8>,
+        signature_algorithms: Vec<u16>,
+        supported_versions: Vec<u16>,
+        has_sni: bool,
+        first_alpn: Option<Vec<u8>>,
+    }
+
+    impl ClientHelloProfile {
+        fn ja3_raw(&self) -> String {
+            format!(
+                "{},{},{},{},{}",
+                self.legacy_version,
+                join_u16(&self.ciphers),
+                join_u16(&self.extensions),
+                join_u16(&self.supported_groups),
+                self.point_formats
+                    .iter()
+                    .map(u8::to_string)
+                    .collect::<Vec<_>>()
+                    .join("-")
+            )
+        }
+
+        fn ja3(&self) -> String {
+            format!("{:x}", Md5::digest(self.ja3_raw().as_bytes()))
+        }
+
+        fn ja4_raw(&self) -> String {
+            let version = self
+                .supported_versions
+                .iter()
+                .copied()
+                .max()
+                .unwrap_or(self.legacy_version);
+            let version = match version {
+                0x0304 => "13",
+                0x0303 => "12",
+                0x0302 => "11",
+                0x0301 => "10",
+                _ => "00",
+            };
+            let alpn = self.first_alpn.as_deref().map_or_else(
+                || "00".to_owned(),
+                |value| match (value.first(), value.last()) {
+                    (Some(first), Some(last)) => {
+                        format!("{}{}", char::from(*first), char::from(*last))
+                    }
+                    _ => "00".to_owned(),
+                },
+            );
+            let prefix = format!(
+                "t{version}{}{:02}{:02}{alpn}",
+                if self.has_sni { 'd' } else { 'i' },
+                self.ciphers.len().min(99),
+                self.extensions.len().min(99),
+            );
+
+            let mut ciphers = self.ciphers.clone();
+            ciphers.sort_unstable();
+            let cipher_hash = short_sha256(&join_hex_u16(&ciphers));
+
+            let mut extensions = self
+                .extensions
+                .iter()
+                .copied()
+                .filter(|extension| *extension != 0x0000 && *extension != 0x0010)
+                .collect::<Vec<_>>();
+            extensions.sort_unstable();
+            let extension_input = format!(
+                "{}_{}",
+                join_hex_u16(&extensions),
+                join_hex_u16(&self.signature_algorithms)
+            );
+            format!("{prefix}_{cipher_hash}_{}", short_sha256(&extension_input))
+        }
+    }
+
+    #[tokio::test]
+    async fn native_http_clienthello_matches_codex_reqwest() {
+        let (listener, port) = capture_listener().await;
+        let capture = tokio::spawn(capture_client_hello(listener));
+        let client = Client::builder(TokioExecutor::new()).build(codex_http_connector().unwrap());
+        let request = Request::get(format!("https://localhost:{port}/"))
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let _ = client.request(request).await;
+        let ours = parse_client_hello(&capture.await.unwrap()).unwrap();
+
+        let (listener, port) = capture_listener().await;
+        let capture = tokio::spawn(capture_client_hello(listener));
+        let codex = reqwest::Client::builder().no_proxy().build().unwrap();
+        let _ = codex.get(format!("https://localhost:{port}/")).send().await;
+        let reference = parse_client_hello(&capture.await.unwrap()).unwrap();
+
+        assert_eq!(ours, reference);
+        eprintln!("Codex-compatible JA3: {}", ours.ja3());
+        eprintln!("Codex-compatible JA4: {}", ours.ja4_raw());
+    }
+
+    #[tokio::test]
+    async fn websocket_clienthello_keeps_codex_rustls_profile() {
+        let (listener, port) = capture_listener().await;
+        let capture = tokio::spawn(capture_client_hello(listener));
+        let client =
+            Client::builder(TokioExecutor::new()).build(codex_websocket_connector().unwrap());
+        let request = Request::get(format!("https://localhost:{port}/"))
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let _ = client.request(request).await;
+        let profile = parse_client_hello(&capture.await.unwrap()).unwrap();
+
+        assert_eq!(profile.first_alpn, None);
+        // Rustls deliberately permutes extension order, so JA3 changes between
+        // connections. JA4 sorts the relevant inputs and remains stable.
+        assert_eq!(profile.ja4_raw(), "t13d101000_61a7ad8aa9b6_f9531d972513");
+        eprintln!("Codex WebSocket-compatible JA3: {}", profile.ja3());
+        eprintln!("Codex WebSocket-compatible JA4: {}", profile.ja4_raw());
+    }
+
+    async fn capture_listener() -> (TcpListener, u16) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        (listener, port)
+    }
+
+    async fn capture_client_hello(listener: TcpListener) -> Vec<u8> {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut header = [0u8; 5];
+        stream.read_exact(&mut header).await.unwrap();
+        assert_eq!(header[0], 22, "expected a TLS handshake record");
+        let length = usize::from(u16::from_be_bytes([header[3], header[4]]));
+        let mut record = vec![0u8; length];
+        stream.read_exact(&mut record).await.unwrap();
+        record
+    }
+
+    fn parse_client_hello(record: &[u8]) -> Result<ClientHelloProfile, String> {
+        let mut cursor = Cursor::new(record);
+        if cursor.u8()? != 1 {
+            return Err("TLS handshake was not ClientHello".into());
+        }
+        let handshake_length = cursor.u24()?;
+        let handshake = cursor.take(handshake_length)?;
+        let mut hello = Cursor::new(handshake);
+        let legacy_version = hello.u16()?;
+        hello.take(32)?;
+        let session_id_length = usize::from(hello.u8()?);
+        hello.take(session_id_length)?;
+        let cipher_length = usize::from(hello.u16()?);
+        let ciphers = parse_u16_list(hello.take(cipher_length)?)
+            .into_iter()
+            .filter(|value| !is_grease(*value))
+            .collect();
+        let compression_length = usize::from(hello.u8()?);
+        hello.take(compression_length)?;
+        let extension_length = usize::from(hello.u16()?);
+        let mut extension_cursor = Cursor::new(hello.take(extension_length)?);
+        let mut extensions = Vec::new();
+        let mut supported_groups = Vec::new();
+        let mut point_formats = Vec::new();
+        let mut signature_algorithms = Vec::new();
+        let mut supported_versions = Vec::new();
+        let mut has_sni = false;
+        let mut first_alpn = None;
+        let mut seen = BTreeSet::new();
+
+        while !extension_cursor.is_empty() {
+            let extension_type = extension_cursor.u16()?;
+            let data_length = usize::from(extension_cursor.u16()?);
+            let data = extension_cursor.take(data_length)?;
+            if !is_grease(extension_type) {
+                extensions.push(extension_type);
+            }
+            if !seen.insert(extension_type) {
+                return Err(format!("duplicate TLS extension {extension_type:#06x}"));
+            }
+            match extension_type {
+                0x0000 => has_sni = true,
+                0x000a => supported_groups = parse_prefixed_u16_list(data)?,
+                0x000b => point_formats = parse_prefixed_u8_list(data)?,
+                0x000d => signature_algorithms = parse_prefixed_u16_list(data)?,
+                0x0010 => first_alpn = parse_first_alpn(data)?,
+                0x002b => supported_versions = parse_prefixed_u8_u16_list(data)?,
+                _ => {}
+            }
+        }
+
+        supported_groups.retain(|value| !is_grease(*value));
+        supported_versions.retain(|value| !is_grease(*value));
+        Ok(ClientHelloProfile {
+            legacy_version,
+            ciphers,
+            extensions,
+            supported_groups,
+            point_formats,
+            signature_algorithms,
+            supported_versions,
+            has_sni,
+            first_alpn,
+        })
+    }
+
+    fn parse_u16_list(data: &[u8]) -> Vec<u16> {
+        data.chunks_exact(2)
+            .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
+            .collect()
+    }
+
+    fn parse_prefixed_u16_list(data: &[u8]) -> Result<Vec<u16>, String> {
+        let mut cursor = Cursor::new(data);
+        let length = usize::from(cursor.u16()?);
+        Ok(parse_u16_list(cursor.take(length)?))
+    }
+
+    fn parse_prefixed_u8_u16_list(data: &[u8]) -> Result<Vec<u16>, String> {
+        let mut cursor = Cursor::new(data);
+        let length = usize::from(cursor.u8()?);
+        Ok(parse_u16_list(cursor.take(length)?))
+    }
+
+    fn parse_prefixed_u8_list(data: &[u8]) -> Result<Vec<u8>, String> {
+        let mut cursor = Cursor::new(data);
+        let length = usize::from(cursor.u8()?);
+        Ok(cursor.take(length)?.to_vec())
+    }
+
+    fn parse_first_alpn(data: &[u8]) -> Result<Option<Vec<u8>>, String> {
+        let mut cursor = Cursor::new(data);
+        let list_length = usize::from(cursor.u16()?);
+        let mut list = Cursor::new(cursor.take(list_length)?);
+        if list.is_empty() {
+            return Ok(None);
+        }
+        let length = usize::from(list.u8()?);
+        Ok(Some(list.take(length)?.to_vec()))
+    }
+
+    fn is_grease(value: u16) -> bool {
+        let [high, low] = value.to_be_bytes();
+        high == low && high & 0x0f == 0x0a
+    }
+
+    fn join_u16(values: &[u16]) -> String {
+        values
+            .iter()
+            .map(u16::to_string)
+            .collect::<Vec<_>>()
+            .join("-")
+    }
+
+    fn join_hex_u16(values: &[u16]) -> String {
+        values
+            .iter()
+            .map(|value| format!("{value:04x}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    fn short_sha256(value: &str) -> String {
+        format!("{:x}", Sha256::digest(value.as_bytes()))[..12].to_owned()
+    }
+
+    struct Cursor<'a> {
+        data: &'a [u8],
+        offset: usize,
+    }
+
+    impl<'a> Cursor<'a> {
+        fn new(data: &'a [u8]) -> Self {
+            Self { data, offset: 0 }
+        }
+
+        fn is_empty(&self) -> bool {
+            self.offset == self.data.len()
+        }
+
+        fn take(&mut self, length: usize) -> Result<&'a [u8], String> {
+            let end = self
+                .offset
+                .checked_add(length)
+                .ok_or_else(|| "TLS length overflow".to_owned())?;
+            let value = self
+                .data
+                .get(self.offset..end)
+                .ok_or_else(|| "truncated TLS ClientHello".to_owned())?;
+            self.offset = end;
+            Ok(value)
+        }
+
+        fn u8(&mut self) -> Result<u8, String> {
+            Ok(self.take(1)?[0])
+        }
+
+        fn u16(&mut self) -> Result<u16, String> {
+            let bytes = self.take(2)?;
+            Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+        }
+
+        fn u24(&mut self) -> Result<usize, String> {
+            let bytes = self.take(3)?;
+            Ok(
+                (usize::from(bytes[0]) << 16)
+                    | (usize::from(bytes[1]) << 8)
+                    | usize::from(bytes[2]),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Uses the current Codex transport defaults for upstream HTTP and WebSocket connections.

- uses native TLS for normal HTTP traffic
- pins the Rustls/AWS-LC WebSocket configuration and platform roots
- adds packet-level ClientHello regression coverage

Validated on macOS and Debian Docker, including the production image build.