### PR TITLE
Harden service and quota recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,18 +157,19 @@ An installed Comradex binary can manage its own LaunchAgent:
 
 ```sh
 comradex service install
+comradex service start
 comradex service status
 comradex service restart
 comradex service uninstall
 ```
 
-`service restart` validates the edited configuration before stopping anything, then restarts the LaunchAgent and waits for every listener to answer a health probe. A broken edit fails validation and leaves the running daemon untouched. The configuration path comes from the installed plist, so the service always restarts against the configuration it actually uses regardless of `--config`.
+`service start` is idempotent: it loads an installed but unloaded LaunchAgent, revives a stopped job, and leaves an already-running daemon uninterrupted after verifying its listeners. `service restart` validates the edited configuration before stopping anything, then restarts the LaunchAgent and waits for every listener to answer a health probe. A broken edit fails validation and leaves the running daemon untouched. Both commands use the configuration path recorded in the installed plist regardless of `--config`.
 
-The installer records the exact executable and configuration paths, validates the generated plist, starts the daemon at login, and writes logs beneath Comradex's state directory. Installation waits for launchd to report a running PID and verifies every configured listener with a Comradex-specific HTTP probe. A failed replacement restores the previous Comradex plist and loaded job when possible.
+The installer records the exact executable and configuration paths, validates the generated plist, starts the daemon at login, and writes logs beneath Comradex's state directory. Early-login platform certificate loading is retried for up to 7.75 seconds so a temporarily unavailable macOS trust store does not strand the LaunchAgent. Installation waits for launchd to report a running PID and verifies every configured listener with a Comradex-specific HTTP probe. A failed replacement restores the previous Comradex plist and loaded job when possible.
 
 The service manages only `com.nicosuave.comradex`; it does not inspect, stop, or remove OpenCodex or any other relay. Stop OpenCodex first if it owns the same listener port. Codex configuration installation and service installation are separate reversible operations.
 
-`service status` reports whether launchd currently has a running Comradex process. On SIGTERM, Comradex stops the listeners, aborts and joins tracked HTTP/WebSocket connection tasks, clears in-flight counters, and only then writes final affinity, file-owner, and statistics snapshots. Active requests are terminated rather than gracefully completed during shutdown.
+`service status` reports whether launchd currently has a running Comradex process. When an installed service is down, it shows the last bounded stderr line and the exact start command; launchctl permission and communication failures are reported as errors instead of being mistaken for an unloaded job. On SIGTERM, Comradex stops the listeners, aborts and joins tracked HTTP/WebSocket connection tasks, clears in-flight counters, and only then writes final affinity, file-owner, and statistics snapshots. Active requests are terminated rather than gracefully completed during shutdown.
 
 ## How routing works
 
@@ -187,6 +188,8 @@ HTTP requests and the frame-aware WebSocket modes enforce file ownership found i
 Existing healthy bindings stay put even after usage crosses `switch_at`; the threshold controls only admission of new threads.
 
 A pre-output quota response, account-scoped connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Responses bodies carrying encrypted reasoning, hosted operation state, or durable operation metadata become bound to the first account that actually receives them; a proven pre-dispatch connection failure does not create that binding. Shared DNS and network-reachability failures remain account-neutral and do not rotate credentials. Successful or ambiguous Live Voice creation is never replayed. On HTTP, a managed-account 401 gets one same-account refresh retry, and a 401/403 never crosses accounts. No response is retried after visible output. When no alternate is eligible, the original upstream rejection and its `Retry-After` or reset headers are preserved; primary, secondary, and tertiary reset windows bound quota cooldowns.
+
+Quota cooldowns recover automatically on the next selection or status request. When upstream reports several quota windows, only windows explicitly reported at 100% constrain a quota rejection; unrelated longer windows do not keep the account blocked. `comradex status` and `comradex status --json` expose each account's availability, retry deadline, usage, and blocking quota windows. Neither Comradex nor Codex needs to be restarted when a quota window resets.
 
 Requests up to 256 KiB are replayed from memory by default; larger requests use a temporary file, and all bodies have a hard cap. Responses and upgraded streams are forwarded with backpressure and are never retained.
 

