### PR TITLE
Prevent proxy capacity exhaustion and hangs

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -40,6 +40,16 @@ pub const PROACTIVE_REFRESH_INTERVAL_SECONDS: u64 = 60;
 /// bounds both lock contention and OAuth I/O so one stalled account cannot block later accounts
 /// or keep the next scheduled sweep waiting indefinitely.
 pub const PROACTIVE_REFRESH_ACCOUNT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Request-time credential recovery must not consume global request capacity indefinitely while
+/// another task or process owns the managed home.
+pub const REQUEST_AUTH_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+/// Includes DNS, TCP/TLS connection establishment, request upload, and response headers.
+pub const OAUTH_RESPONSE_HEADERS_TIMEOUT: Duration = Duration::from_secs(15);
+/// Maximum silence between response body frames. The size limit below remains an independent
+/// bound for peers that continuously trickle data.
+pub const OAUTH_RESPONSE_BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Caps the complete OAuth exchange even when every individual stage continues making progress.
+pub const OAUTH_TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_REFRESH_RESPONSE_BYTES: usize = 1024 * 1024;
 const DEFAULT_OAUTH_EXPIRES_IN_SECONDS: u64 = 60 * 60;
 const MAX_OAUTH_EXPIRES_IN_SECONDS: u64 = 24 * 60 * 60;
