### PR TITLE
Prevent service startup and descriptor stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,6 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -290,6 +289,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ native-tls = "=0.2.14"
 rand = "0.9"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 rustls = { version = "=0.23.36", default-features = false, features = ["aws_lc_rs", "std"] }
-rustls-native-certs = "=0.8.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
@@ -56,6 +55,7 @@ toml = "0.9"
 toml_edit = "0.23"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+webpki-roots = "1"
 
 [dev-dependencies]
 md-5 = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,10 @@ kind = "inbound"
 }
 
 async fn serve(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    if let Some((soft, hard)) = open_file_limits() {
+        info!(soft, hard, "open file limits");
+    }
     let config_path =
         fs::canonicalize(path).with_context(|| format!("resolve config {}", path.display()))?;
     let config = Arc::new(load_config(path)?);
@@ -351,6 +355,17 @@ async fn serve(path: &Path) -> Result<()> {
         return Err(error);
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn open_file_limits() -> Option<(u64, u64)> {
+    let mut limits = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: `limits` points to initialized writable storage for getrlimit.
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut limits) };
+    (result == 0).then_some((limits.rlim_cur, limits.rlim_max))
 }
 
 async fn shutdown_signal() -> Result<()> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,6 +14,9 @@ use std::process::Stdio;
 use anyhow::{Context, Result, bail};
 
 const LABEL: &str = "com.nicosuave.comradex";
+// Replay spooling plus the configured bridge/session ceilings can legitimately
+// consume about 6,800 descriptors before ordinary HTTP keep-alives.
+const SERVICE_NOFILE_SOFT_LIMIT: u64 = 8192;
 // launchd can take several seconds to uncork a freshly installed or upgraded
 // executable. Keep this comfortably above the 8-9 second starts observed on
 // otherwise healthy Apple Silicon hosts.
@@ -124,6 +127,8 @@ fn render_plist(
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>ProcessType</key><string>Background</string>
+  <key>SoftResourceLimits</key>
+  <dict><key>NumberOfFiles</key><integer>{nofile_soft_limit}</integer></dict>
   <key>EnvironmentVariables</key>
   <dict><key>COMRADEX_SERVICE_NONCE</key><string>{service_nonce}</string></dict>
   <key>StandardOutPath</key><string>{stdout}</string>
@@ -138,6 +143,7 @@ fn render_plist(
         stdout = xml(stdout),
         stderr = xml(stderr),
         service_nonce = service_nonce,
+        nofile_soft_limit = SERVICE_NOFILE_SOFT_LIMIT,
     )
 }
 
@@ -1200,5 +1206,14 @@ mod tests {
         file.write_all(plist.as_bytes()).unwrap();
         file.as_file().sync_all().unwrap();
         validate_plist(file.path()).unwrap();
+
+        let output = Command::new("plutil")
+            .args(["-extract", "SoftResourceLimits.NumberOfFiles", "raw", "--"])
+            .arg(file.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "8192");
+        assert!(!plist.contains("HardResourceLimits"));
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,24 +1,10 @@
-use std::{sync::Arc, thread, time::Duration};
+use std::sync::Arc;
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result};
 use hyper_rustls::HttpsConnector as RustlsHttpsConnector;
 use hyper_tls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
-use rustls::{ClientConfig, RootCertStore, pki_types::CertificateDer};
-
-// macOS can briefly return an empty trust store while a user's login session is
-// still coming up. Keep this well below the service's 20-second readiness
-// timeout while allowing the platform security services time to settle.
-#[cfg(target_os = "macos")]
-const TLS_ROOT_RETRY_DELAYS: &[Duration] = &[
-    Duration::from_millis(250),
-    Duration::from_millis(500),
-    Duration::from_secs(1),
-    Duration::from_secs(2),
-    Duration::from_secs(4),
-];
-#[cfg(not(target_os = "macos"))]
-const TLS_ROOT_RETRY_DELAYS: &[Duration] = &[];
+use rustls::{ClientConfig, RootCertStore};
 
 /// Builds the same transport-default TLS shape used by Codex's reqwest 0.12 client.
 ///
