### PR TITLE
Simplify the macOS menu UI

### DIFF
--- a/macos/ComradexMenu/README.md
+++ b/macos/ComradexMenu/README.md
@@ -1,6 +1,6 @@
 # Comradex Menu
 
-A native macOS 14+ menu-bar companion for viewing Comradex daemon, routing, account, and pool status; choosing a pool's preferred account (or automatic selection); and completing account login or re-login.
+A native macOS 14+ menu-bar companion for viewing Comradex daemon, routing, account, and pool status; choosing a pool's preferred account; and completing account login when authentication is required.
 
 The app talks directly to the daemon's newline-delimited JSON protocol at `~/.config/comradex/state/control.sock`. It does not invoke the Comradex CLI, read configuration files, expose subprocess output, or handle credentials. Device login polling uses the daemon-issued random session ID and displays only the verification URI, user code, coarse state, and safe error text. Set `COMRADEX_CONTROL_SOCKET` before launching to use another socket path.
 

--- a/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
@@ -58,6 +58,14 @@ struct AccountSnapshot: Codable, Equatable, Identifiable, Sendable {
     var isSignedIn: Bool {
         signedIn ?? ["signed_in", "authenticated", "ready"].contains(authState?.lowercased())
     }
+    var isInbound: Bool {
+        kind.caseInsensitiveCompare("inbound") == .orderedSame
+            || authState?.caseInsensitiveCompare("inbound") == .orderedSame
+    }
+    var needsLoginAction: Bool {
+        guard !isInbound else { return false }
+        return authState?.caseInsensitiveCompare("signed_out") == .orderedSame
+    }
 
     enum CodingKeys: String, CodingKey {
         case name, kind, pools

--- a/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
@@ -7,16 +7,17 @@ struct MenuContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             Divider()
 
             if let snapshot = store.snapshot {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 0) {
                     if store.errorMessage != nil { staleDataWarning }
                     statusContent(snapshot)
                 }
-                .padding(12)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
             } else if let error = store.errorMessage {
                 errorState(error)
                     .padding(16)
@@ -26,50 +27,26 @@ struct MenuContentView: View {
                     .padding(16)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+
+            Divider()
+            commands
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
         }
         .frame(width: 340)
         .task { await store.refreshLoop() }
     }
 
     private var header: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Comradex")
-                    .font(.headline)
-                Label(connectionLabel, systemImage: "circle.fill")
-                    .font(.caption)
-                    .foregroundStyle(connectionColor)
-                    .labelStyle(CompactStatusLabelStyle())
-            }
-            Spacer()
-
-            if store.isRefreshing {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Button {
-                    Task { await store.refresh() }
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .buttonStyle(.borderless)
-                .help("Refresh")
-                .keyboardShortcut("r")
-            }
-
-            Menu {
-                Button("Refresh") { Task { await store.refresh() } }
-                    .keyboardShortcut("r")
-                Divider()
-                Button("Quit Comradex") { NSApplication.shared.terminate(nil) }
-                    .keyboardShortcut("q")
-            } label: {
-                Image(systemName: "ellipsis.circle")
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            .help("More")
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Comradex")
+                .font(.title3.weight(.medium))
+            Label(connectionLabel, systemImage: "circle.fill")
+                .font(.caption)
+                .foregroundStyle(connectionColor)
+                .labelStyle(CompactStatusLabelStyle())
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
@@ -79,100 +56,159 @@ struct MenuContentView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
         } else {
             if !snapshot.pools.isEmpty {
-                sectionTitle("Pools")
                 VStack(spacing: 0) {
-                    ForEach(Array(snapshot.pools.enumerated()), id: \.element.id) { index, pool in
-                        poolRow(pool)
-                        if index < snapshot.pools.count - 1 { Divider() }
+                    ForEach(snapshot.pools) { pool in
+                        poolGroup(pool, snapshot: snapshot)
                     }
                 }
             }
 
-            if !snapshot.pools.isEmpty && !snapshot.accounts.isEmpty { Divider() }
-
-            if !snapshot.accounts.isEmpty {
-                sectionTitle("Accounts")
+            let renderedAccountNames = Set(snapshot.pools.flatMap(\.members))
+            let standaloneAccounts = snapshot.accounts.filter { !renderedAccountNames.contains($0.name) }
+            if !standaloneAccounts.isEmpty {
                 VStack(spacing: 0) {
-                    ForEach(Array(snapshot.accounts.enumerated()), id: \.element.id) { index, account in
-                        accountRow(account)
-                        if index < snapshot.accounts.count - 1 { Divider() }
+                    ForEach(standaloneAccounts) { account in
+                        accountRow(account, pool: nil, isPreferred: false)
                     }
                 }
+                .padding(.top, snapshot.pools.isEmpty ? 0 : 8)
             }
         }
     }
 
-    private func sectionTitle(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(.caption2.weight(.semibold))
-            .foregroundStyle(.secondary)
-    }
-
-    private func poolRow(_ pool: PoolSnapshot) -> some View {
-        HStack(spacing: 10) {
+    private func poolGroup(_ pool: PoolSnapshot, snapshot: UIStatusSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 2) {
-                Text(pool.name)
-                    .font(.callout.weight(.medium))
-                Text("Active: \(pool.active ?? "None")")
+                Text(pool.name).font(.callout.weight(.medium))
+                Text("Pool · Active: \(pool.active ?? "None")")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            Spacer()
-            preferenceMenu(pool)
-        }
-        .padding(.vertical, 7)
-    }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
 
-    private func preferenceMenu(_ pool: PoolSnapshot) -> some View {
-        Menu(pool.preferred ?? "Automatic") {
-            Button {
-                Task { await store.setPreferred(pool: pool.name, account: nil) }
-            } label: {
-                if pool.preferred == nil { Label("Automatic", systemImage: "checkmark") }
-                else { Text("Automatic") }
-            }
-            Divider()
-            ForEach(pool.members, id: \.self) { account in
-                Button {
-                    Task { await store.setPreferred(pool: pool.name, account: account) }
-                } label: {
-                    if pool.preferred == account { Label(account, systemImage: "checkmark") }
-                    else { Text(account) }
+            ForEach(pool.members, id: \.self) { member in
+                if let account = snapshot.accounts.first(where: { $0.name == member }) {
+                    accountRow(account, pool: pool, isPreferred: pool.preferred == member)
+                } else {
+                    missingAccountRow(member, pool: pool)
                 }
             }
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
-        .disabled(store.updatingPool != nil)
+        .padding(.bottom, 8)
     }
 
-    private func accountRow(_ account: AccountSnapshot) -> some View {
+    private func accountRow(_ account: AccountSnapshot, pool: PoolSnapshot?, isPreferred: Bool) -> some View {
         HStack(spacing: 9) {
             Image(systemName: accountIcon(account))
                 .foregroundStyle(accountColor(account))
                 .frame(width: 16)
             VStack(alignment: .leading, spacing: 2) {
-                Text(account.name)
-                    .font(.callout.weight(.medium))
-                Text(accountSubtitle(account))
+                Text(account.name).font(.callout.weight(.medium))
+                Text(accountSubtitle(account, poolName: pool?.name))
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
-            Spacer()
+            Spacer(minLength: 8)
 
-            if account.kind.caseInsensitiveCompare("inbound") != .orderedSame {
-                Button(account.isSignedIn ? "Re-login" : "Login") {
-                    openWindow(id: "account-login")
-                    store.beginLogin(account: account.name)
-                }
-                .buttonStyle(.borderless)
-                .disabled(store.isLoginRunning)
+            if let pool {
+                preferenceButton(account: account.name, pool: pool, isPreferred: isPreferred)
+            }
+
+            if account.needsLoginAction {
+                Button("Re-login") { beginLogin(account.name) }
+                    .buttonStyle(.borderless)
+                    .disabled(store.isLoginRunning)
+                    .accessibilityLabel("Re-login \(account.name)")
+            } else if account.authState?.lowercased() == "login_in_progress" {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Login in progress for \(account.name)")
             }
         }
+        .padding(.horizontal, 8)
         .padding(.vertical, 7)
+    }
+
+    private func missingAccountRow(_ name: String, pool: PoolSnapshot) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: "questionmark.circle")
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name).font(.callout.weight(.medium))
+                Text("Unavailable · \(pool.name)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+    }
+
+    @ViewBuilder
+    private func preferenceButton(account: String, pool: PoolSnapshot, isPreferred: Bool) -> some View {
+        if isPreferred {
+            Text("Preferred")
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.tint)
+                .accessibilityLabel("\(account) is preferred for \(pool.name)")
+        } else {
+            Button("Prefer") {
+                Task { await store.setPreferred(pool: pool.name, account: account) }
+            }
+            .buttonStyle(.borderless)
+            .disabled(store.updatingPool != nil)
+            .accessibilityLabel("Prefer \(account) for \(pool.name)")
+        }
+    }
+
+    private func beginLogin(_ account: String) {
+        openWindow(id: "account-login")
+        store.beginLogin(account: account)
+    }
+
+    private var commands: some View {
+        VStack(spacing: 0) {
+            commandButton("Refresh", shortcut: "⌘ R", key: "r", disabled: store.isRefreshing) {
+                Task { await store.refresh() }
+            }
+            commandButton("Quit Comradex", shortcut: "⌘ Q", key: "q") {
+                NSApplication.shared.terminate(nil)
+            }
+        }
+    }
+
+    private func commandButton(
+        _ title: String,
+        shortcut: String,
+        key: KeyEquivalent,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                Spacer()
+                if title == "Refresh", store.isRefreshing {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text(shortcut)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(key, modifiers: .command)
+        .disabled(disabled)
     }
 
     private var staleDataWarning: some View {
@@ -198,7 +234,6 @@ struct MenuContentView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
-            Button("Try Again") { Task { await store.refresh() } }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -221,7 +256,7 @@ struct MenuContentView: View {
         }
     }
 
-    private func accountSubtitle(_ account: AccountSnapshot) -> String {
+    private func accountSubtitle(_ account: AccountSnapshot, poolName: String?) -> String {
         let state: String
         switch account.authState?.lowercased() {
         case "login_in_progress": state = "Login in progress"
@@ -230,6 +265,7 @@ struct MenuContentView: View {
         case "signed_out": state = "Signed out"
         default: state = account.isSignedIn ? "Signed in" : "Signed out"
         }
+        if let poolName { return "\(state) · \(poolName)" }
         guard !account.pools.isEmpty else { return state }
         return "\(state) · \(account.pools.joined(separator: ", "))"
     }

--- a/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
@@ -12,12 +12,16 @@ struct MenuContentView: View {
             Divider()
 
             if let snapshot = store.snapshot {
-                VStack(alignment: .leading, spacing: 0) {
-                    if store.errorMessage != nil { staleDataWarning }
-                    statusContent(snapshot)
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        if store.errorMessage != nil { staleDataWarning }
+                        statusContent(snapshot)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
                 }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
+                .scrollBounceBehavior(.basedOnSize)
+                .frame(maxHeight: 360)
             } else if let error = store.errorMessage {
                 errorState(error)
                     .padding(16)

--- a/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
+++ b/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
@@ -31,6 +31,20 @@ final class ComradexMenuTests: XCTestCase {
         XCTAssertEqual(value.pools.first?.active, "work")
     }
 
+    func testLoginActionOnlyAppearsForSignedOutManagedAccounts() throws {
+        let signedIn = try decodeAccount(#"{"name":"healthy","kind":"codex_home","signed_in":true,"auth_state":"signed_in"}"#)
+        let signedOut = try decodeAccount(#"{"name":"broken","kind":"codex_home","signed_in":false,"auth_state":"signed_out"}"#)
+        let inbound = try decodeAccount(#"{"name":"app","kind":"inbound","signed_in":true,"auth_state":"inbound"}"#)
+        let inProgress = try decodeAccount(#"{"name":"pending","kind":"codex_home","signed_in":false,"auth_state":"login_in_progress"}"#)
+        let unknown = try decodeAccount(#"{"name":"legacy","kind":"codex_home","signed_in":false}"#)
+
+        XCTAssertFalse(signedIn.needsLoginAction)
+        XCTAssertTrue(signedOut.needsLoginAction)
+        XCTAssertFalse(inbound.needsLoginAction)
+        XCTAssertFalse(inProgress.needsLoginAction)
+        XCTAssertFalse(unknown.needsLoginAction)
+    }
+
     func testLoginDecodesOnlyAllowlistedDeviceFlowFields() throws {
         let data = Data(#"{"ok":true,"account":"work","session_id":"random","state":"running","verification_uri":"https://auth.openai.com/codex/device","user_code":"ABCD-EFGH","output":"must not be decoded"}"#.utf8)
         let value = try ControlSocketClient.decode(
@@ -192,6 +206,10 @@ final class ComradexMenuTests: XCTestCase {
 
         XCTAssertThrowsError(try ControlSocketClient.send(Data(repeating: 0x41, count: 64 * 1024), to: path))
         wait(for: [closed], timeout: 2)
+    }
+
+    private func decodeAccount(_ json: String) throws -> AccountSnapshot {
+        try JSONDecoder().decode(AccountSnapshot.self, from: Data(json.utf8))
     }
 }
 


### PR DESCRIPTION
Reworks the menu into compact native-style rows with pool context and account-level preference controls. Re-login now appears only when authentication is required, while Refresh and Quit live as standard bottom commands. The layout also handles multiple pools and partial status data without repeated row dividers.