@@ -57,6 +67,26 @@ pub struct Resolver {
     client: AuthClient,
     locks: HashMap<PathBuf, Arc<Mutex<()>>>,
     refresh_url: hyper::Uri,
+    timeouts: AuthTimeouts,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AuthTimeouts {
+    lock: Duration,
+    oauth_headers: Duration,
+    oauth_body_idle: Duration,
+    oauth_total: Duration,
+}
+
+impl Default for AuthTimeouts {
+    fn default() -> Self {
+        Self {
+            lock: REQUEST_AUTH_LOCK_TIMEOUT,
+            oauth_headers: OAUTH_RESPONSE_HEADERS_TIMEOUT,
+            oauth_body_idle: OAUTH_RESPONSE_BODY_IDLE_TIMEOUT,
+            oauth_total: OAUTH_TOTAL_TIMEOUT,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +153,7 @@ impl Resolver {
             client: Client::builder(TokioExecutor::new()).build(https),
             locks,
             refresh_url: REFRESH_URL.parse().expect("static refresh URL is valid"),
+            timeouts: AuthTimeouts::default(),
         }
     }
 
@@ -136,14 +167,7 @@ impl Resolver {
             AccountConfig::CodexHome { path } => {
                 let document = read_auth(&path.join("auth.json"))?;
                 if access_token_needs_refresh(&document.value) {
-                    let lock = self.lock(path)?;
-                    let _guard = lock.lock().await;
-                    let _home_guard = HomeAuthLock::acquire_async(path).await?;
-                    let current = read_auth(&path.join("auth.json"))?;
-                    if access_token_needs_refresh(&current.value) {
-                        return self.refresh(path, current, unix_now()).await;
-                    }
-                    return Ok(current.credentials);
+                    return self.spawn_request_refresh(path, None).await;
                 }
                 Ok(document.credentials)
             }
@@ -158,16 +182,9 @@ impl Resolver {
         let AccountConfig::CodexHome { path } = account else {
             return Ok(None);
         };
-        let lock = self.lock(path)?;
-        let _guard = lock.lock().await;
-        let _home_guard = HomeAuthLock::acquire_async(path).await?;
-        let current = read_auth(&path.join("auth.json"))?;
-        if auth_failure_recovery(&current.credentials, previous)
-            == AuthFailureRecovery::ReuseCurrent
-        {
-            return Ok(Some(current.credentials));
-        }
-        self.refresh(path, current, unix_now()).await.map(Some)
+        self.spawn_request_refresh(path, Some(previous.clone()))
+            .await
+            .map(Some)
     }
 
     /// Refresh a managed account only when its access-token JWT is within the documented safety
@@ -181,16 +198,7 @@ impl Resolver {
         let AccountConfig::CodexHome { path } = account else {
             return Ok(None);
         };
-        let lock = self.lock(path)?;
-        let _guard = lock.lock().await;
-        let _home_guard = HomeAuthLock::acquire_async(path).await?;
-        let current = read_auth(&path.join("auth.json"))?;
-        if !access_token_needs_refresh_at(&current.value, now) {
-            return Ok(Some(ProactiveRefresh::Fresh));
-        }
-        self.refresh(path, current, now)
-            .await
-            .map(|_| Some(ProactiveRefresh::Refreshed))
+        self.spawn_proactive_refresh(path, now).await.map(Some)
     }
 
     /// Run a bounded pass over managed accounts. Every result is retained independently so one
@@ -246,29 +254,113 @@ impl Resolver {
             .with_context(|| format!("no resolver lock for codex_home {}", identity.display()))
     }
 
-    async fn refresh(
+    /// Run request-time refresh independently of the waiting caller. If the caller disconnects
+    /// after the OAuth server rotates its refresh token, the exchange still reaches the guarded
+    /// compare-and-swap write instead of abandoning the new token and poisoning later refreshes.
+    async fn spawn_request_refresh(
         &self,
         home: &Path,
-        mut document: AuthDocument,
-        now: u64,
+        failed: Option<Credentials>,
     ) -> Result<Credentials> {
-        let refresh_token = lookup(&document.value, &["tokens", "refresh_token"])
-            .filter(|value| !value.is_empty())
-            .context("Codex auth has no refresh token")?
-            .to_owned();
-        let body = Bytes::from(serde_json::to_vec(&json!({
-            "client_id": CLIENT_ID,
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-        }))?);
-        let request = Request::post(self.refresh_url.clone())
-            .header(CONTENT_TYPE, "application/json")
-            .body(Full::new(body))?;
-        let response = self.client.request(request).await?;
+        let home = home.to_owned();
+        let lock = self.lock(&home)?;
+        let client = self.client.clone();
+        let refresh_url = self.refresh_url.clone();
+        let timeouts = self.timeouts;
+        tokio::spawn(async move {
+            let _guard = tokio::time::timeout(timeouts.lock, lock.lock_owned())
+                .await
+                .with_context(|| {
+                    format!(
+                        "timed out after {} ms waiting for in-process auth lock {}",
+                        timeouts.lock.as_millis(),
+                        home.display()
+                    )
+                })?;
+            let _home_guard =
+                HomeAuthLock::acquire_async_with_timeout(&home, timeouts.lock).await?;
+            let current = read_auth(&home.join("auth.json"))?;
+            if let Some(failed) = failed.as_ref() {
+                if auth_failure_recovery(&current.credentials, failed)
+                    == AuthFailureRecovery::ReuseCurrent
+                {
+                    return Ok(current.credentials);
+                }
+            } else if !access_token_needs_refresh(&current.value) {
+                return Ok(current.credentials);
+            }
+            refresh_with(&client, &refresh_url, &home, current, unix_now(), timeouts).await
+        })
+        .await
+        .context("request-time auth refresh task failed")?
+    }
+
+    /// Keep a proactive OAuth exchange alive if its sweep deadline expires or shutdown cancels
+    /// the waiter. The bounded worker must either persist/CAS-reconcile a rotated token or fail on
+    /// its own lock/network deadline.
+    async fn spawn_proactive_refresh(&self, home: &Path, now: u64) -> Result<ProactiveRefresh> {
+        let home = home.to_owned();
+        let lock = self.lock(&home)?;
+        let client = self.client.clone();
+        let refresh_url = self.refresh_url.clone();
+        let timeouts = self.timeouts;
+        tokio::spawn(async move {
+            let _guard = tokio::time::timeout(timeouts.lock, lock.lock_owned())
+                .await
+                .with_context(|| {
+                    format!(
+                        "timed out after {} ms waiting for in-process auth lock {}",
+                        timeouts.lock.as_millis(),
+                        home.display()
+                    )
+                })?;
+            let _home_guard =
+                HomeAuthLock::acquire_async_with_timeout(&home, timeouts.lock).await?;
+            let current = read_auth(&home.join("auth.json"))?;
+            if !access_token_needs_refresh_at(&current.value, now) {
+                return Ok(ProactiveRefresh::Fresh);
+            }
+            refresh_with(&client, &refresh_url, &home, current, now, timeouts).await?;
+            Ok(ProactiveRefresh::Refreshed)
+        })
+        .await
+        .context("proactive auth refresh task failed")?
+    }
+}
+
+async fn refresh_with(
+    client: &AuthClient,
+    refresh_url: &hyper::Uri,
+    home: &Path,
+    mut document: AuthDocument,
+    now: u64,
+    timeouts: AuthTimeouts,
+) -> Result<Credentials> {
+    let original = document.value.clone();
+    let refresh_token = lookup(&original, &["tokens", "refresh_token"])
+        .filter(|value| !value.is_empty())
+        .context("Codex auth has no refresh token")?
+        .to_owned();
+    let body = Bytes::from(serde_json::to_vec(&json!({
+        "client_id": CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }))?);
+    let request = Request::post(refresh_url.clone())
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(body))?;
+    let exchange = async {
+        let response = tokio::time::timeout(timeouts.oauth_headers, client.request(request))
+            .await
+            .context("OAuth refresh timed out waiting for response headers")??;
         let status = response.status();
         let mut response_body = response.into_body();
         let mut bytes = Vec::new();
-        while let Some(frame) = response_body.frame().await {
+        loop {
+            let frame = tokio::time::timeout(timeouts.oauth_body_idle, response_body.frame())
+                .await
+                .context("OAuth refresh response body became idle")?;
+            let Some(frame) = frame else { break };
             let frame = frame?;
             let Ok(data) = frame.into_data() else {
                 continue;
@@ -298,47 +390,57 @@ impl Resolver {
             bail!("OAuth refresh failed with HTTP {status} ({code})")
         }
         let refreshed: Value = serde_json::from_slice(&bytes).context("parse OAuth refresh")?;
-        let access_token = refreshed
-            .get("access_token")
-            .and_then(Value::as_str)
-            .filter(|token| !token.is_empty())
-            .context("OAuth refresh response has no access token")?;
-        let expires_at = now.saturating_add(validated_expires_in(&refreshed));
-        let tokens = document
-            .value
-            .get_mut("tokens")
-            .and_then(Value::as_object_mut)
-            .context("Codex auth tokens are not an object")?;
-        tokens.insert(
-            "access_token".to_owned(),
-            Value::String(access_token.to_owned()),
-        );
-        tokens.insert(
-            ACCESS_TOKEN_EXPIRES_AT_KEY.to_owned(),
-            Value::Number(expires_at.into()),
-        );
-        for key in ["id_token", "refresh_token"] {
-            if let Some(value) = refreshed.get(key).and_then(Value::as_str) {
-                tokens.insert(key.to_owned(), Value::String(value.to_owned()));
-            }
+        Result::<Value>::Ok(refreshed)
+    };
+    let refreshed = tokio::time::timeout(timeouts.oauth_total, exchange)
+        .await
+        .context("OAuth refresh exceeded total deadline")??;
+    let access_token = refreshed
+        .get("access_token")
+        .and_then(Value::as_str)
+        .filter(|token| !token.is_empty())
+        .context("OAuth refresh response has no access token")?;
+    let expires_at = now.saturating_add(validated_expires_in(&refreshed));
+    let tokens = document
+        .value
+        .get_mut("tokens")
+        .and_then(Value::as_object_mut)
+        .context("Codex auth tokens are not an object")?;
+    tokens.insert(
+        "access_token".to_owned(),
+        Value::String(access_token.to_owned()),
+    );
+    tokens.insert(
+        ACCESS_TOKEN_EXPIRES_AT_KEY.to_owned(),
+        Value::Number(expires_at.into()),
+    );
+    for key in ["id_token", "refresh_token"] {
+        if let Some(value) = refreshed.get(key).and_then(Value::as_str) {
+            tokens.insert(key.to_owned(), Value::String(value.to_owned()));
         }
-        if let Some(account_id) = tokens
-            .get("id_token")
-            .and_then(Value::as_str)
-            .and_then(jwt_account_id)
-        {
-            tokens.insert("account_id".to_owned(), Value::String(account_id));
-        }
-        let refreshed_at = chrono::DateTime::<Utc>::from_timestamp(now as i64, 0)
-            .unwrap_or_else(Utc::now)
-            .to_rfc3339();
-        document.value["last_refresh"] = Value::String(refreshed_at);
-        atomic_write_auth(
-            &home.join("auth.json"),
-            &serde_json::to_vec_pretty(&document.value)?,
-        )?;
-        credentials_from_value(&document.value)
     }
+    if let Some(account_id) = tokens
+        .get("id_token")
+        .and_then(Value::as_str)
+        .and_then(jwt_account_id)
+    {
+        tokens.insert("account_id".to_owned(), Value::String(account_id));
+    }
+    let refreshed_at = chrono::DateTime::<Utc>::from_timestamp(now as i64, 0)
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339();
+    document.value["last_refresh"] = Value::String(refreshed_at);
+    // `codex login` does not honor Comradex's advisory lock. Re-read immediately before the
+    // atomic replace and never overwrite any external writer's newer document.
+    let latest = read_auth(&home.join("auth.json"))?;
+    if latest.value != original {
+        return Ok(latest.credentials);
+    }
+    atomic_write_auth(
+        &home.join("auth.json"),
+        &serde_json::to_vec_pretty(&document.value)?,
+    )?;
+    credentials_from_value(&document.value)
 }
 
 struct AuthDocument {
@@ -529,6 +631,14 @@ mod tests {
     }
 
     fn test_resolver(homes: &[&Path], refresh_url: hyper::Uri) -> Resolver {
+        test_resolver_with_timeouts(homes, refresh_url, AuthTimeouts::default())
+    }
+
+    fn test_resolver_with_timeouts(
+        homes: &[&Path],
+        refresh_url: hyper::Uri,
+        timeouts: AuthTimeouts,
+    ) -> Resolver {
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_webpki_roots()
             .https_or_http()
@@ -547,6 +657,7 @@ mod tests {
             client: Client::builder(TokioExecutor::new()).build(https),
             locks,
             refresh_url,
+            timeouts,
         }
     }
 
@@ -583,6 +694,69 @@ mod tests {
             std::future::pending::<()>().await;
         });
         format!("http://{address}/oauth/token").parse().unwrap()
+    }
+
+    async fn serve_paused_refresh_body() -> hyper::Uri {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 1024\r\n\r\n{",
+                )
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+        format!("http://{address}/oauth/token").parse().unwrap()
+    }
+
+    async fn serve_controlled_refresh_response(
+        body: Value,
+    ) -> (
+        hyper::Uri,
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let body = serde_json::to_vec(&body).unwrap();
+        let (request_seen_tx, request_seen_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            let _ = request_seen_tx.send(());
+            let _ = release_rx.await;
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(&body).await.unwrap();
+        });
+        (
+            format!("http://{address}/oauth/token").parse().unwrap(),
+            request_seen_rx,
+            release_tx,
+        )
+    }
+
+    fn short_timeouts() -> AuthTimeouts {
+        AuthTimeouts {
+            lock: Duration::from_millis(50),
+            oauth_headers: Duration::from_millis(100),
+            oauth_body_idle: Duration::from_millis(100),
+            oauth_total: Duration::from_millis(500),
+        }
     }
 
     fn credentials(token: &str) -> Credentials {
@@ -796,12 +970,198 @@ mod tests {
         assert!(matches!(results[1].1, Ok(ProactiveRefresh::Fresh)));
         let lock = resolver.lock(&stalled_home).unwrap();
         assert!(
-            lock.try_lock().is_ok(),
-            "timeout cancellation must release the managed-home lock"
+            lock.try_lock().is_err(),
+            "the sweep timeout must detach rather than cancel the in-flight OAuth exchange"
         );
         assert!(
-            HomeAuthLock::try_acquire(&stalled_home).unwrap().is_some(),
-            "timeout cancellation must release the cross-process auth lock"
+            HomeAuthLock::try_acquire(&stalled_home).unwrap().is_none(),
+            "the detached exchange must retain exclusive ownership until its own deadline"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_time_refresh_bounds_cross_process_lock_wait() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        write_managed_auth(&home, &jwt(now + 60, "stale"));
+        let resolver = test_resolver_with_timeouts(
+            &[&home],
+            "http://127.0.0.1:9/oauth/token".parse().unwrap(),
+            short_timeouts(),
+        );
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        let login_guard = HomeAuthLock::acquire(&home).unwrap();
+
+        let error = resolver
+            .resolve(&account, &HeaderMap::new())
+            .await
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("timed out"));
+        drop(login_guard);
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        assert!(
+            HomeAuthLock::try_acquire(&home).unwrap().is_some(),
+            "the timed-out detached refresh must not later acquire the home"
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth_response_headers_and_body_idle_are_independently_bounded() {
+        let now = unix_now();
+        for (label, refresh_url, expected) in [
+            (
+                "headers",
+                serve_paused_refresh_response().await,
+                "response headers",
+            ),
+            (
+                "body",
+                serve_paused_refresh_body().await,
+                "response body became idle",
+            ),
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            let home = directory.path().join(label);
+            write_managed_auth(&home, &jwt(now + 60, label));
+            let resolver = test_resolver_with_timeouts(&[&home], refresh_url, short_timeouts());
+            let account = AccountConfig::CodexHome { path: home };
+
+            let error = resolver
+                .resolve(&account, &HeaderMap::new())
+                .await
+                .unwrap_err();
+
+            assert!(
+                format!("{error:#}").contains(expected),
+                "{label} timeout returned an unexpected error: {error:#}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn caller_cancellation_does_not_abandon_rotated_refresh_token() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        write_managed_auth(&home, &jwt(now + 60, "stale"));
+        let replacement = jwt(now + 7_200, "replacement");
+        let (refresh_url, request_seen, release) = serve_controlled_refresh_response(json!({
+            "access_token": replacement,
+            "refresh_token": "rotated-refresh-token"
+        }))
+        .await;
+        let resolver = Arc::new(test_resolver(&[&home], refresh_url));
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        let caller = {
+            let resolver = resolver.clone();
+            tokio::spawn(async move { resolver.resolve(&account, &HeaderMap::new()).await })
+        };
+        request_seen.await.unwrap();
+
+        caller.abort();
+        release.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let written = read_auth(&home.join("auth.json")).unwrap();
+                if lookup(&written.value, &["tokens", "refresh_token"])
+                    == Some("rotated-refresh-token")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("detached refresh should persist the rotated token");
+    }
+
+    #[tokio::test]
+    async fn proactive_cancellation_persists_rotated_token_without_lock_convoy() {
+        let now = 1_000_000;
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        write_managed_auth(&home, &jwt(now + 60, "stale"));
+        let replacement = jwt(now + 7_200, "replacement");
+        let (refresh_url, request_seen, release) = serve_controlled_refresh_response(json!({
+            "access_token": replacement,
+            "refresh_token": "proactively-rotated-refresh-token"
+        }))
+        .await;
+        let resolver = Arc::new(test_resolver(&[&home], refresh_url));
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        let sweep_waiter = {
+            let resolver = resolver.clone();
+            let account = account.clone();
+            tokio::spawn(async move { resolver.proactive_refresh_at(&account, now).await })
+        };
+        request_seen.await.unwrap();
+
+        sweep_waiter.abort();
+        release.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let written = read_auth(&home.join("auth.json")).unwrap();
+                if lookup(&written.value, &["tokens", "refresh_token"])
+                    == Some("proactively-rotated-refresh-token")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("canceled sweep waiter must not abandon the rotated token");
+
+        let next = tokio::time::timeout(
+            Duration::from_millis(250),
+            resolver.proactive_refresh_at(&account, now),
+        )
+        .await
+        .expect("completed detached worker must release the per-home locks")
+        .unwrap();
+        assert_eq!(next, Some(ProactiveRefresh::Fresh));
+    }
+
+    #[tokio::test]
+    async fn external_auth_writer_wins_compare_and_swap_race() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let stale = jwt(now + 60, "stale");
+        write_managed_auth(&home, &stale);
+        let oauth_replacement = jwt(now + 7_200, "oauth-replacement");
+        let (refresh_url, request_seen, release) = serve_controlled_refresh_response(json!({
+            "access_token": oauth_replacement,
+            "refresh_token": "oauth-rotated-refresh-token"
+        }))
+        .await;
+        let resolver = Arc::new(test_resolver(&[&home], refresh_url));
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        let refresh = {
+            let resolver = resolver.clone();
+            tokio::spawn(async move { resolver.resolve(&account, &HeaderMap::new()).await })
+        };
+        request_seen.await.unwrap();
+        let external = jwt(now + 8_000, "external-writer");
+        write_managed_auth(&home, &external);
+        release.send(()).unwrap();
+
+        let resolved = refresh.await.unwrap().unwrap();
+        let written = read_auth(&home.join("auth.json")).unwrap();
+
+        assert_eq!(resolved.authorization, format!("Bearer {external}"));
+        assert_eq!(
+            written.credentials.authorization,
+            format!("Bearer {external}")
+        );
+        assert_eq!(
+            lookup(&written.value, &["tokens", "refresh_token"]),
+            Some("test-refresh-token"),
+            "the OAuth result must not overwrite an externally replaced auth document"
         );
     }
 

--- a/src/auth_lock.rs
+++ b/src/auth_lock.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Context, Result};
 
 const LOCK_FILE_NAME: &str = ".comradex-auth.lock";
+const LOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
 
 /// A process-wide advisory lock for a managed CODEX_HOME credential file.
 ///
@@ -33,8 +34,26 @@ impl HomeAuthLock {
             if let Some(lock) = Self::try_acquire(home)? {
                 return Ok(lock);
             }
-            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            tokio::time::sleep(LOCK_POLL_INTERVAL).await;
         }
+    }
+
+    /// Wait for the file lock for at most `timeout`. Unlike wrapping the
+    /// blocking lock in `spawn_blocking`, timing this polling loop out cannot
+    /// leave a detached task that later acquires the credential lock.
+    pub async fn acquire_async_with_timeout(
+        home: &Path,
+        timeout: std::time::Duration,
+    ) -> Result<Self> {
+        tokio::time::timeout(timeout, Self::acquire_async(home))
+            .await
+            .with_context(|| {
+                format!(
+                    "timed out after {} ms waiting for managed auth lock {}",
+                    timeout.as_millis(),
+                    home.display()
+                )
+            })?
     }
 
     /// Attempt to own this managed home without waiting.
@@ -152,5 +171,25 @@ mod tests {
                 .mode();
             assert_eq!(mode & 0o777, 0o600);
         }
+    }
+
+    #[tokio::test]
+    async fn bounded_async_acquire_times_out_without_late_lock_ownership() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("account");
+        let first = HomeAuthLock::acquire(&home).unwrap();
+
+        let error =
+            HomeAuthLock::acquire_async_with_timeout(&home, std::time::Duration::from_millis(40))
+                .await
+                .unwrap_err();
+        assert!(format!("{error:#}").contains("timed out"));
+
+        drop(first);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            HomeAuthLock::try_acquire(&home).unwrap().is_some(),
+            "a timed-out waiter must not acquire the lock later"
+        );
     }
 }

--- a/src/codex_process.rs
+++ b/src/codex_process.rs
@@ -6,14 +6,14 @@
 //! desktop app respawns its app-server after termination.
 //!
 //! Matching is intentionally narrow (same contract as OpenCodex): the process
-//! must be a Codex binary whose subcommand is `app-server`, or a
-//! `codex-code-mode-host` entrypoint. Never a broad `*codex*` pattern that
-//! would hit unrelated tools. Only current-user processes are listed, only
-//! SIGTERM is sent (never SIGKILL), and PIDs are re-resolved with a
-//! pid+command-line identity check immediately before signaling so a recycled
-//! PID is never killed.
+//! must be a Codex binary (or its immediate npm/Node entrypoint) whose
+//! subcommand is `app-server`, or a `codex-code-mode-host` entrypoint. Never a
+//! broad `*codex*` pattern that would hit unrelated tools. Only current-user
+//! processes are listed, only SIGTERM is sent (never SIGKILL), and PIDs are
+//! re-resolved with a pid+command-line identity check immediately before
+//! signaling so a recycled PID is never killed.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 
@@ -48,6 +48,7 @@ pub trait ProcessControl {
     fn list(&self) -> Result<Vec<CodexProcess>>;
     fn send_sigterm(&self, pid: i32) -> std::io::Result<()>;
     fn is_alive(&self, pid: i32) -> bool;
+    fn now(&self) -> Instant;
     fn sleep(&self, duration: Duration);
 }
 
@@ -93,6 +94,10 @@ impl ProcessControl for SystemProcesses {
         false
     }
 
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+
     fn sleep(&self, duration: Duration) {
         std::thread::sleep(duration);
     }
@@ -132,54 +137,89 @@ fn list_current_user_snapshots() -> Result<Vec<(i32, String)>> {
 /// Send SIGTERM to matched processes and wait briefly; never escalates to SIGKILL.
 pub fn restart(processes: &[CodexProcess], control: &dyn ProcessControl) -> RestartOutcome {
     let mut outcome = RestartOutcome::default();
-    // Re-resolve immediately before signaling: a PID must still belong to the
-    // same command line as the original match, otherwise it is skipped.
-    let live: std::collections::BTreeMap<i32, CodexProcess> = control
-        .list()
-        .unwrap_or_default()
-        .into_iter()
-        .map(|process| (process.pid, process))
-        .collect();
     let mut signaled = Vec::new();
     for process in processes {
-        match live.get(&process.pid) {
-            Some(current) if current.identity() == process.identity() => {
+        // Re-resolve each target immediately before its signal. A single
+        // snapshot for the whole batch leaves a race where an earlier signal
+        // gives a later PID time to exit and be recycled.
+        match current_process(control, process.pid) {
+            Ok(Some(current)) if current.identity() == process.identity() => {
                 match control.send_sigterm(process.pid) {
-                    Ok(()) => signaled.push(process.pid),
-                    Err(error) if control.is_alive(process.pid) => {
+                    Ok(()) => signaled.push(process.clone()),
+                    Err(error) => {
                         outcome.failed.push((process.pid, error.to_string()));
-                        outcome.surviving.push(process.pid);
+                        // Report a survivor only when the same process identity
+                        // is still present. `kill(pid, 0)` alone is unsafe here:
+                        // it also succeeds for a replacement process.
+                        match current_process(control, process.pid) {
+                            Ok(Some(current)) if current.identity() == process.identity() => {
+                                outcome.surviving.push(process.pid);
+                            }
+                            Ok(_) => outcome.stopped.push(process.pid),
+                            Err(_) => {}
+                        }
                     }
-                    Err(_) => outcome.stopped.push(process.pid),
                 }
             }
-            _ => {
+            Ok(_) => {
                 // Original target exited (or the PID was recycled); never
                 // signal a replacement process.
-                if !control.is_alive(process.pid) {
-                    outcome.stopped.push(process.pid);
-                }
+                outcome.stopped.push(process.pid);
             }
+            Err(error) => outcome.failed.push((
+                process.pid,
+                format!("revalidate process identity before SIGTERM: {error}"),
+            )),
         }
     }
-    // Shared ~2s budget so N survivors wait ~2s total, not N x 2s.
-    let mut polls_remaining = 40u32;
+
+    // Poll the entire set together under one ~2s deadline. This bounds total
+    // restart latency independently of process count and avoids ever widening
+    // the target set or escalating to SIGKILL.
     let poll = Duration::from_millis(50);
-    for pid in signaled {
-        loop {
-            if !control.is_alive(pid) {
-                outcome.stopped.push(pid);
+    let deadline = control.now() + Duration::from_secs(2);
+    let mut pending = signaled;
+    loop {
+        if let Ok(live) = control.list() {
+            pending.retain(|target| {
+                let still_same_process = live
+                    .iter()
+                    .any(|current| current.identity() == target.identity());
+                if !still_same_process {
+                    outcome.stopped.push(target.pid);
+                }
+                still_same_process
+            });
+            if pending.is_empty() {
                 break;
             }
-            if polls_remaining == 0 {
-                outcome.surviving.push(pid);
-                break;
+        }
+        let now = control.now();
+        if now >= deadline {
+            break;
+        }
+        control.sleep(poll.min(deadline.saturating_duration_since(now)));
+    }
+    for target in pending {
+        match current_process(control, target.pid) {
+            Ok(Some(current)) if current.identity() == target.identity() => {
+                outcome.surviving.push(target.pid);
             }
-            polls_remaining -= 1;
-            control.sleep(poll);
+            Ok(_) => outcome.stopped.push(target.pid),
+            Err(error) => outcome.failed.push((
+                target.pid,
+                format!("verify process after SIGTERM deadline: {error}"),
+            )),
         }
     }
     outcome
+}
+
+fn current_process(control: &dyn ProcessControl, pid: i32) -> Result<Option<CodexProcess>> {
+    Ok(control
+        .list()?
+        .into_iter()
+        .find(|process| process.pid == pid))
 }
 
 /// Codex global options that take a following value when written without `=`.
@@ -218,12 +258,21 @@ pub fn is_codex_app_server_command_line(command_line: &str) -> bool {
     if is_code_mode_host_process(&tokens) {
         return true;
     }
-    // Require Codex as argv0 so later-argument occurrences stay unmatched
-    // (e.g. `node worker.js codex app-server`).
-    if !is_codex_executable_token(&tokens[0]) {
+    // Codex is either argv0 or the immediate script owned by a Node runtime.
+    // Requiring the entrypoint at argv1 keeps later-argument occurrences
+    // unmatched (e.g. `node worker.js codex app-server`).
+    let codex_index = if is_codex_executable_token(&tokens[0]) {
+        0
+    } else if is_node_token(&tokens[0])
+        && tokens
+            .get(1)
+            .is_some_and(|token| is_codex_node_entrypoint_token(token))
+    {
+        1
+    } else {
         return false;
-    }
-    let mut index = 1;
+    };
+    let mut index = codex_index + 1;
     while index < tokens.len() {
         if tokens[index].starts_with('-') {
             index = advance_past_global_option(&tokens, index);
@@ -302,6 +351,19 @@ fn is_codex_executable_token(token: &str) -> bool {
         })
 }
 
+fn is_node_token(token: &str) -> bool {
+    matches!(token_basename(token).as_str(), "node" | "node.exe")
+}
+
+/// npm's Codex launcher may remain visible as `node .../codex[.js]` rather
+/// than `codex`. Keep this basename check as narrow as the native matcher.
+fn is_codex_node_entrypoint_token(token: &str) -> bool {
+    matches!(
+        token_basename(token).as_str(),
+        "codex" | "codex.js" | "codex.cmd"
+    )
+}
+
 fn is_code_mode_host_token(token: &str) -> bool {
     matches!(
         token_basename(token).as_str(),
@@ -359,7 +421,7 @@ fn advance_past_global_option(tokens: &[String], index: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
 
     #[test]
     fn matches_only_real_app_server_command_lines() {
@@ -371,6 +433,8 @@ mod tests {
             "codex --profile work APP-SERVER",
             "codex-aarch64-apple-darwin app-server",
             "codex-x86_64-unknown-linux-musl app-server",
+            "node /opt/homebrew/bin/codex app-server",
+            "node /opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js app-server",
             "codex-code-mode-host --port 4000",
             "node /opt/codex-code-mode-host serve",
         ] {
@@ -382,6 +446,8 @@ mod tests {
             "codex exec --json",
             "codex resume app-server",
             "node worker.js codex app-server",
+            "node /tmp/not-codex.js app-server",
+            "bun /opt/homebrew/bin/codex app-server",
             "hermes-codex-bridge-mcp app-server",
             "opencodex app-server",
             "codex-wrapper app-server",
@@ -405,6 +471,11 @@ mod tests {
     struct FakeControl {
         live: RefCell<Vec<CodexProcess>>,
         term_error: Option<i32>,
+        terminate_on_term: bool,
+        replace_on_term: Option<(i32, CodexProcess)>,
+        signaled: RefCell<Vec<i32>>,
+        sleeps: Cell<u32>,
+        now: Cell<Instant>,
     }
 
     impl ProcessControl for FakeControl {
@@ -412,16 +483,32 @@ mod tests {
             Ok(self.live.borrow().clone())
         }
         fn send_sigterm(&self, pid: i32) -> std::io::Result<()> {
+            self.signaled.borrow_mut().push(pid);
             if self.term_error == Some(pid) {
                 return Err(std::io::Error::other("operation not permitted"));
             }
-            self.live.borrow_mut().retain(|process| process.pid != pid);
+            let mut live = self.live.borrow_mut();
+            if self.terminate_on_term {
+                live.retain(|process| process.pid != pid);
+            }
+            if let Some((trigger, replacement)) = &self.replace_on_term
+                && *trigger == pid
+            {
+                live.retain(|process| process.pid != replacement.pid);
+                live.push(replacement.clone());
+            }
             Ok(())
         }
         fn is_alive(&self, pid: i32) -> bool {
             self.live.borrow().iter().any(|process| process.pid == pid)
         }
-        fn sleep(&self, _duration: Duration) {}
+        fn now(&self) -> Instant {
+            self.now.get()
+        }
+        fn sleep(&self, duration: Duration) {
+            self.sleeps.set(self.sleeps.get() + 1);
+            self.now.set(self.now.get() + duration);
+        }
     }
 
     fn process(pid: i32, command_line: &str) -> CodexProcess {
@@ -439,6 +526,11 @@ mod tests {
                 process(200, "codex app-server"),
             ]),
             term_error: Some(200),
+            terminate_on_term: true,
+            replace_on_term: None,
+            signaled: RefCell::new(Vec::new()),
+            sleeps: Cell::new(0),
+            now: Cell::new(Instant::now()),
         };
         let targets = [
             process(100, "codex app-server"),
@@ -455,11 +547,88 @@ mod tests {
         let control = FakeControl {
             live: RefCell::new(vec![process(100, "codex --profile other app-server")]),
             term_error: None,
+            terminate_on_term: true,
+            replace_on_term: None,
+            signaled: RefCell::new(Vec::new()),
+            sleeps: Cell::new(0),
+            now: Cell::new(Instant::now()),
         };
         let outcome = restart(&[process(100, "codex app-server")], &control);
-        assert!(outcome.stopped.is_empty());
+        assert_eq!(outcome.stopped, vec![100]);
         assert!(outcome.surviving.is_empty());
         assert!(outcome.failed.is_empty());
         assert!(control.is_alive(100));
+        assert!(control.signaled.borrow().is_empty());
+    }
+
+    #[test]
+    fn restart_revalidates_each_identity_immediately_before_signal() {
+        let control = FakeControl {
+            live: RefCell::new(vec![
+                process(100, "codex app-server"),
+                process(200, "codex app-server"),
+            ]),
+            term_error: None,
+            terminate_on_term: true,
+            replace_on_term: Some((100, process(200, "codex --profile replacement app-server"))),
+            signaled: RefCell::new(Vec::new()),
+            sleeps: Cell::new(0),
+            now: Cell::new(Instant::now()),
+        };
+        let outcome = restart(
+            &[
+                process(100, "codex app-server"),
+                process(200, "codex app-server"),
+            ],
+            &control,
+        );
+        assert_eq!(*control.signaled.borrow(), vec![100]);
+        assert_eq!(outcome.stopped, vec![200, 100]);
+        assert!(control.is_alive(200));
+    }
+
+    #[test]
+    fn restart_does_not_report_a_post_signal_replacement_as_a_survivor() {
+        let control = FakeControl {
+            live: RefCell::new(vec![process(100, "codex app-server")]),
+            term_error: None,
+            terminate_on_term: true,
+            replace_on_term: Some((100, process(100, "codex --profile replacement app-server"))),
+            signaled: RefCell::new(Vec::new()),
+            sleeps: Cell::new(0),
+            now: Cell::new(Instant::now()),
+        };
+        let outcome = restart(&[process(100, "codex app-server")], &control);
+        assert_eq!(*control.signaled.borrow(), vec![100]);
+        assert_eq!(outcome.stopped, vec![100]);
+        assert!(outcome.surviving.is_empty());
+        assert!(control.is_alive(100));
+    }
+
+    #[test]
+    fn restart_uses_one_grace_deadline_for_all_survivors() {
+        let started = Instant::now();
+        let control = FakeControl {
+            live: RefCell::new(vec![
+                process(100, "codex app-server"),
+                process(200, "node /opt/bin/codex.js app-server"),
+            ]),
+            term_error: None,
+            terminate_on_term: false,
+            replace_on_term: None,
+            signaled: RefCell::new(Vec::new()),
+            sleeps: Cell::new(0),
+            now: Cell::new(started),
+        };
+        let targets = control.live.borrow().clone();
+        let outcome = restart(&targets, &control);
+        assert_eq!(*control.signaled.borrow(), vec![100, 200]);
+        assert_eq!(control.sleeps.get(), 40);
+        assert_eq!(
+            control.now.get().duration_since(started),
+            Duration::from_secs(2)
+        );
+        assert_eq!(outcome.surviving, vec![100, 200]);
+        assert!(outcome.stopped.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,42 @@ use rand::RngCore;
 use tokio::signal;
 use tracing::{info, warn};
 
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// One process-shutdown budget shared by async cleanup and Tokio runtime
+/// destruction. Calling `begin` more than once never extends the deadline.
+struct ShutdownBudget {
+    timeout: Duration,
+    deadline: Option<tokio::time::Instant>,
+}
+
+impl ShutdownBudget {
+    fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            deadline: None,
+        }
+    }
+
+    fn begin(&mut self) -> tokio::time::Instant {
+        self.begin_at(tokio::time::Instant::now())
+    }
+
+    fn begin_at(&mut self, now: tokio::time::Instant) -> tokio::time::Instant {
+        *self.deadline.get_or_insert(now + self.timeout)
+    }
+
+    fn remaining(&self) -> Duration {
+        self.remaining_at(tokio::time::Instant::now())
+    }
+
+    fn remaining_at(&self, now: tokio::time::Instant) -> Duration {
+        self.deadline
+            .map(|deadline| deadline.saturating_duration_since(now))
+            .unwrap_or(self.timeout)
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "comradex", version, about)]
 struct Cli {
@@ -123,8 +159,22 @@ enum ServiceCommand {
     Restart,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .context("build Tokio runtime")?;
+    let mut shutdown_budget = ShutdownBudget::new(SHUTDOWN_TIMEOUT);
+    let result = runtime.block_on(run(&mut shutdown_budget));
+
+    // Dropping a Tokio runtime can otherwise wait indefinitely for
+    // `spawn_blocking` work. Use whatever remains of the same absolute
+    // shutdown budget used by `serve`'s async cleanup.
+    runtime.shutdown_timeout(shutdown_budget.remaining());
+    result
+}
+
+async fn run(shutdown_budget: &mut ShutdownBudget) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
@@ -148,7 +198,7 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
-        CommandName::Serve => serve(&config_path).await,
+        CommandName::Serve => serve(&config_path, shutdown_budget).await,
         CommandName::Install {
             codex_config,
             listener,
@@ -254,7 +304,7 @@ kind = "inbound"
     Ok(())
 }
 
-async fn serve(path: &Path) -> Result<()> {
+async fn serve(path: &Path, shutdown_budget: &mut ShutdownBudget) -> Result<()> {
     let config_path =
         fs::canonicalize(path).with_context(|| format!("resolve config {}", path.display()))?;
     let config = Arc::new(load_config(path)?);
@@ -288,6 +338,7 @@ async fn serve(path: &Path) -> Result<()> {
     let background_app = app.clone();
     let background = tokio::spawn(async move {
         let mut interval = tokio::time::interval(background_config.snapshot_interval());
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
             if let Err(e) = background_router.affinity.flush().await {
@@ -312,6 +363,7 @@ async fn serve(path: &Path) -> Result<()> {
         let mut interval = tokio::time::interval(Duration::from_secs(
             comradex::auth::PROACTIVE_REFRESH_INTERVAL_SECONDS,
         ));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             interval.tick().await;
             let now = SystemTime::now()
@@ -343,22 +395,61 @@ async fn serve(path: &Path) -> Result<()> {
         }
     };
     info!("shutting down");
+    let shutdown_deadline = shutdown_budget.begin();
     background.abort();
-    let _ = background.await;
     if !control_task.is_finished() {
         control_task.abort();
-        let _ = control_task.await;
     }
     refresh_background.abort();
-    let _ = refresh_background.await;
     tasks.abort_all();
-    while tasks.join_next().await.is_some() {}
-    app.shutdown_connections().await;
-    router.clear_inflight().await;
-    router.affinity.flush().await?;
-    app.flush_file_owners().await?;
-    stats.write(state.join("stats.json"), &router).await?;
+    let shutdown_result = tokio::time::timeout_at(shutdown_deadline, async {
+        let _ = background.await;
+        let _ = control_task.await;
+        let _ = refresh_background.await;
+        while tasks.join_next().await.is_some() {}
+
+        app.shutdown_connections().await;
+        router.clear_inflight().await;
+
+        // Attempt every final snapshot even if an earlier one fails so the
+        // remaining shutdown diagnostics are still as fresh as possible.
+        let mut first_error = None;
+        if let Err(error) = router.affinity.flush().await {
+            warn!(error = %error, "final affinity snapshot failed");
+            first_error = Some(error.context("final affinity snapshot failed"));
+        }
+        if let Err(error) = app.flush_file_owners().await {
+            warn!(error = %error, "final file-owner snapshot failed");
+            if first_error.is_none() {
+                first_error = Some(error.context("final file-owner snapshot failed"));
+            }
+        }
+        if let Err(error) = stats.write(state.join("stats.json"), &router).await {
+            warn!(error = %error, "final stats snapshot failed");
+            if first_error.is_none() {
+                first_error = Some(error.context("final stats snapshot failed"));
+            }
+        }
+        first_error
+    })
+    .await;
+    let shutdown_error = match shutdown_result {
+        Ok(error) => error,
+        Err(_) => {
+            warn!(
+                timeout_seconds = SHUTDOWN_TIMEOUT.as_secs(),
+                "shutdown deadline exceeded; exiting without waiting for remaining cleanup"
+            );
+            Some(anyhow::anyhow!(
+                "shutdown did not complete within {} seconds",
+                SHUTDOWN_TIMEOUT.as_secs()
+            ))
+        }
+    };
     if let Some(error) = listener_error {
+        return Err(error);
+    }
+    if let Some(error) = shutdown_error {
         return Err(error);
     }
     Ok(())
@@ -883,6 +974,29 @@ mod tests {
         .unwrap();
 
         assert!(HomeAuthLock::try_acquire(&home).unwrap().is_some());
+    }
+
+    #[test]
+    fn shutdown_budget_uses_one_absolute_deadline() {
+        let start = tokio::time::Instant::now();
+        let mut budget = ShutdownBudget::new(Duration::from_secs(15));
+
+        assert_eq!(budget.remaining_at(start), Duration::from_secs(15));
+        let deadline = budget.begin_at(start);
+        assert_eq!(deadline, start + Duration::from_secs(15));
+        assert_eq!(
+            budget.begin_at(start + Duration::from_secs(10)),
+            deadline,
+            "starting another shutdown phase must not extend the deadline"
+        );
+        assert_eq!(
+            budget.remaining_at(start + Duration::from_secs(4)),
+            Duration::from_secs(11)
+        );
+        assert_eq!(
+            budget.remaining_at(start + Duration::from_secs(20)),
+            Duration::ZERO
+        );
     }
 
     #[test]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -39,7 +39,7 @@ use hyper_util::{
 };
 use tokio::{
     net::TcpListener,
-    sync::{Mutex as AsyncMutex, Notify, Semaphore, mpsc, oneshot},
+    sync::{Mutex as AsyncMutex, Notify, OwnedSemaphorePermit, Semaphore, mpsc, oneshot},
     task::{AbortHandle, JoinSet},
 };
 use tokio_tungstenite::{
@@ -70,6 +70,11 @@ use websocket_protocol::{
 const FILE_CREATE_RESPONSE_LIMIT: usize = 1024 * 1024;
 const RESPONSES_JSON_RESPONSE_LIMIT: usize = 16 * 1024 * 1024;
 const BRIDGE_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const HTTP_REQUEST_BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const HTTP_RESPONSE_HEADER_TIMEOUT: Duration = Duration::from_secs(30);
+const HTTP_RESPONSE_BODY_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const WEBSOCKET_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(15);
 const UNKNOWN_CONTENT_SNIFF_BYTES: usize = 4 * 1024;
 const SSE_DECODE_SLICE_BYTES: usize = 64 * 1024;
 const MAX_QUEUED_DIRECT_CREATES: usize = 64;
@@ -330,12 +335,106 @@ impl Drop for OpenUpgradeGuard {
     }
 }
 
+struct OpenBridgeSessionGuard(Arc<Stats>);
+
+impl Drop for OpenBridgeSessionGuard {
+    fn drop(&mut self) {
+        self.0.open_bridge_sessions.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
 struct InflightGuard<'a>(&'a AtomicUsize);
 
 impl<'a> InflightGuard<'a> {
     fn new(counter: &'a AtomicUsize) -> Self {
         counter.fetch_add(1, Ordering::Relaxed);
         Self(counter)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CapacityKind {
+    Http,
+    BridgeTurn,
+    UpgradeHandshake,
+}
+
+/// Couples admission to accounting. Dropping a request future, response body, bridge turn, or
+/// handshake releases the permit and every counter exactly once.
+struct CapacityLease {
+    permit: Option<OwnedSemaphorePermit>,
+    stats: Arc<Stats>,
+    kind: CapacityKind,
+    stage_id: u64,
+}
+
+impl CapacityLease {
+    fn new(permit: OwnedSemaphorePermit, stats: Arc<Stats>, kind: CapacityKind) -> Self {
+        stats.inflight_http.fetch_add(1, Ordering::AcqRel);
+        match kind {
+            CapacityKind::Http => {
+                stats.inflight_regular_http.fetch_add(1, Ordering::AcqRel);
+            }
+            CapacityKind::BridgeTurn => {
+                stats.active_bridge_turns.fetch_add(1, Ordering::AcqRel);
+            }
+            CapacityKind::UpgradeHandshake => {
+                stats.upgrade_handshakes.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+        let stage_id = stats.capacity_stage_started(kind.stage());
+        Self {
+            permit: Some(permit),
+            stats,
+            kind,
+            stage_id,
+        }
+    }
+
+    fn into_permit(mut self) -> OwnedSemaphorePermit {
+        self.release_accounting();
+        self.permit.take().expect("capacity permit")
+    }
+
+    fn release_accounting(&mut self) {
+        if self.stage_id == 0 {
+            return;
+        }
+        self.stats.inflight_http.fetch_sub(1, Ordering::AcqRel);
+        match self.kind {
+            CapacityKind::Http => {
+                self.stats
+                    .inflight_regular_http
+                    .fetch_sub(1, Ordering::AcqRel);
+            }
+            CapacityKind::BridgeTurn => {
+                self.stats
+                    .active_bridge_turns
+                    .fetch_sub(1, Ordering::AcqRel);
+            }
+            CapacityKind::UpgradeHandshake => {
+                self.stats.upgrade_handshakes.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+        self.stats
+            .capacity_stage_finished(self.kind.stage(), self.stage_id);
+        self.stage_id = 0;
+    }
+}
+
+impl CapacityKind {
+    fn stage(self) -> crate::state::CapacityStage {
+        match self {
+            Self::Http => crate::state::CapacityStage::Http,
+            Self::BridgeTurn => crate::state::CapacityStage::BridgeTurn,
+            Self::UpgradeHandshake => crate::state::CapacityStage::UpgradeHandshake,
+        }
+    }
+}
+
+impl Drop for CapacityLease {
+    fn drop(&mut self) {
+        self.release_accounting();
     }
 }
 
@@ -459,6 +558,7 @@ pub struct App {
     upgrade_client: UpgradeHttpClient,
     stats: Arc<Stats>,
     http_slots: Arc<Semaphore>,
+    bridge_turn_slots: Arc<Semaphore>,
     upgrade_slots: Arc<Semaphore>,
     bridge_sessions: AsyncMutex<HashMap<u64, BridgeSessionEntry>>,
     bridge_sessions_changed: Arc<Notify>,
@@ -501,8 +601,17 @@ impl App {
             config.proxy.max_affinity_bytes,
             Duration::from_secs(config.proxy.affinity_idle_days * 86_400),
         )?);
+        stats.configure_capacity(
+            config.proxy.max_inflight,
+            config.proxy.max_inflight,
+            config.proxy.max_upgrades,
+        );
+        stats.configure_bridge_session_capacity(config.proxy.max_bridge_sessions);
         Ok(Arc::new(Self {
             http_slots: Arc::new(Semaphore::new(config.proxy.max_inflight)),
+            // Bridge turns use an independent bulkhead. A stalled bridge can no longer consume
+            // the ordinary HTTP serving pool, while the combined counters remain truthful.
+            bridge_turn_slots: Arc::new(Semaphore::new(config.proxy.max_inflight)),
             upgrade_slots: Arc::new(Semaphore::new(config.proxy.max_upgrades)),
             bridge_sessions: AsyncMutex::new(HashMap::new()),
             bridge_sessions_changed: Arc::new(Notify::new()),
@@ -672,10 +781,18 @@ impl App {
         listener: ListenerConfig,
     ) -> Result<Response<ProxyBody>, Infallible> {
         let response = if self.service_health_path(req.uri()) {
+            let capacity = self.stats.capacity_snapshot();
+            let (status, state) = if capacity.saturated {
+                (StatusCode::SERVICE_UNAVAILABLE, "degraded")
+            } else {
+                (StatusCode::OK, "ok")
+            };
             Response::builder()
-                .status(StatusCode::OK)
+                .status(status)
                 .header(CONTENT_TYPE, "application/json")
-                .body(json_body(serde_json::json!({"status":"ok"})))
+                .body(json_body(
+                    serde_json::json!({"status":state,"capacity":capacity}),
+                ))
                 .expect("static health response is valid")
         } else {
             match self.authorized_path(req.uri()) {
@@ -705,6 +822,9 @@ impl App {
                     let permit = match self.http_slots.clone().try_acquire_owned() {
                         Ok(v) => v,
                         Err(_) => {
+                            self.stats
+                                .http_admission_rejected
+                                .fetch_add(1, Ordering::Relaxed);
                             return Ok(error_response(
                                 StatusCode::SERVICE_UNAVAILABLE,
                                 "at_capacity",
@@ -712,13 +832,31 @@ impl App {
                             ));
                         }
                     };
-                    let _inflight = InflightGuard::new(&self.stats.inflight_http);
-                    let result = self
-                        .handle_http(req, &listener, path)
-                        .await
-                        .unwrap_or_else(internal_error);
-                    drop(permit);
-                    result
+                    let lease = CapacityLease::new(permit, self.stats.clone(), CapacityKind::Http);
+                    let deadline = tokio::time::Instant::now() + HTTP_REQUEST_TIMEOUT;
+                    let (result, response_deadline) = match tokio::time::timeout_at(
+                        deadline,
+                        self.handle_http(req, &listener, path, deadline),
+                    )
+                    .await
+                    {
+                        Ok(Ok(response)) => (response, Some(deadline)),
+                        Ok(Err(error)) => (internal_error(error), Some(deadline)),
+                        Err(_) => {
+                            self.stats
+                                .admission_timed_out
+                                .fetch_add(1, Ordering::Relaxed);
+                            (
+                                error_response(
+                                    StatusCode::GATEWAY_TIMEOUT,
+                                    "upstream_request_timeout",
+                                    "upstream request deadline exceeded",
+                                ),
+                                None,
+                            )
+                        }
+                    };
+                    bound_http_response(result, lease, response_deadline)
                 }
             }
         };
@@ -756,19 +894,22 @@ impl App {
         req: Request<Incoming>,
         listener: &ListenerConfig,
         path: String,
+        deadline: tokio::time::Instant,
     ) -> Result<Response<ProxyBody>> {
         let (parts, body) = req.into_parts();
         let inbound_headers = parts.headers;
         let method = parts.method;
-        let replay = ReplayBody::read(
+        let replay = ReplayBody::read_with_timeouts(
             body,
             self.config.proxy.replay_memory_bytes,
             self.config.proxy.max_request_bytes,
             self.config.proxy.max_spool_bytes,
             self.stats.clone(),
+            HTTP_REQUEST_BODY_IDLE_TIMEOUT,
+            deadline.saturating_duration_since(tokio::time::Instant::now()),
         )
         .await?;
-        self.handle_http_replay(inbound_headers, method, listener, path, replay)
+        self.handle_http_replay(inbound_headers, method, listener, path, replay, deadline)
             .await
     }
 
@@ -779,6 +920,7 @@ impl App {
         listener: &ListenerConfig,
         path: String,
         replay: ReplayBody,
+        deadline: tokio::time::Instant,
     ) -> Result<Response<ProxyBody>> {
         self.handle_http_replay_with_routing_anchor(
             inbound_headers,
@@ -787,10 +929,12 @@ impl App {
             path,
             replay,
             None,
+            deadline,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_http_replay_with_routing_anchor(
         &self,
         mut inbound_headers: hyper::HeaderMap,
@@ -799,6 +943,7 @@ impl App {
         mut path: String,
         mut replay: ReplayBody,
         routing_previous_response_id: Option<String>,
+        request_deadline: tokio::time::Instant,
     ) -> Result<Response<ProxyBody>> {
         let legacy_compact = method == Method::POST && is_legacy_compact_path(&path);
         if legacy_compact {
@@ -939,6 +1084,7 @@ impl App {
                     &inbound_headers,
                     credentials.clone(),
                     replay.body(attempt)?,
+                    request_deadline,
                 )
                 .await;
             match result {
@@ -1104,6 +1250,7 @@ impl App {
         inbound: &hyper::HeaderMap,
         credentials: auth::Credentials,
         body: ProxyBody,
+        request_deadline: tokio::time::Instant,
     ) -> Result<Response<Incoming>> {
         let uri = self.upstream_uri(path, false)?;
         let mut builder = Request::builder().method(method).uri(uri);
@@ -1113,7 +1260,14 @@ impl App {
         headers.remove(CONTENT_LENGTH);
         let _ = inbound;
         apply_credentials(headers, credentials)?;
-        Ok(self.client.request(builder.body(body)?).await?)
+        let header_deadline =
+            request_deadline.min(tokio::time::Instant::now() + HTTP_RESPONSE_HEADER_TIMEOUT);
+        match tokio::time::timeout_at(header_deadline, self.client.request(builder.body(body)?))
+            .await
+        {
+            Ok(result) => Ok(result?),
+            Err(_) => anyhow::bail!("upstream response header timeout"),
+        }
     }
 
     async fn map_file_create_response(
@@ -1265,6 +1419,9 @@ impl App {
             ));
         }
         let Some(admission) = self.admit_bridge_session().await else {
+            self.stats
+                .bridge_turn_admission_rejected
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(bridge_capacity_response());
         };
         let accept = tokio_tungstenite::tungstenite::handshake::derive_accept_key(key);
@@ -1276,13 +1433,15 @@ impl App {
         let session_id = admission.id;
         let activity = admission.activity;
         let evicted = admission.evicted;
-        self.stats.open_upgrades.fetch_add(1, Ordering::Relaxed);
-        let upgrade_guard = OpenUpgradeGuard(self.stats.clone());
+        self.stats
+            .open_bridge_sessions
+            .fetch_add(1, Ordering::Relaxed);
+        let bridge_guard = OpenBridgeSessionGuard(self.stats.clone());
         let spawned = self
             .spawn_tracked(async move {
-                let _upgrade_guard = upgrade_guard;
-                match client_upgrade.await {
-                    Ok(client) => {
+                let _bridge_guard = bridge_guard;
+                match tokio::time::timeout(WEBSOCKET_HANDSHAKE_TIMEOUT, client_upgrade).await {
+                    Ok(Ok(client)) => {
                         let websocket = WebSocketStream::from_raw_socket(
                             TokioIo::new(client),
                             Role::Server,
@@ -1298,7 +1457,13 @@ impl App {
                             warn!(%error, "Responses HTTP bridge ended");
                         }
                     }
-                    Err(error) => warn!(%error, "Responses HTTP bridge upgrade failed"),
+                    Ok(Err(error)) => warn!(%error, "Responses HTTP bridge upgrade failed"),
+                    Err(_) => {
+                        app.stats
+                            .admission_timed_out
+                            .fetch_add(1, Ordering::Relaxed);
+                        warn!("Responses HTTP bridge downstream upgrade timed out");
+                    }
                 }
                 cleanup_app.finish_bridge_session(session_id).await;
             })
@@ -1531,9 +1696,12 @@ impl App {
                             let _turn_guard = turn_guard;
                             let dispatch_deadline =
                                 tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT;
-                            let _http_permit = match app.http_slots.clone().try_acquire_owned() {
+                            let permit = match app.bridge_turn_slots.clone().try_acquire_owned() {
                                 Ok(permit) => permit,
                                 Err(_) => {
+                                    app.stats
+                                        .bridge_turn_admission_rejected
+                                        .fetch_add(1, Ordering::Relaxed);
                                     send_ws_error(
                                         &outbound,
                                         "server_busy",
@@ -1543,6 +1711,11 @@ impl App {
                                     return;
                                 }
                             };
+                            let _capacity = CapacityLease::new(
+                                permit,
+                                app.stats.clone(),
+                                CapacityKind::BridgeTurn,
+                            );
                             let replay = match ReplayBody::from_bytes(
                                 body,
                                 app.config.proxy.max_request_bytes,
@@ -1569,6 +1742,7 @@ impl App {
                                     path,
                                     replay,
                                     routing_previous_response_id,
+                                    dispatch_deadline,
                                 ),
                             )
                             .await
@@ -1814,6 +1988,7 @@ impl App {
         clear_session_state: bool,
         connect_timeout: Duration,
     ) -> Result<DirectUpstream> {
+        let connect_deadline = tokio::time::Instant::now() + connect_timeout;
         for attempt in 0..2 {
             let uri = self.upstream_uri(path, false)?;
             let mut upstream_req = Request::builder()
@@ -1832,7 +2007,6 @@ impl App {
                 .await?;
             apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
             self.router.begin(account).await;
-            let connect_deadline = tokio::time::Instant::now() + connect_timeout;
             let mut response = match tokio::time::timeout_at(
                 connect_deadline,
                 self.upgrade_client.request(upstream_req),
@@ -2092,7 +2266,7 @@ impl App {
                                     continue;
                                 }
                             };
-                            upstream.send(client_message.clone()).await?;
+                            send_upgraded_bounded(&mut upstream, client_message.clone()).await?;
                             if analysis.has_nonportable_state {
                                 route.hard_owner = true;
                                 route.non_previous_hard_owner = true;
@@ -2110,7 +2284,7 @@ impl App {
                         }
                     }
                     let closes = matches!(client_message, Message::Close(_));
-                    upstream.send(client_message).await?;
+                    send_upgraded_bounded(&mut upstream, client_message).await?;
                     if closes { break; }
                 }
                 upstream_message = upstream.next() => {
@@ -2140,14 +2314,6 @@ impl App {
                                 {
                                     awaiting_response_created = None;
                                     missing_created_deadline = None;
-                                } else if awaiting_response_created.is_some() {
-                                    // A recoverable pre-acceptance close may replace the upstream
-                                    // and replay the one safe turn. Its acknowledgement gets a new
-                                    // full deadline on the replacement generation.
-                                    missing_created_deadline = Some(
-                                        tokio::time::Instant::now()
-                                            + RESPONSES_MISSING_CREATED_TIMEOUT,
-                                    );
                                 }
                                 upstream_idle_deadlines.clear();
                                 if close_downstream {
@@ -2160,7 +2326,7 @@ impl App {
                                 _ => None,
                             };
                             let Some(event) = parsed else {
-                                client.send(message).await?;
+                                send_upgraded_bounded(&mut client, message).await?;
                                 continue;
                             };
                             let failure = classify_failure(&event);
@@ -2207,10 +2373,6 @@ impl App {
                                     lease.replace(account.clone()).await;
                                     upstream = replacement.socket;
                                     upstream_credentials = replacement.credentials;
-                                    missing_created_deadline = Some(
-                                        tokio::time::Instant::now()
-                                            + RESPONSES_MISSING_CREATED_TIMEOUT,
-                                    );
                                     upstream_idle_deadlines.clear();
                                     continue;
                                 }
@@ -2245,13 +2407,15 @@ impl App {
                                         .turn(turn_id)
                                         .and_then(|turn| turn.response_id())
                                         .unwrap_or("");
-                                    client
-                                        .send(Message::Text(
+                                    send_upgraded_bounded(
+                                        &mut client,
+                                        Message::Text(
                                             previous_response_not_found_event(response_id)
                                                 .to_string()
                                                 .into(),
-                                        ))
-                                        .await?;
+                                        ),
+                                    )
+                                    .await?;
                                     let _ = protocol.settle(turn_id, Settlement::Failed);
                                     turns.remove(&turn_id);
                                     upstream_idle_deadlines.remove(&turn_id);
@@ -2262,11 +2426,13 @@ impl App {
                                 // Never expose account-scoped continuity identifiers from an
                                 // unassociated upstream miss. It may belong to another in-flight
                                 // request, so keep our pending turns alive.
-                                client
-                                    .send(Message::Text(
+                                send_upgraded_bounded(
+                                    &mut client,
+                                    Message::Text(
                                         previous_response_not_found_error().to_string().into(),
-                                    ))
-                                    .await?;
+                                    ),
+                                )
+                                .await?;
                                 continue;
                             }
                             if association.event_type.as_deref() == Some("response.created") {
@@ -2305,7 +2471,7 @@ impl App {
                                 &association.turn_ids,
                                 RESPONSES_UPSTREAM_IDLE_TIMEOUT,
                             );
-                            client.send(message).await?;
+                            send_upgraded_bounded(&mut client, message).await?;
                             for turn_id in &association.turn_ids {
                                 protocol
                                     .mark_downstream_delivered(*turn_id, &event)
@@ -2540,7 +2706,9 @@ impl App {
         if committed != plan {
             anyhow::bail!("direct replay plan changed before commit")
         }
-        if let Err(error) = replacement.socket.send(replay_message.clone()).await {
+        if let Err(error) =
+            send_upgraded_bounded(&mut replacement.socket, replay_message.clone()).await
+        {
             warn!(%error, account = replacement_account, "safe direct replay send failed");
             return Ok(None);
         }
@@ -2651,8 +2819,7 @@ impl App {
                             "error":{"type":"server_error","code":code,"message":message,"retryable":false}
                         }
                     });
-                    client
-                        .send(Message::Text(payload.to_string().into()))
+                    send_upgraded_bounded(client, Message::Text(payload.to_string().into()))
                         .await?;
                     let _ = protocol.settle(action.turn_id, Settlement::Incomplete);
                 }
@@ -2704,8 +2871,16 @@ impl App {
     ) -> Result<Response<ProxyBody>> {
         let permit = match self.upgrade_slots.clone().try_acquire_owned() {
             Ok(permit) => permit,
-            Err(_) => return Ok(upgrade_capacity_response()),
+            Err(_) => {
+                self.stats
+                    .upgrade_admission_rejected
+                    .fetch_add(1, Ordering::Relaxed);
+                return Ok(upgrade_capacity_response());
+            }
         };
+        let capacity =
+            CapacityLease::new(permit, self.stats.clone(), CapacityKind::UpgradeHandshake);
+        let handshake_deadline = tokio::time::Instant::now() + WEBSOCKET_HANDSHAKE_TIMEOUT;
         let inbound_headers = req.headers().clone();
         let pool = self.pool(listener)?;
         let forced_live = live_call_id.is_some();
@@ -2820,11 +2995,27 @@ impl App {
                 .await?;
             apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
             self.router.begin(&selection.account_id).await;
-            let mut response = match self.upgrade_client.request(upstream_req).await {
-                Ok(response) => response,
-                Err(error) => {
+            let mut response = match tokio::time::timeout_at(
+                handshake_deadline,
+                self.upgrade_client.request(upstream_req),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                Ok(Err(error)) => {
                     self.router.end(&selection.account_id).await;
                     return Err(error.into());
+                }
+                Err(_) => {
+                    self.router.end(&selection.account_id).await;
+                    self.stats
+                        .admission_timed_out
+                        .fetch_add(1, Ordering::Relaxed);
+                    return Ok(error_response(
+                        StatusCode::GATEWAY_TIMEOUT,
+                        "upstream_websocket_handshake_timeout",
+                        "upstream WebSocket handshake timed out",
+                    ));
                 }
             };
             if response.status() == StatusCode::SWITCHING_PROTOCOLS {
@@ -2865,12 +3056,17 @@ impl App {
                     && self.config.proxy.responses_websocket_mode == ResponsesWebsocketMode::Direct;
                 stats.open_upgrades.fetch_add(1, Ordering::Relaxed);
                 let upgrade_guard = OpenUpgradeGuard(stats.clone());
+                let permit = capacity.into_permit();
                 let spawned = self
                     .spawn_tracked(async move {
                         let _upgrade_guard = upgrade_guard;
                         let _permit = permit;
-                        match tokio::try_join!(client_upgrade, upstream_upgrade) {
-                            Ok((client, upstream)) => {
+                        match tokio::time::timeout_at(handshake_deadline, async {
+                            tokio::try_join!(client_upgrade, upstream_upgrade)
+                        })
+                        .await
+                        {
+                            Ok(Ok((client, upstream))) => {
                                 if direct {
                                     let client = WebSocketStream::from_raw_socket(
                                         TokioIo::new(client),
@@ -2909,8 +3105,12 @@ impl App {
                                     router.end(&account).await;
                                 }
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 warn!(error = %e, "upgrade failed");
+                                router.end(&account).await;
+                            }
+                            Err(_) => {
+                                warn!("downstream or upstream WebSocket upgrade timed out");
                                 router.end(&account).await;
                             }
                         }
@@ -3354,6 +3554,110 @@ fn map_http_response(response: Response<Incoming>) -> Response<ProxyBody> {
     Response::from_parts(parts, incoming_body(body))
 }
 
+fn bound_http_response(
+    response: Response<ProxyBody>,
+    lease: CapacityLease,
+    total_deadline: Option<tokio::time::Instant>,
+) -> Response<ProxyBody> {
+    bound_http_response_with_timeouts(
+        response,
+        lease,
+        total_deadline,
+        HTTP_RESPONSE_BODY_IDLE_TIMEOUT,
+    )
+}
+
+fn bound_http_response_with_timeouts(
+    response: Response<ProxyBody>,
+    lease: CapacityLease,
+    total_deadline: Option<tokio::time::Instant>,
+    idle_timeout: Duration,
+) -> Response<ProxyBody> {
+    let (parts, body) = response.into_parts();
+    Response::from_parts(
+        parts,
+        BodyExt::boxed(BoundedHttpBody {
+            inner: body,
+            lease: Some(lease),
+            total: total_deadline.map(|deadline| Box::pin(tokio::time::sleep_until(deadline))),
+            idle_timeout,
+            idle: Box::pin(tokio::time::sleep(idle_timeout)),
+            finished: false,
+        }),
+    )
+}
+
+struct BoundedHttpBody {
+    inner: ProxyBody,
+    lease: Option<CapacityLease>,
+    total: Option<Pin<Box<tokio::time::Sleep>>>,
+    idle_timeout: Duration,
+    idle: Pin<Box<tokio::time::Sleep>>,
+    finished: bool,
+}
+
+impl Body for BoundedHttpBody {
+    type Data = bytes::Bytes;
+    type Error = std::io::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.finished {
+            return Poll::Ready(None);
+        }
+        if self
+            .total
+            .as_mut()
+            .is_some_and(|deadline| deadline.as_mut().poll(cx).is_ready())
+        {
+            self.finished = true;
+            if let Some(lease) = self.lease.take() {
+                lease
+                    .stats
+                    .admission_timed_out
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            return Poll::Ready(Some(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "upstream response total deadline exceeded",
+            ))));
+        }
+        if self.idle.as_mut().poll(cx).is_ready() {
+            self.finished = true;
+            self.lease.take();
+            return Poll::Ready(Some(Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "upstream response body idle timeout",
+            ))));
+        }
+        match Pin::new(&mut self.inner).poll_frame(cx) {
+            Poll::Ready(Some(frame)) => {
+                let idle_timeout = self.idle_timeout;
+                self.idle
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + idle_timeout);
+                Poll::Ready(Some(frame))
+            }
+            Poll::Ready(None) => {
+                self.finished = true;
+                self.lease.take();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.finished || self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
 fn map_http_response_leased(
     response: Response<Incoming>,
     router: Arc<Router>,
@@ -3472,6 +3776,16 @@ fn response_ids_from_sse_finish(decoder: &mut SseDecoder) -> Vec<String> {
         .collect()
 }
 
+fn response_id_from_protocol_event(event: ProtocolEvent) -> Option<String> {
+    event
+        .value
+        .get("response")
+        .and_then(|response| response.get("id"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+}
+
 impl Body for LeasedIncoming {
     type Data = bytes::Bytes;
     type Error = std::io::Error;
@@ -3562,16 +3876,6 @@ impl LeasedIncoming {
             }
         }))
     }
-}
-
-fn response_id_from_protocol_event(event: ProtocolEvent) -> Option<String> {
-    event
-        .value
-        .get("response")
-        .and_then(|response| response.get("id"))
-        .and_then(serde_json::Value::as_str)
-        .filter(|id| !id.is_empty())
-        .map(str::to_owned)
 }
 
 fn response_ids_from_json(bytes: &[u8]) -> Vec<String> {
@@ -3751,17 +4055,25 @@ async fn send_direct_error(
     kind: &str,
     message: &str,
 ) -> Result<()> {
-    websocket
-        .send(Message::Text(
+    send_upgraded_bounded(
+        websocket,
+        Message::Text(
             serde_json::json!({
                 "type": "error",
                 "error": {"type": kind, "message": message}
             })
             .to_string()
             .into(),
-        ))
-        .await?;
-    Ok(())
+        ),
+    )
+    .await
+}
+
+async fn send_upgraded_bounded(websocket: &mut UpgradedWebSocket, message: Message) -> Result<()> {
+    match tokio::time::timeout(BRIDGE_SEND_TIMEOUT, websocket.send(message)).await {
+        Ok(result) => Ok(result?),
+        Err(_) => anyhow::bail!("WebSocket send timed out under downstream backpressure"),
+    }
 }
 
 fn previous_response_not_found_event(response_id: &str) -> serde_json::Value {
@@ -3893,7 +4205,6 @@ async fn pump_http_response_to_websocket(
         progress_events: 0,
     };
     let mut liveness = None;
-    let result: Result<()> = async {
     let status = response.status();
     let response_headers = response.headers().clone();
     let content_type = response
@@ -3907,6 +4218,7 @@ async fn pump_http_response_to_websocket(
         .extensions
         .get::<SelectedAccount>()
         .map(|selected| selected.0.clone());
+    let result: Result<()> = async {
     if !status.is_success() {
         let bytes = match tokio::time::timeout_at(
             response_created_deadline,
@@ -4130,6 +4442,7 @@ async fn send_protocol_events(
     Ok(false)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_sse_data(
     decoder: &mut SseDecoder,
     data: &[u8],
@@ -4328,7 +4641,7 @@ mod tests {
     #[tokio::test]
     async fn http_inflight_counter_clears_when_connection_task_is_aborted() {
         let dir = tempfile::tempdir().unwrap();
-        let (app, mut listener, _, stats) = direct_test_app(dir.path());
+        let (app, mut listener, _, stats) = direct_test_app(dir.path()).await;
         let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
         listener.address = tcp.local_addr().unwrap();
         let proxy = tokio::spawn(
@@ -4356,6 +4669,51 @@ mod tests {
 
         drop(stream);
         proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn response_progress_cannot_extend_the_absolute_http_deadline() {
+        let stats = Arc::new(Stats::default());
+        let slots = Arc::new(Semaphore::new(1));
+        let permit = slots.clone().try_acquire_owned().unwrap();
+        let lease = CapacityLease::new(permit, stats.clone(), CapacityKind::Http);
+        let (sender, receiver) = mpsc::channel::<std::io::Result<Frame<Bytes>>>(4);
+        let stream = futures_util::stream::unfold(receiver, |mut receiver| async move {
+            receiver.recv().await.map(|item| (item, receiver))
+        });
+        let response = Response::new(BodyExt::boxed(http_body_util::StreamBody::new(stream)));
+        let response = bound_http_response_with_timeouts(
+            response,
+            lease,
+            Some(tokio::time::Instant::now() + Duration::from_millis(40)),
+            Duration::from_secs(1),
+        );
+        let producer = tokio::spawn(async move {
+            loop {
+                if sender
+                    .send(Ok(Frame::data(Bytes::from_static(b"progress"))))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        });
+
+        let error =
+            tokio::time::timeout(Duration::from_millis(500), response.into_body().collect())
+                .await
+                .expect("absolute response deadline should fire")
+                .expect_err("periodic response frames must not extend the total deadline");
+        assert!(
+            error.to_string().contains("total deadline exceeded"),
+            "{error}"
+        );
+        assert_eq!(stats.inflight_http.load(Ordering::Acquire), 0);
+        assert_eq!(stats.inflight_regular_http.load(Ordering::Acquire), 0);
+        assert_eq!(slots.available_permits(), 1);
+        producer.await.unwrap();
     }
 
     #[test]
@@ -4427,8 +4785,8 @@ mod tests {
         assert!(unrelated.finish().is_empty());
     }
 
-    #[test]
-    fn public_constructor_rejects_noncanonical_credential_destinations() {
+    #[tokio::test]
+    async fn public_constructor_rejects_noncanonical_credential_destinations() {
         for upstream in [
             "https://example.invalid/backend-api/codex",
             "http://127.0.0.1:12345/backend-api/codex",
@@ -4491,13 +4849,13 @@ mod tests {
         assert_eq!(payload["error"]["type"], "at_capacity");
     }
 
-    fn direct_test_app(
+    async fn direct_test_app(
         dir: &std::path::Path,
     ) -> (Arc<App>, ListenerConfig, Arc<Router>, Arc<Stats>) {
-        direct_test_app_with_upstream(dir, ProxyConfig::default().upstream)
+        direct_test_app_with_upstream(dir, ProxyConfig::default().upstream).await
     }
 
-    fn direct_test_app_with_upstream(
+    async fn direct_test_app_with_upstream(
         dir: &std::path::Path,
         upstream: String,
     ) -> (Arc<App>, ListenerConfig, Arc<Router>, Arc<Stats>) {
@@ -4543,7 +4901,7 @@ mod tests {
         (app, listener, router, stats)
     }
 
-    fn bridge_admission_test_app(
+    async fn bridge_admission_test_app(
         dir: &std::path::Path,
         max_bridge_sessions: usize,
         bridge_admission_timeout_millis: u64,
@@ -4638,7 +4996,7 @@ mod tests {
     #[tokio::test]
     async fn bridge_capacity_evicts_lru_idle_session_without_using_upgrade_slots() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let upstream_upgrade_slots = app.upgrade_slots.available_permits();
         let first = app.admit_bridge_session().await.unwrap();
         assert_eq!(
@@ -4661,7 +5019,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_comments_do_not_disarm_missing_created_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (response, _body_sender) = pending_sse_response(b": keepalive\n\n");
 
         let (failure, receiver) = pump_with_test_watchdogs(
@@ -4683,7 +5041,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_prelude_does_not_disarm_missing_created_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (response, _body_sender) =
             pending_sse_response(b"data: {\"type\":\"response.queued\",\"sequence_number\":0}\n\n");
 
@@ -4707,7 +5065,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_response_metadata_is_visible_but_does_not_disarm_created_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (response, _body_sender) = pending_sse_response(
             b"data: {\"type\":\"response.metadata\",\"sequence_number\":7,\"response\":{\"metadata\":{\"trace\":\"opaque\"}}}\n\n",
         );
@@ -4736,7 +5094,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_created_starts_semantic_progress_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (response, _body_sender) = pending_sse_response(
             b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_watchdog\"}}\n\n",
         );
@@ -4761,7 +5119,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_heartbeats_do_not_refresh_idle_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (response, body_sender) = pending_sse_response(
             b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_watchdog\"}}\n\n",
         );
@@ -4828,7 +5186,8 @@ mod tests {
         let (app, _, _, _) = direct_test_app_with_upstream(
             dir.path(),
             format!("http://{upstream_addr}/backend-api/codex"),
-        );
+        )
+        .await;
         let mut headers = hyper::HeaderMap::new();
         headers.insert(AUTHORIZATION, "Bearer caller-token".parse().unwrap());
 
@@ -4853,7 +5212,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_partial_json_cannot_bypass_missing_created_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (mut response, _body_sender) = pending_sse_response(b"{\"response\":");
         response
             .headers_mut()
@@ -4878,7 +5237,7 @@ mod tests {
     #[tokio::test]
     async fn http_bridge_error_body_cannot_bypass_missing_created_watchdog() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 500);
+        let app = bridge_admission_test_app(dir.path(), 1, 500).await;
         let (mut response, _body_sender) = pending_sse_response(b"{\"error\":");
         *response.status_mut() = StatusCode::BAD_GATEWAY;
         response
@@ -4922,7 +5281,7 @@ mod tests {
     #[tokio::test]
     async fn bridge_capacity_never_evicts_active_turn_and_returns_retryable_response() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 20);
+        let app = bridge_admission_test_app(dir.path(), 1, 20).await;
         let first = app.admit_bridge_session().await.unwrap();
         let turn =
             BridgeTurnGuard::new(first.activity.clone(), app.bridge_sessions_changed.clone());
@@ -4939,7 +5298,7 @@ mod tests {
     #[tokio::test]
     async fn bridge_lru_eviction_closes_idle_socket_before_replacement() {
         let dir = tempfile::tempdir().unwrap();
-        let app = bridge_admission_test_app(dir.path(), 1, 1_000);
+        let app = bridge_admission_test_app(dir.path(), 1, 1_000).await;
         let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = tcp.local_addr().unwrap();
         let listener = ListenerConfig {
@@ -5122,7 +5481,7 @@ mod tests {
     #[tokio::test]
     async fn direct_fresh_frame_rotates_off_exhausted_socket_account() {
         let dir = tempfile::tempdir().unwrap();
-        let (app, listener, router, stats) = direct_test_app(dir.path());
+        let (app, listener, router, stats) = direct_test_app(dir.path()).await;
         let pool = &app.config.pools["default"];
         assert_eq!(
             router
@@ -5161,7 +5520,7 @@ mod tests {
     #[tokio::test]
     async fn direct_hard_owner_quota_marks_account_without_cross_account_replay() {
         let dir = tempfile::tempdir().unwrap();
-        let (app, listener, router, stats) = direct_test_app(dir.path());
+        let (app, listener, router, stats) = direct_test_app(dir.path()).await;
         let pool = &app.config.pools["default"];
         assert_eq!(
             router

--- a/src/proxy/replay_body.rs
+++ b/src/proxy/replay_body.rs
@@ -2,6 +2,7 @@ use std::{
     fs::File as StdFile,
     io::{Read, Write},
     sync::{Arc, atomic::Ordering},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, bail};
@@ -10,9 +11,10 @@ use futures_util::TryStreamExt;
 use http_body_util::{BodyExt, Full, StreamBody, combinators::BoxBody};
 use hyper::{
     Error as HyperError,
-    body::{Frame, Incoming},
+    body::{Body, Frame, Incoming},
 };
 use tempfile::NamedTempFile;
+use tokio::{sync::mpsc, task::JoinHandle};
 use tokio_util::io::ReaderStream;
 
 use crate::state::Stats;
@@ -283,17 +285,19 @@ struct Reservation {
 
 impl Reservation {
     fn add(&mut self, amount: usize, limit: usize) -> Result<()> {
-        let previous = self
-            .stats
+        let reserved = self
+            .bytes
+            .checked_add(amount)
+            .context("replay reservation overflow")?;
+        self.stats
             .active_spool_bytes
-            .fetch_add(amount, Ordering::AcqRel);
-        if previous.saturating_add(amount) > limit {
-            self.stats
-                .active_spool_bytes
-                .fetch_sub(amount, Ordering::AcqRel);
-            bail!("global replay spool limit exceeded")
-        }
-        self.bytes += amount;
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current
+                    .checked_add(amount)
+                    .filter(|&updated| updated <= limit)
+            })
+            .map_err(|_| anyhow::anyhow!("global replay spool limit exceeded"))?;
+        self.bytes = reserved;
         Ok(())
     }
 }
@@ -311,6 +315,71 @@ enum Storage {
     Files(Vec<Option<StdFile>>),
 }
 
+/// A bounded handoff to a blocking spool writer.
+///
+/// Dropping this value closes the channel. That makes cancellation release the
+/// worker and its `NamedTempFile` without doing filesystem work on a Tokio
+/// executor thread.
+struct SpoolWriter {
+    sender: Option<mpsc::Sender<SpoolCommand>>,
+    task: JoinHandle<Result<Storage>>,
+}
+
+enum SpoolCommand {
+    Write(Bytes),
+    Finish,
+}
+
+impl SpoolWriter {
+    fn start(initial: Vec<u8>) -> Self {
+        // A small queue bounds memory growth while still allowing the reader and
+        // filesystem to make progress independently.
+        let (sender, mut receiver) = mpsc::channel::<SpoolCommand>(2);
+        let task = tokio::task::spawn_blocking(move || {
+            let mut file = NamedTempFile::new().context("create replay spool")?;
+            file.write_all(&initial).context("seed replay spool")?;
+            loop {
+                match receiver.blocking_recv() {
+                    Some(SpoolCommand::Write(chunk)) => {
+                        file.write_all(&chunk).context("write replay spool")?;
+                    }
+                    Some(SpoolCommand::Finish) => break,
+                    None => bail!("replay spool cancelled"),
+                }
+            }
+            file.as_file().sync_data().context("sync replay spool")?;
+            let one = file.reopen().context("open first replay spool reader")?;
+            let two = file.reopen().context("open second replay spool reader")?;
+            drop(file);
+            Ok(Storage::Files(vec![Some(one), Some(two)]))
+        });
+        Self {
+            sender: Some(sender),
+            task,
+        }
+    }
+
+    async fn write(&self, bytes: Bytes) -> Result<()> {
+        self.sender
+            .as_ref()
+            .context("replay spool already finalized")?
+            .send(SpoolCommand::Write(bytes))
+            .await
+            .map_err(|_| anyhow::anyhow!("replay spool writer stopped"))
+    }
+
+    async fn finish(mut self) -> Result<Storage> {
+        self.sender
+            .as_ref()
+            .context("replay spool already finalized")?
+            .send(SpoolCommand::Finish)
+            .await
+            .map_err(|_| anyhow::anyhow!("replay spool writer stopped"))?;
+        self.sender.take();
+        self.task.await.context("join replay spool writer")?
+    }
+}
+
 impl ReplayBody {
     pub fn from_bytes(
         bytes: Bytes,
@@ -321,17 +390,14 @@ impl ReplayBody {
         if bytes.len() > hard_limit {
             bail!("request body exceeds configured limit")
         }
-        let previous = stats
-            .active_spool_bytes
-            .fetch_add(bytes.len(), Ordering::AcqRel);
-        if previous.saturating_add(bytes.len()) > global_limit {
-            stats
-                .active_spool_bytes
-                .fetch_sub(bytes.len(), Ordering::AcqRel);
-            bail!("global replay spool limit exceeded")
-        }
+        let mut reservation = Reservation {
+            stats: stats.clone(),
+            bytes: 0,
+        };
+        reservation.add(bytes.len(), global_limit)?;
         let mut metadata = MetadataScanner::default();
         metadata.feed(&bytes);
+        reservation.bytes = 0;
         Ok(Self {
             len: bytes.len(),
             storage: Storage::Memory(bytes),
@@ -345,23 +411,88 @@ impl ReplayBody {
         })
     }
 
-    pub async fn read(
+    /// Read a replayable request body with both an idle timeout between frames
+    /// and a total ingress deadline.
+    pub async fn read_with_timeouts(
         incoming: Incoming,
         memory_limit: usize,
         hard_limit: usize,
         global_limit: usize,
         stats: Arc<Stats>,
+        idle_timeout: Duration,
+        total_timeout: Duration,
     ) -> Result<Self> {
-        let mut incoming = incoming;
+        Self::read_body_with_timeouts(
+            incoming,
+            memory_limit,
+            hard_limit,
+            global_limit,
+            stats,
+            idle_timeout,
+            total_timeout,
+        )
+        .await
+    }
+
+    async fn read_body_with_timeouts<B>(
+        incoming: B,
+        memory_limit: usize,
+        hard_limit: usize,
+        global_limit: usize,
+        stats: Arc<Stats>,
+        idle_timeout: Duration,
+        total_timeout: Duration,
+    ) -> Result<Self>
+    where
+        B: Body<Data = Bytes> + Unpin,
+        B::Error: std::error::Error + Send + Sync + 'static,
+    {
+        tokio::time::timeout(
+            total_timeout,
+            Self::read_body(
+                incoming,
+                memory_limit,
+                hard_limit,
+                global_limit,
+                stats,
+                Some(idle_timeout),
+            ),
+        )
+        .await
+        .context("request body total ingress timeout")?
+    }
+
+    async fn read_body<B>(
+        mut incoming: B,
+        memory_limit: usize,
+        hard_limit: usize,
+        global_limit: usize,
+        stats: Arc<Stats>,
+        idle_timeout: Option<Duration>,
+    ) -> Result<Self>
+    where
+        B: Body<Data = Bytes> + Unpin,
+        B::Error: std::error::Error + Send + Sync + 'static,
+    {
         let mut memory = Vec::new();
-        let mut temp: Option<NamedTempFile> = None;
+        let mut spool: Option<SpoolWriter> = None;
         let mut len = 0usize;
         let mut reservation = Reservation {
             stats: stats.clone(),
             bytes: 0,
         };
         let mut metadata = MetadataScanner::default();
-        while let Some(frame) = incoming.frame().await {
+        loop {
+            let next = if let Some(idle_timeout) = idle_timeout {
+                tokio::time::timeout(idle_timeout, incoming.frame())
+                    .await
+                    .context("request body idle timeout")?
+            } else {
+                incoming.frame().await
+            };
+            let Some(frame) = next else {
+                break;
+            };
             let frame = frame.context("read request body")?;
             let Ok(data) = frame.into_data() else {
                 continue;
@@ -374,24 +505,17 @@ impl ReplayBody {
             }
             reservation.add(data.len(), global_limit)?;
             metadata.feed(&data);
-            if temp.is_none() && len <= memory_limit {
+            if spool.is_none() && len <= memory_limit {
                 memory.extend_from_slice(&data);
             } else {
-                if temp.is_none() {
-                    let mut file = NamedTempFile::new().context("create replay spool")?;
-                    file.write_all(&memory)?;
-                    memory.clear();
-                    temp = Some(file);
+                if spool.is_none() {
+                    spool = Some(SpoolWriter::start(std::mem::take(&mut memory)));
                 }
-                temp.as_mut().expect("created").write_all(&data)?;
+                spool.as_ref().expect("created").write(data).await?;
             }
         }
-        let storage = if let Some(file) = temp {
-            file.as_file().sync_data()?;
-            let one = StdFile::open(file.path())?;
-            let two = StdFile::open(file.path())?;
-            drop(file);
-            Storage::Files(vec![Some(one), Some(two)])
+        let storage = if let Some(spool) = spool {
+            spool.finish().await?
         } else {
             Storage::Memory(Bytes::from(memory))
         };
@@ -513,7 +637,15 @@ fn never_to_io(never: std::convert::Infallible) -> std::io::Error {
 
 #[cfg(test)]
 mod tests {
+    use std::{io, sync::atomic::Ordering, time::Duration};
+
+    use futures_util::{StreamExt, stream};
+
     use super::*;
+
+    fn data_frame(bytes: &'static [u8]) -> Result<Frame<Bytes>, io::Error> {
+        Ok(Frame::data(Bytes::from_static(bytes)))
+    }
 
     #[test]
     fn finds_body_thread_id_across_chunks_without_retaining_other_strings() {
@@ -562,5 +694,141 @@ mod tests {
             br#"{"input":[{"type":"message","role":"user","content":"hello\nworld"}],"reasoning":{"effort":"high"}}"#,
         );
         assert!(!portable.nonportable_state);
+    }
+
+    #[tokio::test]
+    async fn spills_without_blocking_and_preserves_two_replays() {
+        let stats = Arc::new(Stats::default());
+        let incoming = StreamBody::new(stream::iter([
+            data_frame(br#"{"client_metadata":{"thread_id":"thread-spilled"},"input":""#),
+            data_frame(b"large-body"),
+            data_frame(br#""}"#),
+        ]));
+        let mut replay = ReplayBody::read_body(incoming, 8, 1_024, 1_024, stats.clone(), None)
+            .await
+            .expect("spool request body");
+
+        let expected = Bytes::from_static(
+            br#"{"client_metadata":{"thread_id":"thread-spilled"},"input":"large-body"}"#,
+        );
+        assert!(matches!(&replay.storage, Storage::Files(_)));
+        assert_eq!(replay.thread_id(), Some("thread-spilled"));
+        assert_eq!(
+            stats.active_spool_bytes.load(Ordering::Acquire),
+            expected.len()
+        );
+
+        let first = replay
+            .body(0)
+            .expect("first replay")
+            .collect()
+            .await
+            .expect("read first replay")
+            .to_bytes();
+        let second = replay
+            .body(1)
+            .expect("second replay")
+            .collect()
+            .await
+            .expect("read second replay")
+            .to_bytes();
+        assert_eq!(first, second);
+        assert_eq!(first, expected);
+        assert!(replay.body(0).is_err());
+
+        drop(replay);
+        assert_eq!(stats.active_spool_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn cancellation_releases_spool_reservation() {
+        let stats = Arc::new(Stats::default());
+        let incoming = StreamBody::new(
+            stream::iter([data_frame(b"spill-me")])
+                .chain(stream::pending::<Result<Frame<Bytes>, io::Error>>()),
+        );
+        let task_stats = stats.clone();
+        let task = tokio::spawn(async move {
+            ReplayBody::read_body(incoming, 1, 1_024, 1_024, task_stats, None).await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stats.active_spool_bytes.load(Ordering::Acquire) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("body reader reserved spool bytes");
+        task.abort();
+        let join_error = match task.await {
+            Err(error) => error,
+            Ok(_) => panic!("reader completed instead of being cancelled"),
+        };
+        assert!(join_error.is_cancelled());
+        assert_eq!(stats.active_spool_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn idle_and_total_timeouts_release_reservations() {
+        let stats = Arc::new(Stats::default());
+        let stalled = StreamBody::new(
+            stream::iter([data_frame(b"started")])
+                .chain(stream::pending::<Result<Frame<Bytes>, io::Error>>()),
+        );
+        let error = ReplayBody::read_body_with_timeouts(
+            stalled,
+            1,
+            1_024,
+            1_024,
+            stats.clone(),
+            Duration::from_millis(20),
+            Duration::from_secs(1),
+        )
+        .await
+        .err()
+        .expect("idle input should time out");
+        assert!(error.to_string().contains("idle timeout"), "{error:#}");
+        assert_eq!(stats.active_spool_bytes.load(Ordering::Acquire), 0);
+
+        let never_started = StreamBody::new(stream::pending::<Result<Frame<Bytes>, io::Error>>());
+        let error = ReplayBody::read_body_with_timeouts(
+            never_started,
+            1,
+            1_024,
+            1_024,
+            stats.clone(),
+            Duration::from_secs(1),
+            Duration::from_millis(20),
+        )
+        .await
+        .err()
+        .expect("total input deadline should expire");
+        assert!(
+            error.to_string().contains("total ingress timeout"),
+            "{error:#}"
+        );
+        assert_eq!(stats.active_spool_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn hard_and_global_limits_do_not_leak_reservations() {
+        let hard_stats = Arc::new(Stats::default());
+        let too_large = StreamBody::new(stream::iter([data_frame(b"12345")]));
+        let error = ReplayBody::read_body(too_large, 1, 4, 100, hard_stats.clone(), None)
+            .await
+            .err()
+            .expect("hard limit should reject body");
+        assert!(error.to_string().contains("configured limit"));
+        assert_eq!(hard_stats.active_spool_bytes.load(Ordering::Acquire), 0);
+
+        let global_stats = Arc::new(Stats::default());
+        let globally_too_large = StreamBody::new(stream::iter([data_frame(b"12345")]));
+        let error =
+            ReplayBody::read_body(globally_too_large, 1, 100, 4, global_stats.clone(), None)
+                .await
+                .err()
+                .expect("global limit should reject body");
+        assert!(error.to_string().contains("global replay spool limit"));
+        assert_eq!(global_stats.active_spool_bytes.load(Ordering::Acquire), 0);
     }
 }

--- a/src/routing/affinity.rs
+++ b/src/routing/affinity.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     io::Write,
     path::PathBuf,
+    sync::{Arc, Mutex as StdMutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -11,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 const ACCOUNT_EPOCH_STORAGE_BUDGET: usize = 1024 * 1024;
+const MAX_TOUCH_CHECKPOINT_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ThreadKey(pub String);
@@ -36,11 +38,16 @@ struct StoreState {
     binding_bytes: usize,
     generation: u64,
     persisted_generation: u64,
+    touch_generation: u64,
+    persisted_touch_generation: u64,
+    touch_flush_due_at: u64,
 }
 
 pub struct AffinityStore {
-    inner: Mutex<StoreState>,
-    flush_lock: Mutex<()>,
+    inner: Arc<Mutex<StoreState>>,
+    // This lock is deliberately owned by the blocking writer. If an async caller is cancelled,
+    // the detached blocking task still finishes before a newer generation can replace its file.
+    flush_lock: Arc<StdMutex<()>>,
     path: PathBuf,
     key: [u8; 32],
     max_entries: usize,
@@ -79,13 +86,16 @@ impl AffinityStore {
         let mut binding_bytes = binding_storage_bytes(&snapshot);
         dirty |= trim(&mut snapshot, &mut binding_bytes, max_entries, max_bytes);
         Ok(Self {
-            inner: Mutex::new(StoreState {
+            inner: Arc::new(Mutex::new(StoreState {
                 snapshot,
                 binding_bytes,
                 generation: u64::from(dirty),
                 persisted_generation: 0,
-            }),
-            flush_lock: Mutex::new(()),
+                touch_generation: 0,
+                persisted_touch_generation: 0,
+                touch_flush_due_at: 0,
+            })),
+            flush_lock: Arc::new(StdMutex::new(())),
             path,
             key,
             max_entries,
@@ -129,7 +139,7 @@ impl AffinityStore {
                 .binding_bytes
                 .saturating_sub(previous_bytes)
                 .saturating_add(json_len(&binding));
-            mark_dirty(&mut inner);
+            mark_touched(&mut inner, now, touch_checkpoint_interval(self.idle));
         }
         Some(binding)
     }
@@ -200,30 +210,45 @@ impl AffinityStore {
     }
 
     pub async fn flush(&self) -> Result<()> {
-        let _flush = self.flush_lock.lock().await;
-        let Some((generation, snapshot)) = ({
-            let mut inner = self.inner.lock().await;
-            let StoreState {
-                snapshot,
-                binding_bytes,
-                ..
-            } = &mut *inner;
-            if trim(snapshot, binding_bytes, self.max_entries, self.max_bytes) {
-                mark_dirty(&mut inner);
-            }
-            if account_epoch_storage_bytes(&inner.snapshot) > ACCOUNT_EPOCH_STORAGE_BUDGET {
-                anyhow::bail!("account epoch snapshot exceeds its hard storage budget")
-            }
-            if inner.persisted_generation >= inner.generation {
-                None
-            } else {
-                Some((inner.generation, inner.snapshot.clone()))
-            }
-        }) else {
-            return Ok(());
-        };
+        let inner = self.inner.clone();
+        let flush_lock = self.flush_lock.clone();
         let path = self.path.clone();
+        let max_entries = self.max_entries;
+        let max_bytes = self.max_bytes;
+        let touch_checkpoint_interval = touch_checkpoint_interval(self.idle);
         tokio::task::spawn_blocking(move || -> Result<()> {
+            let _flush = flush_lock
+                .lock()
+                .map_err(|_| anyhow::anyhow!("affinity snapshot writer lock poisoned"))?;
+            let current_now = now();
+            let (generation, touch_generation, snapshot) = {
+                let mut state = inner.blocking_lock();
+                let StoreState {
+                    snapshot,
+                    binding_bytes,
+                    ..
+                } = &mut *state;
+                if trim(snapshot, binding_bytes, max_entries, max_bytes) {
+                    mark_dirty(&mut state);
+                }
+                if account_epoch_storage_bytes(&state.snapshot) > ACCOUNT_EPOCH_STORAGE_BUDGET {
+                    anyhow::bail!("account epoch snapshot exceeds its hard storage budget")
+                }
+                let structural_dirty = state.persisted_generation < state.generation;
+                let touches_due = state.persisted_touch_generation < state.touch_generation
+                    && current_now >= state.touch_flush_due_at;
+                if !structural_dirty && !touches_due {
+                    return Ok(());
+                }
+                if touches_due && !structural_dirty {
+                    mark_dirty(&mut state);
+                }
+                (
+                    state.generation,
+                    state.touch_generation,
+                    state.snapshot.clone(),
+                )
+            };
             let bytes = serde_json::to_vec(&snapshot)?;
             let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
             fs::create_dir_all(parent)?;
@@ -231,18 +256,53 @@ impl AffinityStore {
             temp.write_all(&bytes)?;
             temp.as_file().sync_all()?;
             temp.persist(&path).map_err(|error| error.error)?;
+            sync_parent_directory(parent)?;
+
+            let mut state = inner.blocking_lock();
+            state.persisted_generation = state.persisted_generation.max(generation);
+            state.persisted_touch_generation =
+                state.persisted_touch_generation.max(touch_generation);
+            if state.persisted_touch_generation == state.touch_generation {
+                state.touch_flush_due_at = 0;
+            } else {
+                state.touch_flush_due_at =
+                    current_now.saturating_add(touch_checkpoint_interval.as_secs());
+            }
             Ok(())
         })
         .await
         .context("join affinity snapshot writer")??;
-        let mut inner = self.inner.lock().await;
-        inner.persisted_generation = inner.persisted_generation.max(generation);
         Ok(())
     }
 }
 
 fn mark_dirty(state: &mut StoreState) {
     state.generation = state.generation.saturating_add(1);
+}
+
+fn mark_touched(state: &mut StoreState, now: u64, checkpoint_interval: Duration) {
+    let was_clean = state.touch_generation == state.persisted_touch_generation;
+    state.touch_generation = state.touch_generation.saturating_add(1);
+    if was_clean {
+        state.touch_flush_due_at = now.saturating_add(checkpoint_interval.as_secs());
+    }
+}
+
+fn touch_checkpoint_interval(idle: Duration) -> Duration {
+    let quarter_idle = Duration::from_secs(idle.as_secs().saturating_div(4).max(1));
+    quarter_idle.min(MAX_TOUCH_CHECKPOINT_INTERVAL)
+}
+
+fn sync_parent_directory(path: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
 }
 
 fn trim(
@@ -455,6 +515,102 @@ mod tests {
         store.flush().await.unwrap();
         let inner = store.inner.lock().await;
         assert_eq!(inner.persisted_generation, inner.generation);
+    }
+
+    #[tokio::test]
+    async fn last_seen_churn_is_coalesced_until_the_touch_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        let store = AffinityStore::load(
+            path.clone(),
+            "0123456789abcdef0123456789abcdef",
+            10,
+            100_000,
+            Duration::from_secs(60 * 60),
+        )
+        .unwrap();
+        let key = store.key("hot-thread");
+        store.put(key.clone(), "a".into(), 0).await;
+        store.flush().await.unwrap();
+        let persisted = fs::read(&path).unwrap();
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(store.get(&key).await.is_some());
+        {
+            let state = store.inner.lock().await;
+            assert_eq!(state.persisted_generation, state.generation);
+            assert!(state.touch_generation > state.persisted_touch_generation);
+            assert!(state.touch_flush_due_at > now());
+        }
+
+        store.flush().await.unwrap();
+        assert_eq!(fs::read(&path).unwrap(), persisted);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // The test intentionally pins the blocking writer lock across cancellation.
+    async fn cancelled_flush_cannot_overwrite_a_newer_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        let store = Arc::new(
+            AffinityStore::load(
+                path.clone(),
+                "0123456789abcdef0123456789abcdef",
+                10,
+                100_000,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        store.put(store.key("first"), "a".into(), 0).await;
+
+        let writer_lock = store.flush_lock.clone();
+        let guard = writer_lock.lock().unwrap();
+        let cancelled_store = store.clone();
+        let cancelled = tokio::spawn(async move { cancelled_store.flush().await });
+        tokio::task::yield_now().await;
+        cancelled.abort();
+        store.put(store.key("second"), "b".into(), 0).await;
+        drop(guard);
+
+        store.flush().await.unwrap();
+        let restored = AffinityStore::load(
+            path,
+            "0123456789abcdef0123456789abcdef",
+            10,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        assert_eq!(restored.len_and_bytes().await.0, 2);
+    }
+
+    #[tokio::test]
+    async fn atomic_flush_leaves_only_the_complete_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("affinity.json");
+        fs::write(&path, b"old contents").unwrap();
+        let store = AffinityStore::load(
+            dir.path().join("new-affinity.json"),
+            "0123456789abcdef0123456789abcdef",
+            10,
+            100_000,
+            Duration::from_secs(60),
+        )
+        .unwrap();
+        store.put(store.key("thread"), "account".into(), 0).await;
+        store.flush().await.unwrap();
+
+        let entries = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert!(entries.contains(&"new-affinity.json".into()));
+        assert_eq!(entries.len(), 2);
+        let snapshot: Snapshot =
+            serde_json::from_slice(&fs::read(dir.path().join("new-affinity.json")).unwrap())
+                .unwrap();
+        assert_eq!(snapshot.bindings.len(), 1);
     }
 
     #[tokio::test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,21 +1,61 @@
 use std::{
+    collections::{BTreeMap, HashMap},
     fs,
+    io::Write,
+    path::Path,
     path::PathBuf,
     sync::{
-        Arc,
+        Arc, Mutex, OnceLock, Weak,
         atomic::{AtomicU64, AtomicUsize, Ordering},
     },
+    time::Instant,
 };
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::routing::{Router, RoutingSnapshot};
 
 #[derive(Default)]
+struct StatsWriterState {
+    lock: Mutex<()>,
+    next_generation: AtomicU64,
+    persisted_generation: AtomicU64,
+}
+
+static STATS_WRITERS: OnceLock<Mutex<HashMap<PathBuf, Weak<StatsWriterState>>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CapacityStage {
+    Http,
+    BridgeTurn,
+    UpgradeHandshake,
+}
+
+impl CapacityStage {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::BridgeTurn => "bridge_turn",
+            Self::UpgradeHandshake => "upgrade_handshake",
+        }
+    }
+}
+
+#[derive(Default)]
+struct CapacityStages {
+    next_id: u64,
+    active: HashMap<CapacityStage, BTreeMap<u64, Instant>>,
+}
+
+#[derive(Default)]
 pub struct Stats {
     pub inflight_http: AtomicUsize,
+    pub inflight_regular_http: AtomicUsize,
+    pub active_bridge_turns: AtomicUsize,
+    pub upgrade_handshakes: AtomicUsize,
     pub open_upgrades: AtomicUsize,
+    pub open_bridge_sessions: AtomicUsize,
     pub active_spool_bytes: AtomicUsize,
     pub refresh_inflight: AtomicUsize,
     pub refresh_scheduler_ticks: AtomicU64,
@@ -25,12 +65,53 @@ pub struct Stats {
     pub refresh_reauth_required: AtomicU64,
     pub refresh_last_sweep_unix: AtomicU64,
     pub refresh_last_success_unix: AtomicU64,
+    pub http_capacity_limit: AtomicUsize,
+    pub bridge_turn_capacity_limit: AtomicUsize,
+    pub upgrade_capacity_limit: AtomicUsize,
+    pub bridge_session_capacity_limit: AtomicUsize,
+    pub http_admission_rejected: AtomicU64,
+    pub bridge_turn_admission_rejected: AtomicU64,
+    pub upgrade_admission_rejected: AtomicU64,
+    pub admission_timed_out: AtomicU64,
+    capacity_stages: Mutex<CapacityStages>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CapacitySnapshot {
+    pub http_limit: usize,
+    pub http_active: usize,
+    pub http_available: usize,
+    pub bridge_turn_limit: usize,
+    pub bridge_turn_active: usize,
+    pub bridge_turn_available: usize,
+    pub upgrade_limit: usize,
+    pub upgrade_active: usize,
+    pub upgrade_handshakes: usize,
+    pub upgrade_available: usize,
+    pub open_upgrades: usize,
+    pub bridge_session_limit: usize,
+    pub open_bridge_sessions: usize,
+    pub bridge_session_available: usize,
+    pub saturated: bool,
+    pub admission_rejected: u64,
+    pub http_admission_rejected: u64,
+    pub bridge_turn_admission_rejected: u64,
+    pub upgrade_admission_rejected: u64,
+    /// Admission is fail-fast, so queue depth is deliberately always zero. Rejection counters
+    /// are the durable queue-pressure signal rather than an unbounded waiter count.
+    pub admission_queue_depth: usize,
+    pub admission_timed_out: u64,
+    pub oldest_active_stage: Option<String>,
+    pub oldest_active_age_millis: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StatsSnapshot {
     pub inflight_http: usize,
     pub open_upgrades: usize,
+    #[serde(default)]
+    pub open_bridge_sessions: usize,
     pub affinity_entries: usize,
     pub affinity_bytes: usize,
     pub active_spool_bytes: usize,
@@ -53,9 +134,103 @@ pub struct StatsSnapshot {
     pub refresh_last_sweep_unix: u64,
     #[serde(default)]
     pub refresh_last_success_unix: u64,
+    #[serde(default)]
+    pub capacity: CapacitySnapshot,
 }
 
 impl Stats {
+    pub fn configure_capacity(&self, http: usize, bridge_turns: usize, upgrades: usize) {
+        self.http_capacity_limit.store(http, Ordering::Release);
+        self.bridge_turn_capacity_limit
+            .store(bridge_turns, Ordering::Release);
+        self.upgrade_capacity_limit
+            .store(upgrades, Ordering::Release);
+    }
+
+    pub fn configure_bridge_session_capacity(&self, bridge_sessions: usize) {
+        self.bridge_session_capacity_limit
+            .store(bridge_sessions, Ordering::Release);
+    }
+
+    pub fn capacity_stage_started(&self, stage: CapacityStage) -> u64 {
+        let mut stages = self.capacity_stages.lock().expect("capacity stages");
+        stages.next_id = stages.next_id.wrapping_add(1).max(1);
+        let id = stages.next_id;
+        stages
+            .active
+            .entry(stage)
+            .or_default()
+            .insert(id, Instant::now());
+        id
+    }
+
+    pub fn capacity_stage_finished(&self, stage: CapacityStage, id: u64) {
+        let mut stages = self.capacity_stages.lock().expect("capacity stages");
+        if let Some(active) = stages.active.get_mut(&stage) {
+            active.remove(&id);
+            if active.is_empty() {
+                stages.active.remove(&stage);
+            }
+        }
+    }
+
+    pub fn capacity_snapshot(&self) -> CapacitySnapshot {
+        let http_limit = self.http_capacity_limit.load(Ordering::Acquire);
+        let http_active = self.inflight_regular_http.load(Ordering::Acquire);
+        let bridge_turn_limit = self.bridge_turn_capacity_limit.load(Ordering::Acquire);
+        let bridge_turn_active = self.active_bridge_turns.load(Ordering::Acquire);
+        let upgrade_limit = self.upgrade_capacity_limit.load(Ordering::Acquire);
+        let upgrade_handshakes = self.upgrade_handshakes.load(Ordering::Acquire);
+        let open_upgrades = self.open_upgrades.load(Ordering::Acquire);
+        let upgrade_active = upgrade_handshakes.saturating_add(open_upgrades);
+        let bridge_session_limit = self.bridge_session_capacity_limit.load(Ordering::Acquire);
+        let open_bridge_sessions = self.open_bridge_sessions.load(Ordering::Acquire);
+        let oldest = self
+            .capacity_stages
+            .lock()
+            .expect("capacity stages")
+            .active
+            .iter()
+            .flat_map(|(stage, entries)| entries.values().map(move |started| (*stage, *started)))
+            .min_by_key(|(_, started)| *started);
+        let http_admission_rejected = self.http_admission_rejected.load(Ordering::Acquire);
+        let bridge_turn_admission_rejected =
+            self.bridge_turn_admission_rejected.load(Ordering::Acquire);
+        let upgrade_admission_rejected = self.upgrade_admission_rejected.load(Ordering::Acquire);
+        let rejected =
+            http_admission_rejected + bridge_turn_admission_rejected + upgrade_admission_rejected;
+        CapacitySnapshot {
+            http_limit,
+            http_active,
+            http_available: http_limit.saturating_sub(http_active),
+            bridge_turn_limit,
+            bridge_turn_active,
+            bridge_turn_available: bridge_turn_limit.saturating_sub(bridge_turn_active),
+            upgrade_limit,
+            upgrade_active,
+            upgrade_handshakes,
+            upgrade_available: upgrade_limit.saturating_sub(upgrade_active),
+            open_upgrades,
+            bridge_session_limit,
+            open_bridge_sessions,
+            bridge_session_available: bridge_session_limit.saturating_sub(open_bridge_sessions),
+            saturated: (http_limit != 0 && http_active >= http_limit)
+                || (bridge_turn_limit != 0 && bridge_turn_active >= bridge_turn_limit)
+                || (upgrade_limit != 0 && upgrade_active >= upgrade_limit)
+                || (bridge_session_limit != 0 && open_bridge_sessions >= bridge_session_limit),
+            admission_rejected: rejected,
+            http_admission_rejected,
+            bridge_turn_admission_rejected,
+            upgrade_admission_rejected,
+            admission_queue_depth: 0,
+            admission_timed_out: self.admission_timed_out.load(Ordering::Acquire),
+            oldest_active_stage: oldest.map(|(stage, _)| stage.name().to_owned()),
+            oldest_active_age_millis: oldest.map(|(_, started)| {
+                u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+            }),
+        }
+    }
+
     pub async fn snapshot(&self, router: &Router) -> StatsSnapshot {
         let (affinity_entries, affinity_bytes) = router.affinity.len_and_bytes().await;
         let records = router.record_count().await;
@@ -63,6 +238,7 @@ impl Stats {
         StatsSnapshot {
             inflight_http: self.inflight_http.load(Ordering::Relaxed),
             open_upgrades: self.open_upgrades.load(Ordering::Relaxed),
+            open_bridge_sessions: self.open_bridge_sessions.load(Ordering::Relaxed),
             affinity_entries,
             affinity_bytes,
             active_spool_bytes: self.active_spool_bytes.load(Ordering::Relaxed),
@@ -77,17 +253,183 @@ impl Stats {
             refresh_reauth_required: self.refresh_reauth_required.load(Ordering::Relaxed),
             refresh_last_sweep_unix: self.refresh_last_sweep_unix.load(Ordering::Relaxed),
             refresh_last_success_unix: self.refresh_last_success_unix.load(Ordering::Relaxed),
+            capacity: self.capacity_snapshot(),
         }
     }
 
     pub async fn write(&self, path: PathBuf, router: &Arc<Router>) -> Result<()> {
         let snapshot = self.snapshot(router).await;
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let temp = path.with_extension("json.tmp");
-        fs::write(&temp, serde_json::to_vec_pretty(&snapshot)?)?;
-        fs::rename(temp, path)?;
+        let writer = stats_writer(&path)?;
+        let generation = writer
+            .next_generation
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        tokio::task::spawn_blocking(move || {
+            write_snapshot_ordered(&path, &snapshot, generation, &writer)
+        })
+        .await
+        .context("join stats snapshot writer")?
+    }
+}
+
+fn stats_writer(path: &Path) -> Result<Arc<StatsWriterState>> {
+    let mut writers = STATS_WRITERS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .map_err(|_| anyhow::anyhow!("stats snapshot writer registry lock poisoned"))?;
+    if let Some(writer) = writers.get(path).and_then(Weak::upgrade) {
+        return Ok(writer);
+    }
+    let writer = Arc::new(StatsWriterState::default());
+    writers.insert(path.to_path_buf(), Arc::downgrade(&writer));
+    Ok(writer)
+}
+
+fn write_snapshot_ordered(
+    path: &Path,
+    snapshot: &StatsSnapshot,
+    generation: u64,
+    writer: &StatsWriterState,
+) -> Result<()> {
+    let _writer = writer
+        .lock
+        .lock()
+        .map_err(|_| anyhow::anyhow!("stats snapshot writer lock poisoned"))?;
+    if generation <= writer.persisted_generation.load(Ordering::Acquire) {
+        return Ok(());
+    }
+    write_snapshot_atomic(path, snapshot)?;
+    writer
+        .persisted_generation
+        .store(generation, Ordering::Release);
+    Ok(())
+}
+
+fn write_snapshot_atomic(path: &Path, snapshot: &StatsSnapshot) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let bytes = serde_json::to_vec_pretty(snapshot)?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)?;
+    temp.write_all(&bytes)?;
+    temp.as_file().sync_all()?;
+    temp.persist(path).map_err(|error| error.error)?;
+    sync_parent_directory(parent)?;
+    Ok(())
+}
+
+fn sync_parent_directory(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(inflight_http: usize) -> StatsSnapshot {
+        StatsSnapshot {
+            inflight_http,
+            open_upgrades: 2,
+            open_bridge_sessions: 3,
+            affinity_entries: 3,
+            affinity_bytes: 4,
+            active_spool_bytes: 5,
+            quota_records: 6,
+            health_records: 6,
+            routing: RoutingSnapshot::default(),
+            refresh_inflight: 7,
+            refresh_scheduler_ticks: 8,
+            refresh_accounts_checked: 9,
+            refresh_successes: 10,
+            refresh_failures: 11,
+            refresh_reauth_required: 12,
+            refresh_last_sweep_unix: 13,
+            refresh_last_success_unix: 14,
+            capacity: CapacitySnapshot::default(),
+        }
+    }
+
+    #[test]
+    fn atomic_stats_write_replaces_complete_json_without_temp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        fs::write(&path, b"stale").unwrap();
+
+        write_snapshot_atomic(&path, &snapshot(42)).unwrap();
+
+        let restored: StatsSnapshot = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(restored.inflight_http, 42);
+        let entries = fs::read_dir(dir.path()).unwrap().count();
+        assert_eq!(entries, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_stale_stats_writer_cannot_replace_a_newer_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let writer = Arc::new(StatsWriterState::default());
+        let older = writer
+            .next_generation
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+        let newer = writer
+            .next_generation
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
+
+        let (older_started_tx, older_started_rx) = std::sync::mpsc::channel();
+        let (release_older_tx, release_older_rx) = std::sync::mpsc::channel();
+        let (older_finished_tx, older_finished_rx) = std::sync::mpsc::channel();
+        let older_path = path.clone();
+        let older_writer = writer.clone();
+        let stale_waiter = tokio::task::spawn_blocking(move || {
+            older_started_tx.send(()).unwrap();
+            release_older_rx.recv().unwrap();
+            let result =
+                write_snapshot_ordered(&older_path, &snapshot(1), older, older_writer.as_ref());
+            older_finished_tx.send(()).unwrap();
+            result
+        });
+        older_started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+        stale_waiter.abort();
+        drop(stale_waiter);
+
+        write_snapshot_ordered(&path, &snapshot(2), newer, writer.as_ref()).unwrap();
+        release_older_tx.send(()).unwrap();
+        older_finished_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap();
+
+        let restored: StatsSnapshot = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(restored.inflight_http, 2);
+    }
+
+    #[test]
+    fn bridge_sessions_are_accounted_against_their_own_capacity() {
+        let stats = Stats::default();
+        stats.configure_capacity(64, 64, 32);
+        stats.configure_bridge_session_capacity(256);
+        stats.open_bridge_sessions.store(32, Ordering::Release);
+
+        let snapshot = stats.capacity_snapshot();
+        assert_eq!(snapshot.open_bridge_sessions, 32);
+        assert_eq!(snapshot.bridge_session_available, 224);
+        assert_eq!(snapshot.upgrade_active, 0);
+        assert!(!snapshot.saturated);
+
+        stats.open_upgrades.store(32, Ordering::Release);
+        assert!(stats.capacity_snapshot().saturated);
+        stats.open_upgrades.store(0, Ordering::Release);
+        stats.open_bridge_sessions.store(256, Ordering::Release);
+        assert!(stats.capacity_snapshot().saturated);
     }
 }


### PR DESCRIPTION
Separates serving bulkheads, enforces bounded request and streaming deadlines, makes auth and persistence cancellation-safe, reports truthful saturation, and bounds shutdown and process supervision.