@@ -37,8 +23,9 @@ pub(crate) fn codex_http_connector() -> Result<HttpsConnector<HttpConnector>> {
 
 /// Builds the explicit Rustls transport used by Codex Responses WebSockets.
 ///
-/// Codex uses AWS-LC, platform roots, and no ALPN for this HTTP/1.1 upgrade
-/// path. `enable_http1` deliberately preserves the empty ALPN list.
+/// Codex uses AWS-LC and no ALPN for this HTTP/1.1 upgrade path. The fixed
+/// public upstream uses Mozilla's bundled roots so service startup never blocks
+/// while macOS enumerates Security.framework trust settings.
 pub(crate) fn codex_websocket_connector() -> Result<RustlsHttpsConnector<HttpConnector>> {
     let config = codex_websocket_tls_config()?;
     Ok(hyper_rustls::HttpsConnectorBuilder::new()
@@ -53,200 +40,21 @@ fn codex_websocket_tls_config() -> Result<ClientConfig> {
     let builder = ClientConfig::builder_with_provider(Arc::new(provider))
         .with_safe_default_protocol_versions()
         .context("select Codex Rustls protocol versions")?;
-    let roots = load_platform_root_store()?;
+    let roots = RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     Ok(builder.with_root_certificates(roots).with_no_client_auth())
-}
-
-fn load_platform_root_store() -> Result<RootCertStore> {
-    load_platform_root_store_with(
-        || {
-            let native = rustls_native_certs::load_native_certs();
-            (native.certs, native.errors.len())
-        },
-        thread::sleep,
-        TLS_ROOT_RETRY_DELAYS,
-    )
-}
-
-fn load_platform_root_store_with<Load, Sleep>(
-    mut load: Load,
-    mut sleep: Sleep,
-    retry_delays: &[Duration],
-) -> Result<RootCertStore>
-where
-    Load: FnMut() -> (Vec<CertificateDer<'static>>, usize),
-    Sleep: FnMut(Duration),
-{
-    let mut attempt = 1;
-    loop {
-        let (certs, load_error_count) = load();
-        match root_store_from_native_certs(certs, load_error_count) {
-            Ok(roots) => return Ok(roots),
-            Err(error) => match retry_delays.get(attempt - 1) {
-                Some(delay) => {
-                    sleep(*delay);
-                    attempt += 1;
-                }
-                None => {
-                    return Err(error).with_context(|| {
-                        format!("load platform TLS roots after {attempt} attempts")
-                    });
-                }
-            },
-        }
-    }
-}
-
-fn root_store_from_native_certs(
-    certs: Vec<CertificateDer<'static>>,
-    load_error_count: usize,
-) -> Result<RootCertStore> {
-    let mut roots = RootCertStore::empty();
-    let (valid_count, invalid_count) = roots.add_parsable_certificates(certs);
-    ensure!(
-        valid_count > 0,
-        "load platform TLS roots: no usable certificates ({load_error_count} load errors, {invalid_count} parse errors)"
-    );
-    Ok(roots)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-    use std::time::Duration;
-
     use http_body_util::Empty;
     use hyper::{Request, body::Bytes};
     use hyper_util::{client::legacy::Client, rt::TokioExecutor};
     use md5::{Digest as _, Md5};
     use sha2::Sha256;
+    use std::collections::BTreeSet;
     use tokio::{io::AsyncReadExt, net::TcpListener};
 
-    use rustls::pki_types::CertificateDer;
-
-    #[cfg(target_os = "macos")]
-    use super::TLS_ROOT_RETRY_DELAYS;
-    use super::{
-        codex_http_connector, codex_websocket_connector, load_platform_root_store_with,
-        root_store_from_native_certs,
-    };
-
-    #[test]
-    fn websocket_root_store_rejects_no_native_certificates() {
-        let error = root_store_from_native_certs(Vec::new(), 2).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "load platform TLS roots: no usable certificates (2 load errors, 0 parse errors)"
-        );
-    }
-
-    #[test]
-    fn websocket_root_store_rejects_only_unparsable_certificates() {
-        let error = root_store_from_native_certs(
-            vec![CertificateDer::from(vec![0xde, 0xad, 0xbe, 0xef])],
-            0,
-        )
-        .unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "load platform TLS roots: no usable certificates (0 load errors, 1 parse errors)"
-        );
-    }
-
-    #[test]
-    fn websocket_root_store_tolerates_bad_certificates_when_a_root_is_usable() {
-        let native = rustls_native_certs::load_native_certs();
-        let valid = native
-            .certs
-            .into_iter()
-            .find(|cert| {
-                let mut roots = rustls::RootCertStore::empty();
-                roots.add(cert.clone()).is_ok()
-            })
-            .expect("test platform should provide at least one usable TLS root");
-        let roots = root_store_from_native_certs(
-            vec![CertificateDer::from(vec![0xde, 0xad, 0xbe, 0xef]), valid],
-            1,
-        )
-        .unwrap();
-        assert_eq!(roots.len(), 1);
-    }
-
-    #[test]
-    fn websocket_root_store_retries_until_platform_roots_are_available() {
-        let native = rustls_native_certs::load_native_certs();
-        let valid = native
-            .certs
-            .into_iter()
-            .find(|cert| {
-                let mut roots = rustls::RootCertStore::empty();
-                roots.add(cert.clone()).is_ok()
-            })
-            .expect("test platform should provide at least one usable TLS root");
-        let mut loads = 0;
-        let mut sleeps = Vec::new();
-        let roots = load_platform_root_store_with(
-            || {
-                loads += 1;
-                if loads < 3 {
-                    (Vec::new(), loads)
-                } else {
-                    (vec![valid.clone()], 0)
-                }
-            },
-            |delay| sleeps.push(delay),
-            &[
-                Duration::from_millis(10),
-                Duration::from_millis(20),
-                Duration::from_millis(40),
-            ],
-        )
-        .unwrap();
-
-        assert_eq!(loads, 3);
-        assert_eq!(
-            sleeps,
-            [Duration::from_millis(10), Duration::from_millis(20)]
-        );
-        assert_eq!(roots.len(), 1);
-    }
-
-    #[test]
-    fn websocket_root_store_fails_after_bounded_retries() {
-        let mut loads = 0;
-        let mut sleeps = Vec::new();
-        let error = load_platform_root_store_with(
-            || {
-                loads += 1;
-                (Vec::new(), loads)
-            },
-            |delay| sleeps.push(delay),
-            &[Duration::from_millis(10), Duration::from_millis(20)],
-        )
-        .unwrap_err();
-
-        assert_eq!(loads, 3);
-        assert_eq!(
-            sleeps,
-            [Duration::from_millis(10), Duration::from_millis(20)]
-        );
-        assert_eq!(
-            error.to_string(),
-            "load platform TLS roots after 3 attempts"
-        );
-        assert_eq!(
-            error.root_cause().to_string(),
-            "load platform TLS roots: no usable certificates (3 load errors, 0 parse errors)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn websocket_root_store_retry_budget_stays_below_service_ready_timeout() {
-        let total: Duration = TLS_ROOT_RETRY_DELAYS.iter().sum();
-        assert_eq!(total, Duration::from_millis(7_750));
-        assert!(total < Duration::from_secs(20));
-    }
+    use super::{codex_http_connector, codex_websocket_connector};
 
     #[derive(Debug, PartialEq, Eq)]
     struct ClientHelloProfile {


### PR DESCRIPTION
Replace blocking macOS trust-store enumeration on the fixed ChatGPT WebSocket path with bundled public roots.

Give the LaunchAgent an 8192 open-file soft limit and log inherited limits at daemon startup.