--- a/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
@@ -258,6 +258,19 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func accountState(_ account: AccountSnapshot) -> String {
+        if !account.available {
+            switch account.unavailableReason?.lowercased() {
+            case "quota":
+                if let retry = retryDescription(account.retryAtUnix) {
+                    return "Rate limited · retry in \(retry)"
+                }
+                return "Rate limited"
+            case "temporary_failure": return "Temporarily unavailable"
+            case "login_in_progress": return "Login in progress"
+            case "needs_login": return "Sign-in required"
+            default: return "Unavailable"
+            }
+        }
         switch account.authState?.lowercased() {
         case "login_in_progress": return "Login in progress"
         case "inbound": return "Inbound"
@@ -268,10 +281,24 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func accountIcon(_ account: AccountSnapshot) -> String {
+        if !account.available {
+            return account.unavailableReason?.lowercased() == "quota"
+                ? "clock.arrow.circlepath"
+                : "exclamationmark.circle.fill"
+        }
         switch account.authState?.lowercased() {
         case "login_in_progress": return "clock.fill"
         case "inbound": return "arrow.down.circle.fill"
         default: return account.isSignedIn ? "checkmark.circle.fill" : "exclamationmark.circle.fill"
         }
+    }
+
+    private func retryDescription(_ retryAtUnix: Int64?) -> String? {
+        guard let retryAtUnix else { return nil }
+        let now = Int64(Date().timeIntervalSince1970)
+        let seconds = max(0, retryAtUnix - now)
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3_600 { return "\(seconds / 60)m \(seconds % 60)s" }
+        return "\(seconds / 3_600)h \((seconds % 3_600) / 60)m"
     }
 }

--- a/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
@@ -53,6 +53,10 @@ struct AccountSnapshot: Codable, Equatable, Identifiable, Sendable {
     let signedIn: Bool?
     let authState: String?
     let pools: [String]
+    let available: Bool
+    let unavailableReason: String?
+    let retryAtUnix: Int64?
+    let usagePercent: Int?
 
     var id: String { name }
     var isSignedIn: Bool {
@@ -68,9 +72,12 @@ struct AccountSnapshot: Codable, Equatable, Identifiable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case name, kind, pools
+        case name, kind, pools, available
         case signedIn = "signed_in"
         case authState = "auth_state"
+        case unavailableReason = "unavailable_reason"
+        case retryAtUnix = "retry_at_unix"
+        case usagePercent = "usage_percent"
     }
 
     init(from decoder: Decoder) throws {
@@ -80,6 +87,10 @@ struct AccountSnapshot: Codable, Equatable, Identifiable, Sendable {
         signedIn = try container.decodeIfPresent(Bool.self, forKey: .signedIn)
         authState = try container.decodeIfPresent(String.self, forKey: .authState)
         pools = try container.decodeIfPresent([String].self, forKey: .pools) ?? []
+        available = try container.decodeIfPresent(Bool.self, forKey: .available) ?? true
+        unavailableReason = try container.decodeIfPresent(String.self, forKey: .unavailableReason)
+        retryAtUnix = try container.decodeIfPresent(Int64.self, forKey: .retryAtUnix)
+        usagePercent = try container.decodeIfPresent(Int.self, forKey: .usagePercent)
     }
 }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -108,6 +108,10 @@ pub struct UiAccountStatus {
     pub signed_in: bool,
     pub auth_state: UiAccountAuthState,
     pub pools: Vec<String>,
+    pub available: bool,
+    pub unavailable_reason: Option<String>,
+    pub retry_at_unix: Option<i64>,
+    pub usage_percent: Option<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -812,6 +816,22 @@ async fn build_ui_status(
                 signed_in,
                 auth_state,
                 pools,
+                available: routing
+                    .account_states
+                    .get(name)
+                    .is_none_or(|state| state.available),
+                unavailable_reason: routing
+                    .account_states
+                    .get(name)
+                    .and_then(|state| state.unavailable_reason.clone()),
+                retry_at_unix: routing
+                    .account_states
+                    .get(name)
+                    .and_then(|state| state.retry_at_unix),
+                usage_percent: routing
+                    .account_states
+                    .get(name)
+                    .and_then(|state| state.usage_percent),
             }
         })
         .collect();
@@ -1290,6 +1310,9 @@ path = "accounts/work"
 
         assert!(!work.signed_in);
         assert_eq!(work.auth_state, UiAccountAuthState::SignedOut);
+        assert!(!work.available);
+        assert_eq!(work.unavailable_reason.as_deref(), Some("needs_login"));
+        assert!(work.retry_at_unix.is_none());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,8 @@ enum AccountCommand {
 #[derive(Subcommand)]
 enum ServiceCommand {
     Install,
+    /// Start an installed service without interrupting it when already running
+    Start,
     Uninstall,
     Status,
     /// Restart the daemon so it reloads comradex.toml (needed after config
@@ -386,6 +388,10 @@ fn service_command(config_path: &Path, command: ServiceCommand) -> Result<()> {
             let plist = service::install(config_path, &state_dir(&config))?;
             println!("installed and started {}", plist.display());
         }
+        ServiceCommand::Start => {
+            service::start()?;
+            println!("service is running");
+        }
         ServiceCommand::Uninstall => match service::uninstall()? {
             Some(path) => println!("stopped service and removed {}", path.display()),
             None => println!("service is not installed"),
@@ -393,8 +399,18 @@ fn service_command(config_path: &Path, command: ServiceCommand) -> Result<()> {
         ServiceCommand::Status => {
             if service::status()? {
                 println!("service is running");
+            } else if service::installed()? {
+                println!("service is installed but not running");
+                if let Some(stderr) = service::last_stderr_line()? {
+                    println!(
+                        "last stderr line{}: {}",
+                        stderr_timestamp_suffix(stderr.log_modified_at_unix),
+                        stderr.line
+                    );
+                }
+                println!("run `comradex service start`");
             } else {
-                println!("service is not running");
+                println!("service is not installed (run `comradex service install`)");
             }
         }
         ServiceCommand::Restart => {
@@ -446,7 +462,20 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
 
     let service = match (service::installed(), service::status()) {
         (Ok(true), Ok(true)) => "running".to_owned(),
-        (Ok(true), Ok(false)) => "installed but not running".to_owned(),
+        (Ok(true), Ok(false)) => {
+            let suffix = service::last_stderr_line()
+                .ok()
+                .flatten()
+                .map(|stderr| {
+                    format!(
+                        "; last stderr line{}: {}",
+                        stderr_timestamp_suffix(stderr.log_modified_at_unix),
+                        stderr.line
+                    )
+                })
+                .unwrap_or_default();
+            format!("installed but not running{suffix} (run `comradex service start`)")
+        }
         (Ok(false), _) => "not installed (run `comradex service install`)".to_owned(),
         (Err(error), _) | (_, Err(error)) => format!("unknown ({error})"),
     };
@@ -460,6 +489,9 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
         None => println!("codex    not routed through Comradex (run `comradex install`)"),
     }
 
+    let routing = live_routing
+        .as_ref()
+        .or_else(|| snapshot.as_ref().map(|snapshot| &snapshot.routing));
     println!("\naccounts");
     let width = config.accounts.keys().map(String::len).max().unwrap_or(0);
     for (name, account) in &config.accounts {
@@ -474,12 +506,16 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
         } else {
             format!("pool {}", pools.join(", "))
         };
-        println!("  {name:width$}  {:24}  {pools}", account_state(account));
+        let availability = routing
+            .and_then(|routing| routing.account_states.get(name))
+            .map(account_availability)
+            .unwrap_or_default();
+        println!(
+            "  {name:width$}  {:24}  {pools}{availability}",
+            account_state(account)
+        );
     }
 
-    let routing = live_routing
-        .as_ref()
-        .or_else(|| snapshot.as_ref().map(|snapshot| &snapshot.routing));
     println!("\npools");
     let width = config.pools.keys().map(String::len).max().unwrap_or(0);
     for (name, pool) in &config.pools {
@@ -529,6 +565,46 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
         None => println!("  no snapshot yet (the daemon writes one every few seconds)"),
     }
     Ok(())
+}
+
+fn stderr_timestamp_suffix(timestamp: Option<u64>) -> String {
+    timestamp
+        .map(|timestamp| format!(" (log modified unix {timestamp})"))
+        .unwrap_or_default()
+}
+
+fn account_availability(status: &comradex::routing::AccountRoutingStatus) -> String {
+    if status.available {
+        return String::new();
+    }
+    let reason = match status
+        .unavailable_reason
+        .as_deref()
+        .unwrap_or("unavailable")
+    {
+        "quota" => "rate limited",
+        "temporary_failure" => "temporarily unavailable",
+        "login_in_progress" => "login in progress",
+        "needs_login" => "sign-in required",
+        reason => reason,
+    };
+    let retry = status.retry_at_unix.and_then(|deadline| {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        let deadline = u64::try_from(deadline).ok()?;
+        Some(human_duration(deadline.saturating_sub(now)))
+    });
+    match retry {
+        Some(retry) => format!("; {reason}, retry in {retry}"),
+        None => format!("; {reason}"),
+    }
+}
+
+fn human_duration(seconds: u64) -> String {
+    match seconds {
+        0..60 => format!("{seconds}s"),
+        60..3600 => format!("{}m {}s", seconds / 60, seconds % 60),
+        _ => format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60),
+    }
 }
 
 /// Short, plain-language state for one account.
@@ -886,5 +962,23 @@ mod tests {
 
         assert!(Cli::try_parse_from(["comradex", "account", "prefer", "work", "--clear"]).is_err());
         assert!(Cli::try_parse_from(["comradex", "account", "prefer"]).is_err());
+    }
+
+    #[test]
+    fn service_start_is_a_first_class_command() {
+        let cli = Cli::try_parse_from(["comradex", "service", "start"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Service {
+                command: ServiceCommand::Start
+            }
+        ));
+    }
+
+    #[test]
+    fn durations_are_concise_for_status_output() {
+        assert_eq!(human_duration(12), "12s");
+        assert_eq!(human_duration(125), "2m 5s");
+        assert_eq!(human_duration(7_500), "2h 5m");
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -4,4 +4,4 @@ pub mod metadata;
 pub mod router;
 
 pub use affinity::{AffinityStore, ThreadKey};
-pub use router::{Router, RoutingSnapshot, Selection};
+pub use router::{AccountRoutingStatus, QuotaWindowStatus, Router, RoutingSnapshot, Selection};

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -30,6 +30,30 @@ pub struct RoutingSnapshot {
     pub preferred_accounts: BTreeMap<String, String>,
     #[serde(default)]
     pub active_accounts: BTreeMap<String, String>,
+    #[serde(default)]
+    pub account_states: BTreeMap<String, AccountRoutingStatus>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccountRoutingStatus {
+    pub available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_at_unix: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage_percent: Option<u8>,
+    pub inflight: u64,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub quota_windows: BTreeMap<String, QuotaWindowStatus>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuotaWindowStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub used_percent: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_at_unix: Option<i64>,
 }
 
 #[derive(Debug, Default)]
@@ -41,6 +65,7 @@ struct AccountRuntime {
     needs_login_retry_at: Option<Instant>,
     login_in_progress: bool,
     quota_until: Option<Instant>,
+    quota_reset_at: Option<DateTime<Utc>>,
     quota_evidence: Option<QuotaEvidence>,
     avoid_until: Option<Instant>,
 }
@@ -251,6 +276,17 @@ impl Router {
     }
 
     pub async fn routing_snapshot(&self) -> RoutingSnapshot {
+        let now = Instant::now();
+        let wall_now = Utc::now();
+        let mut accounts = self.accounts.lock().await;
+        for runtime in accounts.values_mut() {
+            reconcile_runtime(runtime, now, wall_now);
+        }
+        let account_states = accounts
+            .iter()
+            .map(|(name, runtime)| (name.clone(), account_routing_status(runtime, now, wall_now)))
+            .collect();
+        drop(accounts);
         RoutingSnapshot {
             preferred_accounts: self
                 .preferred
@@ -266,6 +302,7 @@ impl Router {
                 .iter()
                 .map(|(pool, account)| (pool.clone(), account.clone()))
                 .collect(),
+            account_states,
         }
     }
 
@@ -328,10 +365,13 @@ impl Router {
     }
     pub async fn quota_failure(&self, account: &str, headers: &hyper::HeaderMap) {
         let now = Utc::now();
-        let delay = quota_delay_at(headers, now);
-        let evidence = quota_evidence(headers, now);
+        let evidence = blocking_quota_evidence(headers, now);
+        let delay = quota_delay_at(headers, now, &evidence);
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
             a.quota_until = Some(Instant::now() + delay);
+            a.quota_reset_at = now.checked_add_signed(
+                chrono::Duration::from_std(delay).unwrap_or(chrono::Duration::MAX),
+            );
             a.quota_evidence = (!evidence.is_empty()).then_some(evidence);
         }
     }
@@ -425,6 +465,7 @@ impl Router {
                 .is_some_and(|blocked| quota_reset_confirmed(blocked, &observed_evidence))
             {
                 a.quota_until = None;
+                a.quota_reset_at = None;
                 a.quota_evidence = None;
             }
         }
@@ -439,20 +480,72 @@ fn reconcile_expired_quota(runtime: &mut AccountRuntime, now: Instant, wall_now:
         .quota_until
         .is_some_and(|quota_until| quota_until > now)
         && runtime
-            .quota_evidence
-            .as_ref()
-            .is_some_and(|evidence| quota_reset_elapsed(evidence, wall_now))
+            .quota_reset_at
+            .is_some_and(|reset_at| reset_at <= wall_now)
     {
         runtime.quota_until = None;
+        runtime.quota_reset_at = None;
         runtime.quota_evidence = None;
     }
 }
 
-fn quota_reset_elapsed(evidence: &QuotaEvidence, now: DateTime<Utc>) -> bool {
-    !evidence.is_empty()
-        && evidence
-            .values()
-            .all(|window| window.reset_at.is_some_and(|reset_at| reset_at <= now))
+fn reconcile_runtime(runtime: &mut AccountRuntime, now: Instant, wall_now: DateTime<Utc>) {
+    if runtime.needs_login
+        && runtime
+            .needs_login_retry_at
+            .is_some_and(|retry_at| retry_at <= now)
+    {
+        runtime.needs_login = false;
+        runtime.needs_login_retry_at = None;
+    }
+    reconcile_expired_quota(runtime, now, wall_now);
+}
+
+fn account_routing_status(
+    runtime: &AccountRuntime,
+    now: Instant,
+    wall_now: DateTime<Utc>,
+) -> AccountRoutingStatus {
+    let (unavailable_reason, retry_at) = if runtime.login_in_progress {
+        (Some("login_in_progress".to_owned()), None)
+    } else if runtime.needs_login {
+        (Some("needs_login".to_owned()), runtime.needs_login_retry_at)
+    } else if runtime.quota_until.is_some_and(|until| until > now) {
+        (Some("quota".to_owned()), runtime.quota_until)
+    } else if runtime.avoid_until.is_some_and(|until| until > now) {
+        (Some("temporary_failure".to_owned()), runtime.avoid_until)
+    } else {
+        (None, None)
+    };
+    let retry_at_unix = retry_at.map(|deadline| {
+        wall_now.timestamp()
+            + i64::try_from(deadline.saturating_duration_since(now).as_secs()).unwrap_or(i64::MAX)
+    });
+    let quota_windows = runtime
+        .quota_evidence
+        .as_ref()
+        .into_iter()
+        .flat_map(|evidence| evidence.iter())
+        .map(|(window, evidence)| {
+            (
+                window.name().to_owned(),
+                QuotaWindowStatus {
+                    used_percent: evidence
+                        .used_percent
+                        .map(|percent| percent.clamp(0.0, 100.0).round() as u8),
+                    reset_at_unix: evidence.reset_at.map(|reset_at| reset_at.timestamp()),
+                },
+            )
+        })
+        .collect();
+    AccountRoutingStatus {
+        available: unavailable_reason.is_none(),
+        unavailable_reason,
+        retry_at_unix,
+        usage_percent: runtime.usage,
+        inflight: runtime.inflight,
+        quota_windows,
+    }
 }
 
 fn quota_evidence(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> QuotaEvidence {
@@ -506,62 +599,82 @@ fn quota_evidence(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> QuotaEviden
     .collect()
 }
 
-fn quota_reset_confirmed(blocked: &QuotaEvidence, observed: &QuotaEvidence) -> bool {
-    blocked.iter().any(|(window, before)| {
-        let Some(after) = observed.get(window) else {
-            return false;
-        };
-        let usage_recovered = match (before.used_percent, after.used_percent) {
-            (Some(before), Some(after)) => after < before,
-            (None, Some(after)) => after < 100.0,
-            _ => false,
-        };
-        let reset_advanced = match (before.reset_at, after.reset_at) {
-            (Some(before), Some(after)) => {
-                after.signed_duration_since(before) > chrono::Duration::seconds(60)
-            }
-            _ => false,
-        };
-        usage_recovered && reset_advanced
-    })
+fn blocking_quota_evidence(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> QuotaEvidence {
+    let evidence = quota_evidence(headers, now);
+    let exhausted = evidence
+        .iter()
+        .filter(|(_, window)| window.used_percent.is_some_and(|used| used >= 100.0))
+        .map(|(window, evidence)| (*window, *evidence))
+        .collect::<QuotaEvidence>();
+    if exhausted.is_empty() {
+        evidence
+    } else {
+        exhausted
+    }
 }
 
-fn quota_delay_at(headers: &hyper::HeaderMap, now: DateTime<Utc>) -> Duration {
-    let seconds = headers
-        .iter()
-        .filter_map(|(name, value)| {
-            let name = name.as_str();
-            let value = value.to_str().ok()?.trim();
-            if name == "retry-after" {
-                return value.parse::<u64>().ok().or_else(|| {
-                    parse_http_date(value).map(|reset_at| seconds_until(reset_at, now))
-                });
-            }
-            if !is_quota_reset_header(name) {
-                return None;
-            }
-            if name.ends_with("-reset-after-seconds") {
-                value.parse::<u64>().ok()
-            } else {
-                parse_reset_at(value).map(|reset_at| seconds_until(reset_at, now))
-            }
+fn quota_reset_confirmed(blocked: &QuotaEvidence, observed: &QuotaEvidence) -> bool {
+    !blocked.is_empty()
+        && blocked.iter().all(|(window, before)| {
+            let Some(after) = observed.get(window) else {
+                return false;
+            };
+            let usage_recovered = match (before.used_percent, after.used_percent) {
+                (Some(before), Some(after)) => after < before,
+                (None, Some(after)) => after < 100.0,
+                _ => false,
+            };
+            let reset_advanced = match (before.reset_at, after.reset_at) {
+                (Some(before), Some(after)) => {
+                    after.signed_duration_since(before) > chrono::Duration::seconds(60)
+                }
+                _ => false,
+            };
+            usage_recovered && reset_advanced
         })
+}
+
+fn quota_delay_at(
+    headers: &hyper::HeaderMap,
+    now: DateTime<Utc>,
+    evidence: &QuotaEvidence,
+) -> Duration {
+    let retry_after = headers.get("retry-after").and_then(|value| {
+        let value = value.to_str().ok()?.trim();
+        value
+            .parse::<u64>()
+            .ok()
+            .or_else(|| parse_http_date(value).map(|reset_at| seconds_until(reset_at, now)))
+    });
+    let generic_reset = [
+        "x-codex-reset-after-seconds",
+        "x-ratelimit-reset-after-seconds",
+    ]
+    .into_iter()
+    .filter_map(|name| headers.get(name)?.to_str().ok()?.trim().parse::<u64>().ok())
+    .max();
+    let seconds = retry_after
+        .into_iter()
+        .chain(generic_reset)
+        .chain(
+            evidence
+                .values()
+                .filter_map(|window| window.reset_at.map(|reset_at| seconds_until(reset_at, now))),
+        )
         .max()
         .unwrap_or(60)
         .clamp(1, 24 * 60 * 60);
     Duration::from_secs(seconds)
 }
 
-fn is_quota_reset_header(name: &str) -> bool {
-    let supported_prefix = name.starts_with("x-codex-") || name.starts_with("x-ratelimit-");
-    let supported_window = ["-primary-", "-secondary-", "-tertiary-"]
-        .iter()
-        .any(|window| name.contains(window));
-    supported_prefix
-        && (name == "x-codex-reset-after-seconds"
-            || name == "x-ratelimit-reset-after-seconds"
-            || (supported_window
-                && (name.ends_with("-reset-after-seconds") || name.ends_with("-reset-at"))))
+impl QuotaWindow {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Primary => "primary",
+            Self::Secondary => "secondary",
+            Self::Tertiary => "tertiary",
+        }
+    }
 }
 
 fn parse_reset_at(value: &str) -> Option<DateTime<Utc>> {
@@ -715,6 +828,22 @@ mod tests {
             RoutingSnapshot {
                 preferred_accounts: BTreeMap::from([("default".into(), "b".into())]),
                 active_accounts: BTreeMap::from([("default".into(), "b".into())]),
+                account_states: BTreeMap::from([
+                    (
+                        "a".into(),
+                        AccountRoutingStatus {
+                            available: true,
+                            ..Default::default()
+                        }
+                    ),
+                    (
+                        "b".into(),
+                        AccountRoutingStatus {
+                            available: true,
+                            ..Default::default()
+                        }
+                    ),
+                ]),
             }
         );
     }
@@ -945,6 +1074,7 @@ mod tests {
             let mut accounts = router.accounts.lock().await;
             let account = accounts.get_mut("a").unwrap();
             account.quota_until = Some(Instant::now() + Duration::from_secs(3600));
+            account.quota_reset_at = Some(DateTime::from_timestamp(1_577_836_800, 0).unwrap());
             account.quota_evidence = Some(evidence);
         }
 
@@ -956,6 +1086,57 @@ mod tests {
                 .account_id,
             "a"
         );
+    }
+
+    #[tokio::test]
+    async fn retry_after_deadline_prevents_early_window_reset_reconciliation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = config(dir.path());
+        cfg.pools.get_mut("default").unwrap().members = vec!["a".into()];
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity);
+        let pool = &cfg.pools["default"];
+        let wall_now = Utc::now();
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("120"));
+        headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("100"),
+        );
+        headers.insert(
+            "x-codex-primary-reset-after-seconds",
+            HeaderValue::from_static("45"),
+        );
+        router.quota_failure("a", &headers).await;
+
+        {
+            let mut accounts = router.accounts.lock().await;
+            let account = accounts.get_mut("a").unwrap();
+            account.quota_until = Some(Instant::now() + Duration::from_secs(3600));
+            account.quota_reset_at = Some(wall_now + chrono::Duration::seconds(120));
+            reconcile_expired_quota(
+                account,
+                Instant::now(),
+                wall_now + chrono::Duration::seconds(46),
+            );
+            assert!(account.quota_until.is_some());
+            reconcile_expired_quota(
+                account,
+                Instant::now(),
+                wall_now + chrono::Duration::seconds(121),
+            );
+            assert!(account.quota_until.is_none());
+        }
+        assert!(router.select("default", pool, None, None).await.is_some());
     }
 
     #[tokio::test]
@@ -1041,6 +1222,11 @@ mod tests {
             .with_timezone(&Utc)
     }
 
+    fn quota_delay(headers: &HeaderMap, now: DateTime<Utc>) -> Duration {
+        let evidence = blocking_quota_evidence(headers, now);
+        quota_delay_at(headers, now, &evidence)
+    }
+
     #[test]
     fn quota_delay_accepts_tertiary_only_evidence() {
         let mut headers = HeaderMap::new();
@@ -1049,10 +1235,7 @@ mod tests {
             HeaderValue::from_static("321"),
         );
 
-        assert_eq!(
-            quota_delay_at(&headers, fixed_now()),
-            Duration::from_secs(321)
-        );
+        assert_eq!(quota_delay(&headers, fixed_now()), Duration::from_secs(321));
     }
 
     #[test]
@@ -1063,17 +1246,14 @@ mod tests {
             "x-codex-primary-reset-at",
             HeaderValue::from_str(&(now.timestamp() + 450).to_string()).unwrap(),
         );
-        assert_eq!(
-            quota_delay_at(&epoch_headers, now),
-            Duration::from_secs(450)
-        );
+        assert_eq!(quota_delay(&epoch_headers, now), Duration::from_secs(450));
 
         let mut iso_headers = HeaderMap::new();
         iso_headers.insert(
             "x-ratelimit-secondary-reset-at",
             HeaderValue::from_static("2026-08-11T12:07:31Z"),
         );
-        assert_eq!(quota_delay_at(&iso_headers, now), Duration::from_secs(451));
+        assert_eq!(quota_delay(&iso_headers, now), Duration::from_secs(451));
     }
 
     #[test]
@@ -1084,10 +1264,7 @@ mod tests {
             HeaderValue::from_static("Tue, 11 Aug 2026 12:02:03 GMT"),
         );
 
-        assert_eq!(
-            quota_delay_at(&headers, fixed_now()),
-            Duration::from_secs(123)
-        );
+        assert_eq!(quota_delay(&headers, fixed_now()), Duration::from_secs(123));
     }
 
     #[test]
@@ -1107,9 +1284,108 @@ mod tests {
             HeaderValue::from_static("90"),
         );
 
-        assert_eq!(
-            quota_delay_at(&headers, fixed_now()),
-            Duration::from_secs(90)
+        assert_eq!(quota_delay(&headers, fixed_now()), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn quota_delay_ignores_non_exhausted_longer_windows() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("100"),
         );
+        headers.insert(
+            "x-codex-primary-reset-after-seconds",
+            HeaderValue::from_static("45"),
+        );
+        headers.insert(
+            "x-codex-secondary-used-percent",
+            HeaderValue::from_static("12"),
+        );
+        headers.insert(
+            "x-codex-secondary-reset-after-seconds",
+            HeaderValue::from_static("86400"),
+        );
+
+        let evidence = blocking_quota_evidence(&headers, fixed_now());
+        assert_eq!(evidence.len(), 1);
+        assert!(evidence.contains_key(&QuotaWindow::Primary));
+        assert_eq!(
+            quota_delay_at(&headers, fixed_now(), &evidence),
+            Duration::from_secs(45)
+        );
+    }
+
+    #[test]
+    fn quota_reset_confirmation_requires_every_blocking_window_to_recover() {
+        let now = fixed_now();
+        let mut blocked_headers = HeaderMap::new();
+        for (usage, reset) in [
+            ("x-codex-primary-used-percent", "x-codex-primary-reset-at"),
+            (
+                "x-codex-secondary-used-percent",
+                "x-codex-secondary-reset-at",
+            ),
+        ] {
+            blocked_headers.insert(usage, HeaderValue::from_static("100"));
+            blocked_headers.insert(reset, HeaderValue::from_static("2026-08-11T13:00:00Z"));
+        }
+        let blocked = blocking_quota_evidence(&blocked_headers, now);
+        let mut observed = HeaderMap::new();
+        observed.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("1"),
+        );
+        observed.insert(
+            "x-codex-primary-reset-at",
+            HeaderValue::from_static("2026-08-12T13:00:00Z"),
+        );
+        observed.insert(
+            "x-codex-secondary-used-percent",
+            HeaderValue::from_static("100"),
+        );
+        observed.insert(
+            "x-codex-secondary-reset-at",
+            HeaderValue::from_static("2026-08-11T13:00:00Z"),
+        );
+        assert!(!quota_reset_confirmed(
+            &blocked,
+            &quota_evidence(&observed, now)
+        ));
+    }
+
+    #[tokio::test]
+    async fn routing_snapshot_exposes_quota_deadline_and_blocking_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = config(dir.path());
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("a.json"),
+                &cfg.proxy.affinity_key,
+                100,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Router::new(&cfg, affinity);
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", HeaderValue::from_static("120"));
+        headers.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("100"),
+        );
+        headers.insert(
+            "x-codex-primary-reset-after-seconds",
+            HeaderValue::from_static("120"),
+        );
+        router.quota_failure("a", &headers).await;
+
+        let snapshot = router.routing_snapshot().await;
+        let account = &snapshot.account_states["a"];
+        assert!(!account.available);
+        assert_eq!(account.unavailable_reason.as_deref(), Some("quota"));
+        assert!(account.retry_at_unix.is_some());
+        assert_eq!(account.quota_windows["primary"].used_percent, Some(100));
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,11 +1,11 @@
 use std::{
     fs,
-    io::{Read, Write},
+    io::{Read, Seek, SeekFrom, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, bail};
@@ -232,6 +232,61 @@ pub fn installed() -> Result<bool> {
     Ok(plist_path()?.exists())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastStderrLine {
+    pub line: String,
+    pub log_modified_at_unix: Option<u64>,
+}
+
+/// Return the last daemon stderr line and log modification time recorded by
+/// the installed LaunchAgent. This is intentionally bounded so status remains
+/// safe even when a log has grown large. It is diagnostic history, not proof
+/// that the latest launch attempt failed.
+pub fn last_stderr_line() -> Result<Option<LastStderrLine>> {
+    platform_check()?;
+    let plist_path = plist_path()?;
+    let plist = match fs::read_to_string(&plist_path) {
+        Ok(plist) => plist,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("read {}", plist_path.display())),
+    };
+    let Some(path) = plist_string_after(&plist, "<key>StandardErrorPath</key><string>") else {
+        return Ok(None);
+    };
+    read_last_nonempty_line(Path::new(&path))
+}
+
+fn read_last_nonempty_line(path: &Path) -> Result<Option<LastStderrLine>> {
+    const MAX_READ: u64 = 64 * 1024;
+    const MAX_LINE_CHARS: usize = 500;
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let metadata = file.metadata()?;
+    let length = metadata.len();
+    let start = length.saturating_sub(MAX_READ);
+    file.seek(SeekFrom::Start(start))?;
+    let mut bytes = Vec::with_capacity((length - start) as usize);
+    file.read_to_end(&mut bytes)?;
+    let text = String::from_utf8_lossy(&bytes);
+    let line = text
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(str::trim)
+        .map(|line| line.chars().take(MAX_LINE_CHARS).collect());
+    Ok(line.map(|line| LastStderrLine {
+        line,
+        log_modified_at_unix: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs()),
+    }))
+}
+
 /// Run account maintenance while an installed LaunchAgent is unloaded. The
 /// previous loaded state is restored even when the maintenance operation
 /// fails, preventing the daemon from racing an external credential writer.
@@ -316,6 +371,64 @@ fn maintenance_transaction<T>(
 /// bounced so a broken edit fails here instead of taking the service down.
 pub fn restart() -> Result<()> {
     platform_check()?;
+    let service = installed_service()?;
+    let domain = launchctl_domain();
+    let state = launchctl_print(&domain)?
+        .as_deref()
+        .map_or(LaunchAgentState::Unloaded, launchctl_output_state);
+    let previous_pid = state.pid();
+    match state {
+        LaunchAgentState::Unloaded => bootstrap(&domain, &service.plist_path)?,
+        LaunchAgentState::LoadedStopped { .. } | LaunchAgentState::Running { .. } => {
+            kickstart(&domain)?
+        }
+    }
+    service.wait_until_ready(&domain, previous_pid)
+}
+
+/// Start an installed LaunchAgent without bouncing an already-running daemon.
+///
+/// This is intentionally idempotent: an unloaded job is bootstrapped, a loaded
+/// but stopped job is kickstarted, and a running job is left alone. All three
+/// paths verify launchd state and, for current plists, the nonce-protected
+/// listener health endpoints before returning.
+pub fn start() -> Result<()> {
+    platform_check()?;
+    let service = installed_service()?;
+    let domain = launchctl_domain();
+    let state = launchctl_print(&domain)?
+        .as_deref()
+        .map_or(LaunchAgentState::Unloaded, launchctl_output_state);
+    execute_start(
+        state,
+        || bootstrap(&domain, &service.plist_path),
+        || kickstart(&domain),
+        |previous_pid| service.wait_until_ready(&domain, previous_pid),
+    )
+}
+
+struct InstalledService {
+    plist_path: PathBuf,
+    listener_addresses: Vec<SocketAddr>,
+    service_nonce: Option<String>,
+}
+
+impl InstalledService {
+    fn wait_until_ready(&self, domain: &str, previous_pid: Option<u32>) -> Result<()> {
+        let (readiness_listeners, readiness_nonce) =
+            readiness_probe(&self.listener_addresses, self.service_nonce.as_deref());
+        wait_until_ready(
+            domain,
+            readiness_listeners,
+            readiness_nonce,
+            previous_pid,
+            READY_TIMEOUT,
+        )
+    }
+}
+
+/// Read and validate every installed input before changing launchd state.
+fn installed_service() -> Result<InstalledService> {
     let plist_path = plist_path()?;
     let plist = match fs::read_to_string(&plist_path) {
         Ok(text) => text,
@@ -324,9 +437,17 @@ pub fn restart() -> Result<()> {
         }
         Err(error) => return Err(error).with_context(|| format!("read {}", plist_path.display())),
     };
+    validate_plist(&plist_path)
+        .with_context(|| format!("validate installed service {}", plist_path.display()))?;
     let config_path = plist_program_config(&plist)
         .with_context(|| format!("no --config argument recorded in {}", plist_path.display()))?;
-    if let Some(executable) = plist_executable(&plist).filter(|path| !path.exists()) {
+    let executable = plist_executable(&plist).with_context(|| {
+        format!(
+            "no executable recorded in ProgramArguments in {}",
+            plist_path.display()
+        )
+    })?;
+    if !executable.is_file() {
         bail!(
             "the service executable {} no longer exists (removed by an upgrade?); \
              run `comradex service install` to re-point the service at the current binary",
@@ -339,23 +460,63 @@ pub fn restart() -> Result<()> {
         .values()
         .map(|listener| listener.address)
         .collect();
-    let service_nonce = plist_string_after(&plist, "<key>COMRADEX_SERVICE_NONCE</key><string>");
-    let domain = launchctl_domain();
-    let previous_pid = launchctl_print(&domain)?.and_then(|output| launchctl_output_pid(&output));
-    if is_loaded(&domain)? {
-        kickstart(&domain)?;
-    } else {
-        bootstrap(&domain, &plist_path)?;
+    if listener_addresses.iter().any(|address| address.port() == 0) {
+        bail!("installed service configuration requires fixed non-zero listener ports")
     }
-    let (readiness_listeners, readiness_nonce) =
-        readiness_probe(&listener_addresses, service_nonce.as_deref());
-    wait_until_ready(
-        &domain,
-        readiness_listeners,
-        readiness_nonce,
-        previous_pid,
-        READY_TIMEOUT,
-    )
+    let service_nonce = plist_string_after(&plist, "<key>COMRADEX_SERVICE_NONCE</key><string>");
+    Ok(InstalledService {
+        plist_path,
+        listener_addresses,
+        service_nonce,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LaunchAgentState {
+    Unloaded,
+    LoadedStopped { previous_pid: Option<u32> },
+    Running { pid: u32 },
+}
+
+impl LaunchAgentState {
+    fn pid(self) -> Option<u32> {
+        match self {
+            Self::Unloaded => None,
+            Self::LoadedStopped { previous_pid } => previous_pid,
+            Self::Running { pid } => Some(pid),
+        }
+    }
+}
+
+fn launchctl_output_state(output: &str) -> LaunchAgentState {
+    let pid = launchctl_output_pid(output);
+    if output.lines().any(|line| line.trim() == "state = running")
+        && let Some(pid) = pid
+    {
+        LaunchAgentState::Running { pid }
+    } else {
+        LaunchAgentState::LoadedStopped { previous_pid: pid }
+    }
+}
+
+fn execute_start(
+    state: LaunchAgentState,
+    bootstrap_job: impl FnOnce() -> Result<()>,
+    kickstart_job: impl FnOnce() -> Result<()>,
+    wait: impl FnOnce(Option<u32>) -> Result<()>,
+) -> Result<()> {
+    let previous_pid = match state {
+        LaunchAgentState::Unloaded => {
+            bootstrap_job()?;
+            None
+        }
+        LaunchAgentState::LoadedStopped { previous_pid } => {
+            kickstart_job()?;
+            previous_pid
+        }
+        LaunchAgentState::Running { .. } => None,
+    };
+    wait(previous_pid)
 }
 
 fn readiness_probe<'a>(
@@ -444,13 +605,28 @@ fn is_running(domain: &str) -> Result<bool> {
 fn launchctl_print(domain: &str) -> Result<Option<String>> {
     let output = Command::new("launchctl")
         .args(["print", &format!("{domain}/{LABEL}")])
-        .stderr(Stdio::null())
         .output()
         .context("launch launchctl print")?;
-    if !output.status.success() {
+    classify_launchctl_print(
+        output.status.success(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn classify_launchctl_print(success: bool, stdout: &str, stderr: &str) -> Result<Option<String>> {
+    if success {
+        return Ok(Some(stdout.to_owned()));
+    }
+    let normalized = stderr.to_ascii_lowercase();
+    if normalized.contains("could not find service") || normalized.contains("service not found") {
         return Ok(None);
     }
-    Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()))
+    let detail = stderr.trim();
+    if detail.is_empty() {
+        bail!("launchctl print failed without an error message")
+    }
+    bail!("launchctl print failed: {detail}")
 }
 
 fn launchctl_output_is_running(output: &str) -> bool {
@@ -811,6 +987,156 @@ mod tests {
             Some(42)
         );
         assert_eq!(launchctl_output_pid("state = running\n\tpid = 0\n"), None);
+    }
+
+    #[test]
+    fn launchctl_print_distinguishes_missing_jobs_from_real_failures() {
+        assert_eq!(
+            classify_launchctl_print(
+                false,
+                "",
+                "Bad request.\nCould not find service com.nicosuave.comradex in domain"
+            )
+            .unwrap(),
+            None
+        );
+        assert!(
+            classify_launchctl_print(false, "", "Operation not permitted")
+                .unwrap_err()
+                .to_string()
+                .contains("Operation not permitted")
+        );
+        assert_eq!(
+            classify_launchctl_print(true, "state = running\n", "")
+                .unwrap()
+                .as_deref(),
+            Some("state = running\n")
+        );
+    }
+
+    #[test]
+    fn last_stderr_reader_is_bounded_and_uses_last_nonempty_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stderr.log");
+        fs::write(
+            &path,
+            format!("{}\nfirst\nlast failure\n\n", "x".repeat(70_000)),
+        )
+        .unwrap();
+        let stderr = read_last_nonempty_line(&path).unwrap().unwrap();
+        assert_eq!(stderr.line, "last failure");
+        assert!(stderr.log_modified_at_unix.is_some());
+        assert_eq!(
+            read_last_nonempty_line(&dir.path().join("missing")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn launchctl_state_distinguishes_unrunning_loaded_jobs() {
+        assert_eq!(
+            launchctl_output_state("state = running\n\tpid = 42\n"),
+            LaunchAgentState::Running { pid: 42 }
+        );
+        assert_eq!(
+            launchctl_output_state("state = waiting\n\tpid = 41\n"),
+            LaunchAgentState::LoadedStopped {
+                previous_pid: Some(41)
+            }
+        );
+        assert_eq!(
+            launchctl_output_state("state = waiting\n"),
+            LaunchAgentState::LoadedStopped { previous_pid: None }
+        );
+    }
+
+    #[test]
+    fn start_bootstraps_only_an_unloaded_job_then_waits() {
+        let bootstraps = Cell::new(0);
+        let kickstarts = Cell::new(0);
+        let waits = Cell::new(0);
+
+        execute_start(
+            LaunchAgentState::Unloaded,
+            || {
+                bootstraps.set(bootstraps.get() + 1);
+                Ok(())
+            },
+            || {
+                kickstarts.set(kickstarts.get() + 1);
+                Ok(())
+            },
+            |previous_pid| {
+                waits.set(waits.get() + 1);
+                assert_eq!(previous_pid, None);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bootstraps.get(), 1);
+        assert_eq!(kickstarts.get(), 0);
+        assert_eq!(waits.get(), 1);
+    }
+
+    #[test]
+    fn start_kickstarts_only_a_loaded_stopped_job_then_waits_for_a_new_pid() {
+        let bootstraps = Cell::new(0);
+        let kickstarts = Cell::new(0);
+        let waits = Cell::new(0);
+
+        execute_start(
+            LaunchAgentState::LoadedStopped {
+                previous_pid: Some(41),
+            },
+            || {
+                bootstraps.set(bootstraps.get() + 1);
+                Ok(())
+            },
+            || {
+                kickstarts.set(kickstarts.get() + 1);
+                Ok(())
+            },
+            |previous_pid| {
+                waits.set(waits.get() + 1);
+                assert_eq!(previous_pid, Some(41));
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bootstraps.get(), 0);
+        assert_eq!(kickstarts.get(), 1);
+        assert_eq!(waits.get(), 1);
+    }
+
+    #[test]
+    fn start_leaves_a_running_job_alone_and_checks_readiness() {
+        let bootstraps = Cell::new(0);
+        let kickstarts = Cell::new(0);
+        let waits = Cell::new(0);
+
+        execute_start(
+            LaunchAgentState::Running { pid: 42 },
+            || {
+                bootstraps.set(bootstraps.get() + 1);
+                Ok(())
+            },
+            || {
+                kickstarts.set(kickstarts.get() + 1);
+                Ok(())
+            },
+            |previous_pid| {
+                waits.set(waits.get() + 1);
+                assert_eq!(previous_pid, None);
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(bootstraps.get(), 0);
+        assert_eq!(kickstarts.get(), 0);
+        assert_eq!(waits.get(), 1);
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -3,10 +3,13 @@ use std::{
     io::{Read, Seek, SeekFrom, Write},
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
-    process::{Command, Stdio},
+    process::Command,
     thread,
     time::{Duration, Instant, UNIX_EPOCH},
 };
+
+#[cfg(target_os = "macos")]
+use std::process::Stdio;
 
 use anyhow::{Context, Result, bail};
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -124,9 +124,11 @@ mod tests {
 
     use rustls::pki_types::CertificateDer;
 
+    #[cfg(target_os = "macos")]
+    use super::TLS_ROOT_RETRY_DELAYS;
     use super::{
-        TLS_ROOT_RETRY_DELAYS, codex_http_connector, codex_websocket_connector,
-        load_platform_root_store_with, root_store_from_native_certs,
+        codex_http_connector, codex_websocket_connector, load_platform_root_store_with,
+        root_store_from_native_certs,
     };
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,10 +1,24 @@
-use std::sync::Arc;
+use std::{sync::Arc, thread, time::Duration};
 
 use anyhow::{Context, Result, ensure};
 use hyper_rustls::HttpsConnector as RustlsHttpsConnector;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use rustls::{ClientConfig, RootCertStore, pki_types::CertificateDer};
+
+// macOS can briefly return an empty trust store while a user's login session is
+// still coming up. Keep this well below the service's 20-second readiness
+// timeout while allowing the platform security services time to settle.
+#[cfg(target_os = "macos")]
+const TLS_ROOT_RETRY_DELAYS: &[Duration] = &[
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+];
+#[cfg(not(target_os = "macos"))]
+const TLS_ROOT_RETRY_DELAYS: &[Duration] = &[];
 
 /// Builds the same transport-default TLS shape used by Codex's reqwest 0.12 client.
 ///
@@ -39,9 +53,48 @@ fn codex_websocket_tls_config() -> Result<ClientConfig> {
     let builder = ClientConfig::builder_with_provider(Arc::new(provider))
         .with_safe_default_protocol_versions()
         .context("select Codex Rustls protocol versions")?;
-    let native = rustls_native_certs::load_native_certs();
-    let roots = root_store_from_native_certs(native.certs, native.errors.len())?;
+    let roots = load_platform_root_store()?;
     Ok(builder.with_root_certificates(roots).with_no_client_auth())
+}
+
+fn load_platform_root_store() -> Result<RootCertStore> {
+    load_platform_root_store_with(
+        || {
+            let native = rustls_native_certs::load_native_certs();
+            (native.certs, native.errors.len())
+        },
+        thread::sleep,
+        TLS_ROOT_RETRY_DELAYS,
+    )
+}
+
+fn load_platform_root_store_with<Load, Sleep>(
+    mut load: Load,
+    mut sleep: Sleep,
+    retry_delays: &[Duration],
+) -> Result<RootCertStore>
+where
+    Load: FnMut() -> (Vec<CertificateDer<'static>>, usize),
+    Sleep: FnMut(Duration),
+{
+    let mut attempt = 1;
+    loop {
+        let (certs, load_error_count) = load();
+        match root_store_from_native_certs(certs, load_error_count) {
+            Ok(roots) => return Ok(roots),
+            Err(error) => match retry_delays.get(attempt - 1) {
+                Some(delay) => {
+                    sleep(*delay);
+                    attempt += 1;
+                }
+                None => {
+                    return Err(error).with_context(|| {
+                        format!("load platform TLS roots after {attempt} attempts")
+                    });
+                }
+            },
+        }
+    }
 }
 
 fn root_store_from_native_certs(
@@ -60,6 +113,7 @@ fn root_store_from_native_certs(
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::time::Duration;
 
     use http_body_util::Empty;
     use hyper::{Request, body::Bytes};
@@ -70,7 +124,10 @@ mod tests {
 
     use rustls::pki_types::CertificateDer;
 
-    use super::{codex_http_connector, codex_websocket_connector, root_store_from_native_certs};
+    use super::{
+        TLS_ROOT_RETRY_DELAYS, codex_http_connector, codex_websocket_connector,
+        load_platform_root_store_with, root_store_from_native_certs,
+    };
 
     #[test]
     fn websocket_root_store_rejects_no_native_certificates() {
@@ -111,6 +168,82 @@ mod tests {
         )
         .unwrap();
         assert_eq!(roots.len(), 1);
+    }
+
+    #[test]
+    fn websocket_root_store_retries_until_platform_roots_are_available() {
+        let native = rustls_native_certs::load_native_certs();
+        let valid = native
+            .certs
+            .into_iter()
+            .find(|cert| {
+                let mut roots = rustls::RootCertStore::empty();
+                roots.add(cert.clone()).is_ok()
+            })
+            .expect("test platform should provide at least one usable TLS root");
+        let mut loads = 0;
+        let mut sleeps = Vec::new();
+        let roots = load_platform_root_store_with(
+            || {
+                loads += 1;
+                if loads < 3 {
+                    (Vec::new(), loads)
+                } else {
+                    (vec![valid.clone()], 0)
+                }
+            },
+            |delay| sleeps.push(delay),
+            &[
+                Duration::from_millis(10),
+                Duration::from_millis(20),
+                Duration::from_millis(40),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(loads, 3);
+        assert_eq!(
+            sleeps,
+            [Duration::from_millis(10), Duration::from_millis(20)]
+        );
+        assert_eq!(roots.len(), 1);
+    }
+
+    #[test]
+    fn websocket_root_store_fails_after_bounded_retries() {
+        let mut loads = 0;
+        let mut sleeps = Vec::new();
+        let error = load_platform_root_store_with(
+            || {
+                loads += 1;
+                (Vec::new(), loads)
+            },
+            |delay| sleeps.push(delay),
+            &[Duration::from_millis(10), Duration::from_millis(20)],
+        )
+        .unwrap_err();
+
+        assert_eq!(loads, 3);
+        assert_eq!(
+            sleeps,
+            [Duration::from_millis(10), Duration::from_millis(20)]
+        );
+        assert_eq!(
+            error.to_string(),
+            "load platform TLS roots after 3 attempts"
+        );
+        assert_eq!(
+            error.root_cause().to_string(),
+            "load platform TLS roots: no usable certificates (3 load errors, 0 parse errors)"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn websocket_root_store_retry_budget_stays_below_service_ready_timeout() {
+        let total: Duration = TLS_ROOT_RETRY_DELAYS.iter().sum();
+        assert_eq!(total, Duration::from_millis(7_750));
+        assert!(total < Duration::from_secs(20));
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -322,7 +455,9 @@ mod tests {
     }
 
     fn parse_u16_list(data: &[u8]) -> Vec<u16> {
-        data.chunks_exact(2)
+        data.as_chunks::<2>()
+            .0
+            .iter()
             .map(|pair| u16::from_be_bytes([pair[0], pair[1]]))
             .collect()
     }


### PR DESCRIPTION
Adds an idempotent service start command and clearer launchd diagnostics.

Retries transient macOS TLS-root initialization during login startup, automatically reconciles quota resets without process restarts, and exposes account cooldown state in the CLI and menu.

Validated with the Rust and Swift test suites plus strict Clippy.