### PR TITLE
Release 0.9.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comradex"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comradex"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "A bounded, sticky account-pool router for native Codex traffic"


### PR DESCRIPTION
Bumps Comradex to 0.9.12 for the service and quota recovery release.