### PR TITLE
Support native history and notes across account rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,41 @@ The service manages only `com.nicosuave.comradex`; it does not inspect, stop, or
 
 ## How routing works
 
+### Experimental Codex history and notes
+
+Codex 0.153.4's native context management is opt-in. If your Codex configuration already contains
+`[features.context_management]` with `experimental_mode = true`, `comradex install` uses
+`/<installation_secret>/backend-api/codex` instead of `/v1`. Comradex does not enable the feature.
+Both authenticated URL forms remain supported. Start a new task after enabling it so Comradex can
+track its history from the first inference request.
+
+The first context operation or qualifying inference dispatch establishes a durable notes owner for
+the root session. After inference switches from account A to B, notes reads and writes still use A's
+credentials, and their results are delivered to inference on B. No notes are copied between accounts.
+Inference quota exhaustion does not prevent accessing notes, but missing credentials, an account
+being logged into, removal from the pool, or a different user signing into the same account alias
+make that owner's context unavailable. Notes writes never fail over to another account.
+
+History remains on every account that participated in inference. Comradex queries those accounts
+with at most four concurrent requests and a 30-second overall deadline. Every participant must
+succeed; one failure fails the history query rather than returning an incomplete record. History
+results stay encrypted and are supplied as separate partitions for the model to combine. Global
+ordering, deduplication, and pagination are not guaranteed by the proxy. A failed context query
+does not change inference quota state or globally stop inference.
+
+The relay preserves native encrypted arguments and protocol headers. It authenticates and encrypts
+the combined tool result, then restores the native results before the next inference request. Only
+verified context outputs receive portable routing treatment; unrelated encrypted reasoning and
+other account-owned state retain their existing continuity restrictions. HTTP, the HTTP WebSocket
+bridge, and direct Responses WebSockets support this path. Backend-alias Responses WebSockets use
+frame inspection even when the legacy `/v1` transport is configured as raw.
+
+Preserve `context.sqlite3` in the state directory and the existing `proxy.affinity_key` across
+restarts. Ownership is scoped to the pool and root session, distinguishes users within a shared
+workspace, and survives quota failures and authentication changes. Up to 32 physical participants
+are recorded per session; a dispatch that would exceed that limit fails before reaching upstream.
+Changing or losing the state/key requires starting a new context task.
+
 Each listener maps to an account pool. Comradex uses Codex's continuity signals to keep related work on the same healthy account, while quota thresholds affect only the admission of new threads.
 
 ### Affinity and ownership

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -54,6 +54,33 @@ pub struct Credentials {
     pub account_id: Option<String>,
 }
 
+impl Credentials {
+    /// Context belongs to a user within a workspace, not to a token or a config alias.
+    /// These claims identify the credential; upstream still authenticates the bearer itself.
+    pub fn context_identity(&self) -> Result<String> {
+        let token = self
+            .authorization
+            .strip_prefix("Bearer ")
+            .context("context identity unavailable")?;
+        let payload = jwt_payload(token).context("context identity unavailable")?;
+        let claims = &payload["https://api.openai.com/auth"];
+        let user = claims["chatgpt_user_id"]
+            .as_str()
+            .or_else(|| payload["sub"].as_str())
+            .filter(|s| !s.is_empty())
+            .context("context identity unavailable")?;
+        let workspace = claims["chatgpt_account_id"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .context("context identity unavailable")?;
+        anyhow::ensure!(
+            self.account_id.as_deref().is_none_or(|id| id == workspace),
+            "context identity mismatch"
+        );
+        Ok(serde_json::to_string(&(workspace, user))?)
+    }
+}
+
 #[derive(Clone)]
 pub struct Resolver {
     client: AuthClient,

--- a/src/install.rs
+++ b/src/install.rs
@@ -19,7 +19,7 @@ pub fn installed_record(record_path: &Path) -> Option<InstallRecord> {
     read_install_record(record_path).ok().flatten()
 }
 
-pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<()> {
+pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<String> {
     let destination = resolve_destination(codex_config)?;
     let original = match fs::read_to_string(&destination) {
         Ok(v) => v,
@@ -29,6 +29,14 @@ pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<()>
     let mut doc = original
         .parse::<DocumentMut>()
         .context("parse Codex config.toml")?;
+    let installed_url = if context_management_experimental_mode(&doc) {
+        let base = url
+            .strip_suffix("/v1")
+            .context("Comradex install URL must end in /v1")?;
+        format!("{base}/backend-api/codex")
+    } else {
+        url.to_owned()
+    };
     let current_url = doc
         .get("openai_base_url")
         .and_then(Item::as_str)
@@ -51,11 +59,11 @@ pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<()>
         }
         None => current_url,
     };
-    doc["openai_base_url"] = value(url);
+    doc["openai_base_url"] = value(&installed_url);
     atomic_write(&destination, doc.to_string().as_bytes())?;
     let record = InstallRecord {
         codex_config: destination.clone(),
-        installed_url: url.to_owned(),
+        installed_url: installed_url.clone(),
         previous_url,
     };
     if let Err(error) = atomic_write(record_path, &serde_json::to_vec_pretty(&record)?) {
@@ -63,7 +71,17 @@ pub fn install(codex_config: &Path, record_path: &Path, url: &str) -> Result<()>
             .context("roll back Codex config after install-record failure")?;
         return Err(error).context("write install record");
     }
-    Ok(())
+    Ok(installed_url)
+}
+
+fn context_management_experimental_mode(doc: &DocumentMut) -> bool {
+    doc.get("features")
+        .and_then(Item::as_table_like)
+        .and_then(|features| features.get("context_management"))
+        .and_then(Item::as_table_like)
+        .and_then(|context_management| context_management.get("experimental_mode"))
+        .and_then(Item::as_bool)
+        == Some(true)
 }
 
 fn read_install_record(path: &Path) -> Result<Option<InstallRecord>> {
@@ -192,20 +210,60 @@ mod tests {
     }
 
     #[test]
+    fn install_uses_backend_api_codex_when_context_management_is_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.toml");
+        let record = dir.path().join("install.json");
+        fs::write(
+            &config,
+            "[features.context_management]\nexperimental_mode = true\n",
+        )
+        .unwrap();
+
+        let installed = install(&config, &record, "http://127.0.0.1:10100/secret/v1").unwrap();
+
+        assert_eq!(installed, "http://127.0.0.1:10100/secret/backend-api/codex");
+        assert!(
+            fs::read_to_string(&config)
+                .unwrap()
+                .contains("http://127.0.0.1:10100/secret/backend-api/codex")
+        );
+    }
+
+    #[test]
+    fn install_uses_v1_when_context_management_is_disabled_or_absent() {
+        for config_text in [
+            "[features.context_management]\nexperimental_mode = false\n",
+            "model = \"gpt-test\"\n",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let config = dir.path().join("config.toml");
+            let record = dir.path().join("install.json");
+            fs::write(&config, config_text).unwrap();
+
+            let installed = install(&config, &record, "http://127.0.0.1:10100/secret/v1").unwrap();
+
+            assert_eq!(installed, "http://127.0.0.1:10100/secret/v1");
+        }
+    }
+
+    #[test]
     fn repeated_install_preserves_original_pre_comradex_url() {
         let dir = tempfile::tempdir().unwrap();
         let config = dir.path().join("config.toml");
         let record = dir.path().join("install.json");
         fs::write(
             &config,
-            "model = \"gpt-test\"\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n",
+            "model = \"gpt-test\"\nopenai_base_url = \"http://127.0.0.1:10100/v1\"\n[features.context_management]\nexperimental_mode = true\n",
         )
         .unwrap();
 
-        install(&config, &record, "http://127.0.0.1:10100/secret-a/v1").unwrap();
-        install(&config, &record, "http://127.0.0.1:10100/secret-b/v1").unwrap();
+        let first = install(&config, &record, "http://127.0.0.1:10100/secret-a/v1").unwrap();
+        let second = install(&config, &record, "http://127.0.0.1:10100/secret-b/v1").unwrap();
         uninstall(&record).unwrap();
 
+        assert!(first.ends_with("/secret-a/backend-api/codex"));
+        assert!(second.ends_with("/secret-b/backend-api/codex"));
         let restored = fs::read_to_string(&config).unwrap();
         assert!(restored.contains("http://127.0.0.1:10100/v1"));
         assert!(!restored.contains("secret-a"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -435,8 +435,9 @@ fn install_config(config_path: &Path, codex_config: &Path, listener_name: &str) 
         "http://{}/{}/v1",
         listener.address, config.proxy.installation_secret
     );
-    install::install(codex_config, &state_dir(&config).join("install.json"), &url)?;
-    println!("installed openai_base_url = {url}");
+    let installed_url =
+        install::install(codex_config, &state_dir(&config).join("install.json"), &url)?;
+    println!("installed openai_base_url = {installed_url}");
     Ok(())
 }
 

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -1,0 +1,352 @@
+//! Account-local native context tools. Their state outlives inference routing affinity.
+use super::context_store::ContextAccount;
+use super::*;
+use futures_util::TryStreamExt;
+use serde_json::Value;
+
+const MAX_CONTEXT_BYTES: usize = 2_000_000;
+
+pub(super) fn context_route(path: &str) -> Option<bool> {
+    let path = path.split('?').next()?.trim_end_matches('/');
+    match path {
+        "/alpha/history/v2/list_windows"
+        | "/alpha/history/v2/list_items"
+        | "/alpha/history/v2/read_item"
+        | "/alpha/history/v2/search_contents" => Some(true),
+        "/alpha/notes/v2/thread_hint"
+        | "/alpha/notes/v2/list_files_by_prefix"
+        | "/alpha/notes/v2/read_file"
+        | "/alpha/notes/v2/search_contents"
+        | "/alpha/notes/v2/append_to_file"
+        | "/alpha/notes/v2/write_file" => Some(false),
+        _ => None,
+    }
+}
+
+fn session_id(value: &Value) -> Option<&str> {
+    value.as_str().filter(|s| {
+        s.len() == 36
+            && s.bytes().enumerate().all(|(i, b)| {
+                if matches!(i, 8 | 13 | 18 | 23) {
+                    b == b'-'
+                } else {
+                    b.is_ascii_digit() || (b'a'..=b'f').contains(&b)
+                }
+            })
+    })
+}
+
+pub(super) fn inference_session(body: &Value) -> Option<&str> {
+    session_id(&body["client_metadata"]["session_id"])
+}
+
+impl App {
+    pub(super) async fn context_routing_view(&self, body: &Value, scope: &str) -> Result<Value> {
+        let session = inference_session(body).unwrap_or("");
+        let sources = self.context_codec.source_partitions(body, scope, session)?;
+        if !sources.is_empty() {
+            let stored = self
+                .context_store
+                .lookup(scope, session)
+                .await?
+                .context("context source unavailable")?;
+            let pool = self
+                .config
+                .pools
+                .get(scope)
+                .context("context source unavailable")?;
+            for source in sources {
+                let account = stored
+                    .participants
+                    .get(source - 1)
+                    .context("context source unavailable")?;
+                anyhow::ensure!(
+                    pool.members.contains(&account.alias),
+                    "context source unavailable"
+                );
+            }
+        }
+        self.context_codec.routing_view(body, scope, session)
+    }
+
+    pub(super) fn expand_context(&self, body: &mut Value, scope: &str) -> Result<bool> {
+        let session = inference_session(body).unwrap_or("").to_owned();
+        self.context_codec.expand(body, scope, &session)
+    }
+
+    pub(super) async fn record_context_dispatch(
+        &self,
+        body: &Value,
+        scope: &str,
+        account: &str,
+        credentials: &auth::Credentials,
+    ) -> Result<()> {
+        let Some(session) = inference_session(body) else {
+            anyhow::ensure!(
+                body["reasoning"]["context"] != "all_turns",
+                "context session unavailable"
+            );
+            return Ok(());
+        };
+        if body["reasoning"]["context"] != "all_turns"
+            && self.context_store.lookup(scope, session).await?.is_none()
+        {
+            return Ok(());
+        }
+        let physical = credentials.context_identity()?;
+        self.context_store
+            .record_dispatch(scope, session, account, &physical)
+            .await
+    }
+
+    async fn context_credentials(
+        &self,
+        owner: &ContextAccount,
+        listener: &ListenerConfig,
+        headers: &hyper::HeaderMap,
+    ) -> Result<auth::Credentials> {
+        // Inference quota is independent of notes/history availability. Login and pool membership
+        // still apply, and a re-login of the same alias must never silently change the owner.
+        anyhow::ensure!(
+            self.router
+                .context_account_available(self.pool(listener)?, &owner.alias)
+                .await,
+            "context owner unavailable"
+        );
+        let config = self
+            .config
+            .accounts
+            .get(&owner.alias)
+            .context("context owner unavailable")?;
+        let credentials = self.auth.resolve(config, headers).await?;
+        let physical = credentials.context_identity()?;
+        anyhow::ensure!(
+            self.context_store.physical_key(&physical) == owner.physical_id,
+            "context owner unavailable"
+        );
+        Ok(credentials)
+    }
+
+    async fn send_context_request(
+        &self,
+        owner: &ContextAccount,
+        listener: &ListenerConfig,
+        path: &str,
+        headers: &hyper::HeaderMap,
+        bytes: bytes::Bytes,
+    ) -> Result<Response<Incoming>> {
+        let mut credentials = self.context_credentials(owner, listener, headers).await?;
+        for attempt in 0..2 {
+            let response = self
+                .send_http(
+                    &Method::POST,
+                    path,
+                    headers,
+                    credentials.clone(),
+                    bytes_body(bytes.clone()),
+                )
+                .await?;
+            if response.status() == StatusCode::UNAUTHORIZED
+                && attempt == 0
+                && let Some(refreshed) = self
+                    .auth
+                    .force_refresh(&self.config.accounts[&owner.alias], &credentials)
+                    .await?
+            {
+                anyhow::ensure!(
+                    self.context_store
+                        .physical_key(&refreshed.context_identity()?)
+                        == owner.physical_id,
+                    "context owner unavailable"
+                );
+                credentials = refreshed;
+                continue;
+            }
+            return Ok(response);
+        }
+        unreachable!()
+    }
+
+    pub(super) async fn handle_context(
+        &self,
+        method: Method,
+        path: &str,
+        headers: &hyper::HeaderMap,
+        listener: &ListenerConfig,
+        replay: ReplayBody,
+    ) -> Result<Response<ProxyBody>> {
+        let Some(history) = context_route(path) else {
+            return Ok(error_response(
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "unknown context operation",
+            ));
+        };
+        if method != Method::POST {
+            return Ok(error_response(
+                StatusCode::METHOD_NOT_ALLOWED,
+                "invalid_request_error",
+                "context operations require POST",
+            ));
+        }
+        let bytes = replay.into_bytes().await?;
+        if bytes.len() > MAX_CONTEXT_BYTES {
+            return Ok(error_response(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "invalid_request_error",
+                "context request exceeds limit",
+            ));
+        }
+        let body: Value = match serde_json::from_slice(&bytes) {
+            Ok(body) => body,
+            Err(_) => {
+                return Ok(error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request_error",
+                    "invalid context request",
+                ));
+            }
+        };
+        let Some(session) = session_id(&body["context"]["session_id"]) else {
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                "context.session_id is required",
+            ));
+        };
+        if !body["context"]["current_agent_name"]
+            .as_str()
+            .is_some_and(|name| {
+                name.len() <= 1024
+                    && (name == "/root" || name.starts_with("/root/"))
+                    && name.split('/').skip(1).all(|part| {
+                        !part.is_empty()
+                            && part != "."
+                            && part != ".."
+                            && !part.chars().any(char::is_control)
+                    })
+            })
+        {
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                "invalid current agent name",
+            ));
+        }
+        let result = self
+            .relay_context(path, headers, listener, session, bytes, history)
+            .await;
+        // Do not echo upstream errors: encrypted tool arguments and private context can occur in them.
+        Ok(result.unwrap_or_else(|_| {
+            error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "context_backend_unavailable",
+                "required context account is unavailable",
+            )
+        }))
+    }
+
+    async fn relay_context(
+        &self,
+        path: &str,
+        headers: &hyper::HeaderMap,
+        listener: &ListenerConfig,
+        session: &str,
+        bytes: bytes::Bytes,
+        history: bool,
+    ) -> Result<Response<ProxyBody>> {
+        let _permit = self
+            .http_slots
+            .clone()
+            .try_acquire_owned()
+            .context("context capacity reached")?;
+        let _inflight = InflightGuard::new(&self.stats.inflight_http);
+        let scope = &listener.pool;
+        if self.context_store.lookup(scope, session).await?.is_none() {
+            let pool = self.pool(listener)?;
+            let mut selected = None;
+            for account in pool.preferred.iter().chain(pool.members.iter()) {
+                if self.router.context_account_available(pool, account).await {
+                    selected = Some(account);
+                    break;
+                }
+            }
+            let selected = selected.context("context owner unavailable")?;
+            let credentials = self
+                .auth
+                .resolve(&self.config.accounts[selected], headers)
+                .await?;
+            let physical = credentials.context_identity()?;
+            self.context_store
+                .record_dispatch(scope, session, selected, &physical)
+                .await?;
+        }
+        let stored = self
+            .context_store
+            .lookup(scope, session)
+            .await?
+            .context("context owner unavailable")?;
+        let accounts = if history {
+            stored.participants
+        } else {
+            vec![stored.owner]
+        };
+        anyhow::ensure!(
+            !accounts.is_empty() && accounts.len() <= 32,
+            "context participants unavailable"
+        );
+        // Bounded fanout. No retry on timeouts, quota, or ambiguous writes, and no model health updates.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let results: Vec<Value> = futures_util::stream::iter(accounts.into_iter().map(|account| {
+            let bytes = bytes.clone();
+            async move {
+                let response = tokio::time::timeout_at(deadline, async {
+                    let response = self
+                        .send_context_request(&account, listener, path, headers, bytes)
+                        .await?;
+                    anyhow::ensure!(
+                        response.status().is_success(),
+                        "context backend unavailable"
+                    );
+                    let mut body = response.into_body();
+                    let mut bytes = bytes::BytesMut::new();
+                    while let Some(frame) = body.frame().await {
+                        let frame = frame?;
+                        if let Some(data) = frame.data_ref() {
+                            anyhow::ensure!(
+                                bytes.len().saturating_add(data.len()) <= MAX_CONTEXT_BYTES,
+                                "context result exceeds limit"
+                            );
+                            bytes.extend_from_slice(data);
+                        }
+                    }
+                    Ok::<Value, anyhow::Error>(serde_json::from_slice(&bytes)?)
+                })
+                .await??;
+                Ok::<Value, anyhow::Error>(response)
+            }
+        }))
+        .buffered(4)
+        .try_collect()
+        .await?;
+        anyhow::ensure!(!results.is_empty(), "context backend unavailable");
+        let value = if path
+            .split('?')
+            .next()
+            .unwrap_or(path)
+            .trim_end_matches('/')
+            .ends_with("/thread_hint")
+        {
+            results
+                .into_iter()
+                .next()
+                .context("context hint unavailable")?
+        } else {
+            self.context_codec.pack(scope, session, results, history)?
+        };
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/json")
+            .body(json_body(value))?)
+    }
+}

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -41,7 +41,13 @@ pub(super) fn inference_session(body: &Value) -> Option<&str> {
 }
 
 impl App {
-    pub(super) async fn context_routing_view(&self, body: &Value, scope: &str) -> Result<Value> {
+    pub(super) async fn context_routing_view(
+        &self,
+        body: &Value,
+        listener: &ListenerConfig,
+        headers: &hyper::HeaderMap,
+    ) -> Result<Value> {
+        let scope = &listener.pool;
         let session = inference_session(body).unwrap_or("");
         let sources = self.context_codec.source_partitions(body, scope, session)?;
         if !sources.is_empty() {
@@ -50,20 +56,13 @@ impl App {
                 .lookup(scope, session)
                 .await?
                 .context("context source unavailable")?;
-            let pool = self
-                .config
-                .pools
-                .get(scope)
-                .context("context source unavailable")?;
             for source in sources {
                 let account = stored
                     .participants
                     .get(source - 1)
                     .context("context source unavailable")?;
-                anyhow::ensure!(
-                    pool.members.contains(&account.alias),
-                    "context source unavailable"
-                );
+                // A retained alias is insufficient after login or a physical identity change.
+                self.context_credentials(account, listener, headers).await?;
             }
         }
         self.context_codec.routing_view(body, scope, session)

--- a/src/proxy/context_codec.rs
+++ b/src/proxy/context_codec.rs
@@ -1,0 +1,721 @@
+use anyhow::{Result, ensure};
+use aws_lc_rs::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+const PREFIX: &str = "comradex-context-v1:";
+const MAX_ENVELOPE_BYTES: usize = 2_000_000;
+const MAX_RESULTS: usize = 32;
+const MAX_EXPANDED_BYTES: usize = 128_000_000;
+const NONCE_BYTES: usize = 12;
+const TAG_BYTES: usize = 16;
+const KEY_DERIVATION_CONTEXT: &str = "comradex context codec v1 AES-256-GCM key";
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextEnvelope {
+    scope: String,
+    session: String,
+    history: bool,
+    results: Vec<Value>,
+}
+
+/// Carries native Codex context results through a single function result.
+pub struct ContextCodec {
+    key_bytes: [u8; 32],
+}
+
+impl ContextCodec {
+    pub fn new(key_text: &str) -> Self {
+        Self {
+            key_bytes: blake3::derive_key(KEY_DERIVATION_CONTEXT, key_text.as_bytes()),
+        }
+    }
+
+    pub fn pack(
+        &self,
+        scope: &str,
+        session: &str,
+        results: Vec<Value>,
+        history: bool,
+    ) -> Result<Value> {
+        ensure!(
+            (1..=MAX_RESULTS).contains(&results.len()),
+            "invalid Comradex context result count"
+        );
+        let mut plaintext = serde_json::to_vec(&ContextEnvelope {
+            scope: scope.to_owned(),
+            session: session.to_owned(),
+            history,
+            results,
+        })?;
+        ensure!(
+            plaintext.len() <= MAX_ENVELOPE_BYTES,
+            "Comradex context envelope exceeds safety limit"
+        );
+
+        let mut nonce_bytes = [0_u8; NONCE_BYTES];
+        rand::fill(&mut nonce_bytes);
+        self.key()?
+            .seal_in_place_append_tag(
+                Nonce::assume_unique_for_key(nonce_bytes),
+                Aad::from(PREFIX.as_bytes()),
+                &mut plaintext,
+            )
+            .map_err(|_| anyhow::anyhow!("failed to seal Comradex context envelope"))?;
+
+        let mut token_bytes = Vec::with_capacity(NONCE_BYTES + plaintext.len());
+        token_bytes.extend_from_slice(&nonce_bytes);
+        token_bytes.extend_from_slice(&plaintext);
+        Ok(json!({
+            "encrypted_output": format!("{PREFIX}{}", URL_SAFE_NO_PAD.encode(token_bytes))
+        }))
+    }
+
+    /// Expands Comradex context tokens in native function-call outputs.
+    ///
+    /// Returns whether any token was expanded. On error, `body` is unchanged.
+    pub fn expand(&self, body: &mut Value, scope: &str, session: &str) -> Result<bool> {
+        let Some(input) = body.get("input").and_then(Value::as_array) else {
+            return Ok(false);
+        };
+
+        let mut expanded_input = input.clone();
+        let mut changed = false;
+        let mut expanded_bytes = 0_usize;
+
+        for item in &mut expanded_input {
+            let Some(item_object) = item.as_object_mut() else {
+                continue;
+            };
+            if item_object.get("type").and_then(Value::as_str) != Some("function_call_output") {
+                continue;
+            }
+            let Some(output) = item_object.get("output").and_then(Value::as_array) else {
+                continue;
+            };
+
+            let mut expanded_output = Vec::with_capacity(output.len());
+            let mut output_changed = false;
+            for part in output {
+                let Some(token) = context_token(part) else {
+                    expanded_output.push(part.clone());
+                    continue;
+                };
+
+                let envelope = self.open_verified(token, scope, session)?;
+                let parts = expanded_parts(envelope.results, envelope.history)?;
+                let part_bytes = serde_json::to_vec(&parts)?.len();
+                expanded_bytes = expanded_bytes.checked_add(part_bytes).ok_or_else(|| {
+                    anyhow::anyhow!("expanded Comradex context exceeds safety limit")
+                })?;
+                ensure!(
+                    expanded_bytes <= MAX_EXPANDED_BYTES,
+                    "expanded Comradex context exceeds safety limit"
+                );
+                expanded_output.extend(parts);
+                output_changed = true;
+            }
+
+            if output_changed {
+                item_object.insert("output".to_owned(), Value::Array(expanded_output));
+                changed = true;
+            }
+        }
+
+        if changed {
+            body.as_object_mut()
+                .expect("a value with an input field must be an object")
+                .insert("input".to_owned(), Value::Array(expanded_input));
+        }
+        Ok(changed)
+    }
+
+    /// Produces a request clone suitable for routing and full-resend analysis.
+    ///
+    /// Authenticated Comradex context wrappers are replaced with a stable marker. Native
+    /// ciphertext and every other request value remain untouched, and the returned view must
+    /// never be sent upstream.
+    pub fn routing_view(&self, body: &Value, scope: &str, session: &str) -> Result<Value> {
+        let mut view = body.clone();
+        let Some(input) = view.get_mut("input").and_then(Value::as_array_mut) else {
+            return Ok(view);
+        };
+
+        for item in input {
+            let Some(item) = item.as_object_mut() else {
+                continue;
+            };
+            if item.get("type").and_then(Value::as_str) != Some("function_call_output") {
+                continue;
+            }
+            let Some(output) = item.get_mut("output").and_then(Value::as_array_mut) else {
+                continue;
+            };
+            for part in output {
+                let Some(token) = context_token(part) else {
+                    continue;
+                };
+                self.open_verified(token, scope, session)?;
+                *part = json!({
+                    "type": "input_text",
+                    "text": "Verified context tool result"
+                });
+            }
+        }
+        Ok(view)
+    }
+
+    /// Returns the authenticated source ordinals represented by context wrappers in a request.
+    pub fn source_partitions(
+        &self,
+        body: &Value,
+        scope: &str,
+        session: &str,
+    ) -> Result<Vec<usize>> {
+        let Some(input) = body.get("input").and_then(Value::as_array) else {
+            return Ok(Vec::new());
+        };
+        let mut present = [false; MAX_RESULTS];
+
+        for item in input {
+            let Some(item) = item.as_object() else {
+                continue;
+            };
+            if item.get("type").and_then(Value::as_str) != Some("function_call_output") {
+                continue;
+            }
+            let Some(output) = item.get("output").and_then(Value::as_array) else {
+                continue;
+            };
+            for part in output {
+                let Some(token) = context_token(part) else {
+                    continue;
+                };
+                let envelope = self.open_verified(token, scope, session)?;
+                if envelope.history {
+                    for partition in 1..=envelope.results.len() {
+                        present[partition - 1] = true;
+                    }
+                } else {
+                    present[0] = true;
+                }
+            }
+        }
+
+        Ok(present
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, is_present)| is_present.then_some(index + 1))
+            .collect())
+    }
+
+    fn key(&self) -> Result<LessSafeKey> {
+        let key = UnboundKey::new(&AES_256_GCM, &self.key_bytes)
+            .map_err(|_| anyhow::anyhow!("failed to initialize Comradex context codec"))?;
+        Ok(LessSafeKey::new(key))
+    }
+
+    fn open(&self, token: &str) -> Result<ContextEnvelope> {
+        let encoded = token
+            .strip_prefix(PREFIX)
+            .ok_or_else(|| anyhow::anyhow!("invalid Comradex context envelope"))?;
+        let max_raw_bytes = MAX_ENVELOPE_BYTES + NONCE_BYTES + TAG_BYTES;
+        let max_encoded_bytes = max_raw_bytes.div_ceil(3) * 4;
+        ensure!(
+            encoded.len() <= max_encoded_bytes,
+            "invalid Comradex context envelope"
+        );
+
+        let mut token_bytes = URL_SAFE_NO_PAD
+            .decode(encoded)
+            .map_err(|_| anyhow::anyhow!("invalid Comradex context envelope"))?;
+        ensure!(
+            (NONCE_BYTES + TAG_BYTES..=max_raw_bytes).contains(&token_bytes.len()),
+            "invalid Comradex context envelope"
+        );
+        let ciphertext = token_bytes.split_off(NONCE_BYTES);
+        let nonce_bytes: [u8; NONCE_BYTES] = token_bytes
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("invalid Comradex context envelope"))?;
+        let mut ciphertext = ciphertext;
+        let plaintext = self
+            .key()?
+            .open_in_place(
+                Nonce::assume_unique_for_key(nonce_bytes),
+                Aad::from(PREFIX.as_bytes()),
+                &mut ciphertext,
+            )
+            .map_err(|_| anyhow::anyhow!("invalid Comradex context envelope"))?;
+        ensure!(
+            plaintext.len() <= MAX_ENVELOPE_BYTES,
+            "invalid Comradex context envelope"
+        );
+        serde_json::from_slice(plaintext)
+            .map_err(|_| anyhow::anyhow!("invalid Comradex context envelope"))
+    }
+
+    fn open_verified(&self, token: &str, scope: &str, session: &str) -> Result<ContextEnvelope> {
+        let envelope = self.open(token)?;
+        ensure!(
+            envelope.scope == scope && envelope.session == session,
+            "Comradex context scope mismatch"
+        );
+        ensure!(
+            (1..=MAX_RESULTS).contains(&envelope.results.len()),
+            "invalid Comradex context envelope"
+        );
+        Ok(envelope)
+    }
+}
+
+fn context_token(part: &Value) -> Option<&str> {
+    let part = part.as_object()?;
+    if part.get("type")?.as_str()? != "encrypted_content" {
+        return None;
+    }
+    part.get("encrypted_content")
+        .and_then(Value::as_str)
+        .filter(|token| token.starts_with(PREFIX))
+}
+
+fn expanded_parts(results: Vec<Value>, history: bool) -> Result<Vec<Value>> {
+    let multiple_history_partitions = history && results.len() > 1;
+    let mut parts = Vec::new();
+    if multiple_history_partitions {
+        parts.push(json!({
+            "type": "input_text",
+            "text": "The following are independent history partitions for the same task. Combine their results, deduplicate matching item and window IDs, and apply the requested ordering and limit across all partitions."
+        }));
+    }
+
+    for (index, result) in results.into_iter().enumerate() {
+        if multiple_history_partitions {
+            parts.push(json!({
+                "type": "input_text",
+                "text": format!("History partition {}:", index + 1)
+            }));
+        }
+        parts.extend(result_parts(result)?);
+    }
+    Ok(parts)
+}
+
+fn result_parts(mut result: Value) -> Result<Vec<Value>> {
+    let images = if let Some(object) = result.as_object_mut() {
+        match object.remove("images") {
+            Some(Value::Array(images)) => images,
+            Some(_) => return Err(anyhow::anyhow!("invalid Comradex context image")),
+            None => Vec::new(),
+        }
+    } else {
+        Vec::new()
+    };
+
+    let encrypted_output = result
+        .as_object()
+        .and_then(|object| object.get("encrypted_output"))
+        .and_then(Value::as_str);
+    let mut parts = Vec::with_capacity(1 + images.len());
+    if let Some(encrypted_output) = encrypted_output {
+        parts.push(json!({
+            "type": "encrypted_content",
+            "encrypted_content": encrypted_output
+        }));
+    } else {
+        parts.push(json!({
+            "type": "input_text",
+            "text": serde_json::to_string(&result).expect("JSON values always serialize")
+        }));
+    }
+    for image in images {
+        parts.push(native_image(&image)?);
+    }
+    Ok(parts)
+}
+
+fn native_image(image: &Value) -> Result<Value> {
+    let image = image
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("invalid Comradex context image"))?;
+    let data = image
+        .get("data")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("invalid Comradex context image"))?;
+    let mime_type = image
+        .get("mime_type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("invalid Comradex context image"))?;
+    let detail = image.get("detail").cloned().unwrap_or(Value::Null);
+    let mut part = Map::new();
+    part.insert("type".to_owned(), Value::String("input_image".to_owned()));
+    part.insert(
+        "image_url".to_owned(),
+        Value::String(format!("data:{mime_type};base64,{data}")),
+    );
+    part.insert("detail".to_owned(), detail);
+    Ok(Value::Object(part))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrapped(token: Value) -> Value {
+        json!({
+            "model": "gpt-test",
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": [{
+                    "type": "encrypted_content",
+                    "encrypted_content": token["encrypted_output"]
+                }]
+            }]
+        })
+    }
+
+    #[test]
+    fn notes_round_trip_native_and_json_results() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![
+                    json!({"encrypted_output":"native-ciphertext"}),
+                    json!({"items":[{"id":"note-1"}],"next":null}),
+                ],
+                false,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+
+        assert!(codec.expand(&mut body, "scope-a", "session-a").unwrap());
+        assert_eq!(
+            body["input"][0]["output"],
+            json!([
+                {"type":"encrypted_content","encrypted_content":"native-ciphertext"},
+                {"type":"input_text","text":"{\"items\":[{\"id\":\"note-1\"}],\"next\":null}"}
+            ])
+        );
+    }
+
+    #[test]
+    fn history_round_trip_labels_independent_partitions() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({"items":[1]}), json!({"items":[2]})],
+                true,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+
+        codec.expand(&mut body, "scope-a", "session-a").unwrap();
+        let output = body["input"][0]["output"].as_array().unwrap();
+        assert_eq!(output.len(), 5);
+        assert!(
+            output[0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("independent history partitions")
+        );
+        assert_eq!(output[1]["text"], "History partition 1:");
+        assert_eq!(output[2]["text"], "{\"items\":[1]}");
+        assert_eq!(output[3]["text"], "History partition 2:");
+        assert_eq!(output[4]["text"], "{\"items\":[2]}");
+    }
+
+    #[test]
+    fn native_images_become_input_images() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({
+                    "encrypted_output":"native-ciphertext",
+                    "images":[{"data":"aGVsbG8=","mime_type":"image/png","detail":"high"}]
+                })],
+                false,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+
+        codec.expand(&mut body, "scope-a", "session-a").unwrap();
+        assert_eq!(
+            body["input"][0]["output"][1],
+            json!({
+                "type":"input_image",
+                "image_url":"data:image/png;base64,aGVsbG8=",
+                "detail":"high"
+            })
+        );
+    }
+
+    #[test]
+    fn native_ciphertext_is_used_when_metadata_is_present() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({
+                    "encrypted_output":"native-ciphertext",
+                    "request_id":"request-metadata",
+                    "next_cursor":null
+                })],
+                false,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+
+        codec.expand(&mut body, "scope-a", "session-a").unwrap();
+        assert_eq!(
+            body["input"][0]["output"],
+            json!([{"type":"encrypted_content","encrypted_content":"native-ciphertext"}])
+        );
+    }
+
+    #[test]
+    fn images_are_attached_to_plaintext_results_and_detail_defaults_to_null() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({
+                    "items":[{"id":"note-1"}],
+                    "images":[{"data":"aGVsbG8=","mime_type":"image/png"}]
+                })],
+                false,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+
+        codec.expand(&mut body, "scope-a", "session-a").unwrap();
+        assert_eq!(
+            body["input"][0]["output"],
+            json!([
+                {"type":"input_text","text":"{\"items\":[{\"id\":\"note-1\"}]}"},
+                {
+                    "type":"input_image",
+                    "image_url":"data:image/png;base64,aGVsbG8=",
+                    "detail":null
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn malformed_images_fail_without_exposing_or_mutating_results() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({
+                    "items":[],
+                    "images":[{"data":7,"mime_type":"image/png"}]
+                })],
+                false,
+            )
+            .unwrap();
+        let mut body = wrapped(token);
+        let original = body.clone();
+
+        assert_eq!(
+            codec
+                .expand(&mut body, "scope-a", "session-a")
+                .unwrap_err()
+                .to_string(),
+            "invalid Comradex context image"
+        );
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn tampering_and_scope_or_session_changes_are_rejected_without_mutation() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack("scope-a", "session-a", vec![json!({"items":[]})], false)
+            .unwrap();
+
+        for (scope, session) in [("scope-b", "session-a"), ("scope-a", "session-b")] {
+            let mut body = wrapped(token.clone());
+            let original = body.clone();
+            let error = codec.expand(&mut body, scope, session).unwrap_err();
+            assert_eq!(error.to_string(), "Comradex context scope mismatch");
+            assert_eq!(body, original);
+        }
+
+        let mut tampered = token;
+        let value = tampered["encrypted_output"].as_str().unwrap();
+        let replacement = if value.ends_with('A') { 'B' } else { 'A' };
+        let mut changed = value[..value.len() - 1].to_owned();
+        changed.push(replacement);
+        tampered["encrypted_output"] = Value::String(changed);
+        let mut body = wrapped(tampered);
+        let original = body.clone();
+        let error = codec.expand(&mut body, "scope-a", "session-a").unwrap_err();
+        assert_eq!(error.to_string(), "invalid Comradex context envelope");
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn oversized_envelopes_are_rejected() {
+        let codec = ContextCodec::new("test-key");
+        let error = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![Value::String("x".repeat(MAX_ENVELOPE_BYTES))],
+                false,
+            )
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Comradex context envelope exceeds safety limit"
+        );
+
+        let error = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![Value::Null; MAX_RESULTS + 1],
+                false,
+            )
+            .unwrap_err();
+        assert_eq!(error.to_string(), "invalid Comradex context result count");
+    }
+
+    #[test]
+    fn arbitrary_ciphertext_and_unknown_values_are_unchanged() {
+        let codec = ContextCodec::new("test-key");
+        let mut body = json!({
+            "input": [
+                {
+                    "type":"function_call_output",
+                    "output":[
+                        {"type":"encrypted_content","encrypted_content":"native-ciphertext"},
+                        {"type":"future_part","value":7}
+                    ]
+                },
+                {"type":"future_item","value":8}
+            ],
+            "future_field": true
+        });
+        let original = body.clone();
+
+        assert!(!codec.expand(&mut body, "scope-a", "session-a").unwrap());
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn routing_view_redacts_only_authenticated_context_wrappers() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({"encrypted_output":"native-context"})],
+                false,
+            )
+            .unwrap();
+        let body = json!({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "arbitrary-reasoning-ciphertext"
+                },
+                {
+                    "type": "function_call_output",
+                    "output": [
+                        {
+                            "type": "encrypted_content",
+                            "encrypted_content": "arbitrary-output-ciphertext"
+                        },
+                        {
+                            "type": "encrypted_content",
+                            "encrypted_content": token["encrypted_output"]
+                        }
+                    ]
+                }
+            ]
+        });
+        let original = body.clone();
+
+        let view = codec.routing_view(&body, "scope-a", "session-a").unwrap();
+
+        assert_eq!(body, original);
+        assert_eq!(
+            view["input"][0]["encrypted_content"],
+            "arbitrary-reasoning-ciphertext"
+        );
+        assert_eq!(
+            view["input"][1]["output"][0],
+            json!({
+                "type": "encrypted_content",
+                "encrypted_content": "arbitrary-output-ciphertext"
+            })
+        );
+        assert_eq!(
+            view["input"][1]["output"][1],
+            json!({"type":"input_text","text":"Verified context tool result"})
+        );
+    }
+
+    #[test]
+    fn routing_view_rejects_wrong_scope() {
+        let codec = ContextCodec::new("test-key");
+        let token = codec
+            .pack("scope-a", "session-a", vec![json!({"items":[]})], false)
+            .unwrap();
+        let body = wrapped(token);
+
+        assert_eq!(
+            codec
+                .routing_view(&body, "scope-b", "session-a")
+                .unwrap_err()
+                .to_string(),
+            "Comradex context scope mismatch"
+        );
+    }
+
+    #[test]
+    fn source_partitions_returns_authenticated_complete_ordinals() {
+        let codec = ContextCodec::new("test-key");
+        let history = codec
+            .pack(
+                "scope-a",
+                "session-a",
+                vec![json!({"items":[1]}), json!({"items":[2]})],
+                true,
+            )
+            .unwrap();
+        let notes = codec
+            .pack("scope-a", "session-a", vec![json!({"items":[]})], false)
+            .unwrap();
+        let body = json!({
+            "input":[{
+                "type":"function_call_output",
+                "output":[
+                    {"type":"encrypted_content","encrypted_content":history["encrypted_output"]},
+                    {"type":"encrypted_content","encrypted_content":notes["encrypted_output"]},
+                    {"type":"encrypted_content","encrypted_content":"arbitrary-ciphertext"}
+                ]
+            }]
+        });
+
+        assert_eq!(
+            codec
+                .source_partitions(&body, "scope-a", "session-a")
+                .unwrap(),
+            vec![1, 2]
+        );
+    }
+}

--- a/src/proxy/context_store.rs
+++ b/src/proxy/context_store.rs
@@ -1,0 +1,494 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, mpsc},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use tokio::sync::oneshot;
+
+const DATABASE_VERSION: i64 = 1;
+const MAX_PARTICIPANTS: i64 = 32;
+
+type Job = Box<dyn FnOnce(&mut Connection) + Send + 'static>;
+
+struct DatabaseWorker {
+    sender: mpsc::Sender<Job>,
+}
+
+impl DatabaseWorker {
+    fn start(path: PathBuf) -> Result<Self> {
+        let (sender, receiver) = mpsc::channel::<Job>();
+        let (ready_sender, ready_receiver) = mpsc::sync_channel(1);
+        std::thread::Builder::new()
+            .name("comradex-context-db".into())
+            .spawn(move || {
+                let mut connection = match open_database(&path) {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        let _ = ready_sender.send(Err(error));
+                        return;
+                    }
+                };
+                if ready_sender.send(Ok(())).is_err() {
+                    return;
+                }
+                for job in receiver {
+                    job(&mut connection);
+                }
+            })
+            .context("spawn context database worker")?;
+        ready_receiver
+            .recv()
+            .context("context database worker stopped during startup")??;
+        Ok(Self { sender })
+    }
+
+    async fn call<T, F>(&self, operation: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> Result<T> + Send + 'static,
+    {
+        let (completed, result) = oneshot::channel();
+        self.sender
+            .send(Box::new(move |connection| {
+                let _ = completed.send(operation(connection));
+            }))
+            .map_err(|_| anyhow::anyhow!("context database worker stopped"))?;
+        result
+            .await
+            .context("context database worker dropped response")?
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextAccount {
+    pub alias: String,
+    pub physical_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextSession {
+    pub owner: ContextAccount,
+    pub participants: Vec<ContextAccount>,
+}
+
+#[derive(Clone)]
+pub struct ContextStore {
+    database: Arc<DatabaseWorker>,
+    key: [u8; 32],
+}
+
+impl ContextStore {
+    pub fn open(path: &Path, key: &str) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create context state directory {}", parent.display()))?;
+        }
+        Ok(Self {
+            database: Arc::new(DatabaseWorker::start(path.to_path_buf())?),
+            key: *blake3::hash(key.as_bytes()).as_bytes(),
+        })
+    }
+
+    pub fn physical_key(&self, physical_id: &str) -> String {
+        hash_component(&self.key, b"physical-id", physical_id)
+    }
+
+    pub async fn record_dispatch(
+        &self,
+        scope: &str,
+        session: &str,
+        account_alias: &str,
+        physical_id: &str,
+    ) -> Result<()> {
+        let scope_key = hash_component(&self.key, b"scope", scope);
+        let session_key = hash_component(&self.key, b"session", session);
+        let alias = account_alias.to_owned();
+        let physical_key = self.physical_key(physical_id);
+        self.database
+            .call(move |connection| {
+                let transaction =
+                    connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+                let exists = transaction
+                    .query_row(
+                        "select 1 from context_sessions where scope_key = ?1 and session_key = ?2",
+                        params![scope_key, session_key],
+                        |_| Ok(()),
+                    )
+                    .optional()?
+                    .is_some();
+
+                if !exists {
+                    transaction.execute(
+                        "insert into context_sessions (scope_key, session_key, owner_alias, owner_physical_key) values (?1, ?2, ?3, ?4)",
+                        params![scope_key, session_key, alias, physical_key],
+                    )?;
+                    transaction.execute(
+                        "insert into context_participants (scope_key, session_key, ordinal, alias, physical_key) values (?1, ?2, 0, ?3, ?4)",
+                        params![scope_key, session_key, alias, physical_key],
+                    )?;
+                    transaction.commit()?;
+                    return Ok(());
+                }
+
+                let already_recorded = transaction
+                    .query_row(
+                        "select 1 from context_participants where scope_key = ?1 and session_key = ?2 and physical_key = ?3",
+                        params![scope_key, session_key, physical_key],
+                        |_| Ok(()),
+                    )
+                    .optional()?
+                    .is_some();
+                if !already_recorded {
+                    let next_ordinal = transaction.query_row(
+                        "select count(*) from context_participants where scope_key = ?1 and session_key = ?2",
+                        params![scope_key, session_key],
+                        |row| row.get::<_, i64>(0),
+                    )?;
+                    anyhow::ensure!(
+                        next_ordinal < MAX_PARTICIPANTS,
+                        "context participant limit of {MAX_PARTICIPANTS} reached"
+                    );
+                    transaction.execute(
+                        "insert into context_participants (scope_key, session_key, ordinal, alias, physical_key) values (?1, ?2, ?3, ?4, ?5)",
+                        params![scope_key, session_key, next_ordinal, alias, physical_key],
+                    )?;
+                }
+                transaction.commit()?;
+                Ok(())
+            })
+            .await
+    }
+
+    pub async fn lookup(&self, scope: &str, session: &str) -> Result<Option<ContextSession>> {
+        let scope_key = hash_component(&self.key, b"scope", scope);
+        let session_key = hash_component(&self.key, b"session", session);
+        self.database
+            .call(move |connection| {
+                let owner = connection
+                    .query_row(
+                        "select owner_alias, owner_physical_key from context_sessions where scope_key = ?1 and session_key = ?2",
+                        params![scope_key, session_key],
+                        |row| {
+                            Ok(ContextAccount {
+                                alias: row.get(0)?,
+                                physical_id: row.get(1)?,
+                            })
+                        },
+                    )
+                    .optional()?;
+                let Some(owner) = owner else {
+                    return Ok(None);
+                };
+
+                let mut statement = connection.prepare(
+                    "select alias, physical_key from context_participants where scope_key = ?1 and session_key = ?2 order by ordinal",
+                )?;
+                let participants = statement
+                    .query_map(params![scope_key, session_key], |row| {
+                        Ok(ContextAccount {
+                            alias: row.get(0)?,
+                            physical_id: row.get(1)?,
+                        })
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                Ok(Some(ContextSession {
+                    owner,
+                    participants,
+                }))
+            })
+            .await
+    }
+}
+
+fn hash_component(key: &[u8; 32], domain: &[u8], raw: &str) -> String {
+    let mut hasher = blake3::Hasher::new_keyed(key);
+    hasher.update(b"comradex-context-store\0");
+    hasher.update(domain);
+    hasher.update(b"\0");
+    hasher.update(raw.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn open_database(path: &Path) -> Result<Connection> {
+    let existed = path.exists();
+    let mut connection = Connection::open(path)
+        .with_context(|| format!("open context database {}", path.display()))?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.pragma_update(None, "journal_mode", "wal")?;
+    connection.pragma_update(None, "synchronous", "full")?;
+    connection.pragma_update(None, "foreign_keys", true)?;
+
+    if existed {
+        let version =
+            connection.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?;
+        anyhow::ensure!(
+            version == DATABASE_VERSION,
+            "unsupported context database version {version}"
+        );
+        return Ok(connection);
+    }
+
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    transaction.execute_batch(
+        "
+        create table context_sessions (
+            scope_key text not null,
+            session_key text not null,
+            owner_alias text not null,
+            owner_physical_key text not null,
+            primary key (scope_key, session_key)
+        ) without rowid;
+        create table context_participants (
+            scope_key text not null,
+            session_key text not null,
+            ordinal integer not null check (ordinal >= 0 and ordinal < 32),
+            alias text not null,
+            physical_key text not null,
+            primary key (scope_key, session_key, ordinal),
+            unique (scope_key, session_key, physical_key),
+            foreign key (scope_key, session_key)
+                references context_sessions (scope_key, session_key)
+                on delete cascade
+        ) without rowid;
+        pragma user_version = 1;
+        ",
+    )?;
+    transaction.commit()?;
+    connection.execute_batch("pragma wal_checkpoint(full);")?;
+    connection
+        .close()
+        .map_err(|(_, error)| error)
+        .context("close newly created context database")?;
+    fs::File::open(path)
+        .with_context(|| format!("open context database for sync {}", path.display()))?
+        .sync_all()
+        .with_context(|| format!("sync context database {}", path.display()))?;
+    sync_parent_directory(path)?;
+
+    let connection = Connection::open(path)
+        .with_context(|| format!("reopen context database {}", path.display()))?;
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.pragma_update(None, "journal_mode", "wal")?;
+    connection.pragma_update(None, "synchronous", "full")?;
+    connection.pragma_update(None, "foreign_keys", true)?;
+    Ok(connection)
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<()> {
+    fs::File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &str = "0123456789abcdef0123456789abcdef";
+
+    #[tokio::test]
+    async fn dispatches_persist_without_storing_raw_context_identifiers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contexts.sqlite3");
+        let expected_physical_key;
+        {
+            let store = ContextStore::open(&path, KEY).unwrap();
+            expected_physical_key = store.physical_key("physical-secret-one");
+            store
+                .record_dispatch(
+                    "scope-secret",
+                    "session-secret",
+                    "primary",
+                    "physical-secret-one",
+                )
+                .await
+                .unwrap();
+            store
+                .record_dispatch(
+                    "scope-secret",
+                    "session-secret",
+                    "secondary",
+                    "physical-secret-two",
+                )
+                .await
+                .unwrap();
+        }
+
+        let restored = ContextStore::open(&path, KEY).unwrap();
+        let context = restored
+            .lookup("scope-secret", "session-secret")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(context.owner.alias, "primary");
+        assert_eq!(context.owner.physical_id, expected_physical_key);
+        assert_eq!(context.participants.len(), 2);
+        let bytes = fs::read(path).unwrap();
+        for raw in [
+            "scope-secret",
+            "session-secret",
+            "physical-secret-one",
+            "physical-secret-two",
+        ] {
+            assert!(
+                !bytes
+                    .windows(raw.len())
+                    .any(|window| window == raw.as_bytes())
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_first_dispatch_selects_one_owner_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let store =
+            Arc::new(ContextStore::open(&dir.path().join("contexts.sqlite3"), KEY).unwrap());
+        let mut tasks = Vec::new();
+        for index in 0..16 {
+            let store = Arc::clone(&store);
+            tasks.push(tokio::spawn(async move {
+                let alias = format!("account-{index}");
+                let physical = format!("physical-{index}");
+                store
+                    .record_dispatch("scope", "session", &alias, &physical)
+                    .await
+                    .unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        let context = store.lookup("scope", "session").await.unwrap().unwrap();
+        assert_eq!(context.participants.len(), 16);
+        assert!(context.participants.contains(&context.owner));
+    }
+
+    #[tokio::test]
+    async fn duplicate_physical_account_retains_first_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ContextStore::open(&dir.path().join("contexts.sqlite3"), KEY).unwrap();
+        store
+            .record_dispatch("scope", "session", "first-alias", "same-physical")
+            .await
+            .unwrap();
+        store
+            .record_dispatch("scope", "session", "renamed-alias", "same-physical")
+            .await
+            .unwrap();
+
+        let context = store.lookup("scope", "session").await.unwrap().unwrap();
+        assert_eq!(context.owner.alias, "first-alias");
+        assert_eq!(context.participants.len(), 1);
+        assert_eq!(context.participants[0].alias, "first-alias");
+    }
+
+    #[tokio::test]
+    async fn same_alias_with_new_physical_id_records_a_distinct_participant() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ContextStore::open(&dir.path().join("contexts.sqlite3"), KEY).unwrap();
+        store
+            .record_dispatch("scope", "session", "shared-alias", "physical-one")
+            .await
+            .unwrap();
+        store
+            .record_dispatch("scope", "session", "shared-alias", "physical-two")
+            .await
+            .unwrap();
+
+        let context = store.lookup("scope", "session").await.unwrap().unwrap();
+        assert_eq!(context.owner.alias, "shared-alias");
+        assert_eq!(
+            context.owner.physical_id,
+            store.physical_key("physical-one")
+        );
+        assert_eq!(context.participants.len(), 2);
+        assert_ne!(
+            context.participants[0].physical_id,
+            context.participants[1].physical_id
+        );
+    }
+
+    #[tokio::test]
+    async fn participant_limit_rejects_dispatch_and_remains_durable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contexts.sqlite3");
+        let store = ContextStore::open(&path, KEY).unwrap();
+        for index in 0..32 {
+            store
+                .record_dispatch(
+                    "scope",
+                    "session",
+                    &format!("account-{index}"),
+                    &format!("physical-{index}"),
+                )
+                .await
+                .unwrap();
+        }
+        let error = store
+            .record_dispatch("scope", "session", "account-32", "physical-32")
+            .await
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("participant limit of 32 reached"));
+        drop(store);
+
+        let restored = ContextStore::open(&path, KEY).unwrap();
+        let context = restored.lookup("scope", "session").await.unwrap().unwrap();
+        assert_eq!(context.owner.alias, "account-0");
+        assert_eq!(context.participants.len(), 32);
+        assert_eq!(context.participants.last().unwrap().alias, "account-31");
+        assert!(
+            !context
+                .participants
+                .iter()
+                .any(|participant| participant.alias == "account-32")
+        );
+    }
+
+    #[tokio::test]
+    async fn database_errors_are_returned_and_failed_creation_rolls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ContextStore::open(&dir.path().join("contexts.sqlite3"), KEY).unwrap();
+        store
+            .record_dispatch("scope", "existing", "account", "physical")
+            .await
+            .unwrap();
+        store
+            .database
+            .call(|connection| {
+                connection.execute("drop table context_participants", [])?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert!(store.lookup("scope", "existing").await.is_err());
+        assert!(
+            store
+                .record_dispatch("scope", "failed", "other", "other-physical")
+                .await
+                .is_err()
+        );
+        let session_count = store
+            .database
+            .call(|connection| {
+                Ok(
+                    connection.query_row("select count(*) from context_sessions", [], |row| {
+                        row.get::<_, i64>(0)
+                    })?,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(session_count, 1);
+    }
+}

--- a/src/proxy/context_tests.rs
+++ b/src/proxy/context_tests.rs
@@ -442,6 +442,88 @@ async fn notes_stay_with_owner_and_history_fans_out_to_all_inference_participant
 }
 
 #[tokio::test]
+async fn context_wrappers_revalidate_source_credentials_before_inference() {
+    for history in [false, true] {
+        for state in [
+            "login",
+            "different-user",
+            "different-workspace",
+            "same-owner",
+        ] {
+            let upstream = start_upstream(Arc::new(|_| {
+                (
+                    StatusCode::OK,
+                    json!({"encrypted_output": "source-ciphertext"}),
+                )
+            }))
+            .await;
+            let dir = tempfile::tempdir().unwrap();
+            let test = context_test_app(dir.path(), upstream.address);
+            let mut wrapper = establish_owner_and_fetch_note_wrapper(&test).await;
+            let source_home = if history {
+                // Validate the second participant too, not just the notes owner.
+                test.app
+                    .context_store
+                    .record_dispatch(
+                        "default",
+                        SESSION,
+                        "b",
+                        &context_identity("workspace-b", "user-b"),
+                    )
+                    .await
+                    .unwrap();
+                let (status, body) = post(
+                    &test.app,
+                    &test.listener,
+                    "/alpha/history/v2/list_items",
+                    hyper::HeaderMap::new(),
+                    Bytes::from_static(
+                        br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+                    ),
+                )
+                .await;
+                assert_eq!(status, StatusCode::OK);
+                wrapper = serde_json::from_slice(&body).unwrap();
+                dir.path().join("b")
+            } else {
+                test.account_a.clone()
+            };
+            let (alias, workspace, user) = if history {
+                ("b", "workspace-b", "user-b")
+            } else {
+                ("a", "workspace-a", "user-a")
+            };
+            match state {
+                "login" => assert!(test.app.router.begin_login(alias).await),
+                "different-user" => write_auth(&source_home, workspace, "replacement-user"),
+                "different-workspace" => write_auth(&source_home, "replacement-workspace", user),
+                "same-owner" => write_auth(&source_home, workspace, user),
+                _ => unreachable!(),
+            }
+            upstream.seen.lock().unwrap().clear();
+
+            let (status, body) = post(
+                &test.app,
+                &test.listener,
+                "/responses",
+                hyper::HeaderMap::new(),
+                response_with_context_wrapper(&wrapper, false),
+            )
+            .await;
+            if state == "same-owner" {
+                assert_eq!(status, StatusCode::OK);
+                assert!(!upstream.seen.lock().unwrap().is_empty());
+            } else {
+                assert_eq!(status, StatusCode::BAD_REQUEST, "{history}: {state}");
+                let error: Value = serde_json::from_slice(&body).unwrap();
+                assert_eq!(error["error"]["type"], "context_result_invalid");
+                assert!(upstream.seen.lock().unwrap().is_empty());
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn signed_context_wrapper_can_rotate_inference_without_moving_notes_owner() {
     let upstream = start_upstream(Arc::new(|request| {
         if request.path.contains("/alpha/notes/") {

--- a/src/proxy/context_tests.rs
+++ b/src/proxy/context_tests.rs
@@ -1,0 +1,882 @@
+use super::*;
+use crate::config::{AccountConfig, ProxyConfig};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{body::Incoming, server::conn::http1};
+use hyper_util::rt::TokioIo;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+const SESSION: &str = "123e4567-e89b-12d3-a456-426614174000";
+const SECRET: &str = "0123456789abcdef";
+const AFFINITY_KEY: &str = "0123456789abcdef0123456789abcdef";
+
+#[derive(Clone, Debug)]
+struct SeenRequest {
+    path: String,
+    authorization: String,
+    account_id: String,
+    encrypted_tool_arguments: Option<String>,
+    tool_output_truncation_policy: Option<String>,
+    body: Bytes,
+}
+
+type Responder = dyn Fn(&SeenRequest) -> (StatusCode, Value) + Send + Sync;
+
+struct MockUpstream {
+    address: std::net::SocketAddr,
+    seen: Arc<Mutex<Vec<SeenRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for MockUpstream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn start_upstream(responder: Arc<Responder>) -> MockUpstream {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let task_seen = seen.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let seen = task_seen.clone();
+            let responder = responder.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |request: Request<Incoming>| {
+                    let seen = seen.clone();
+                    let responder = responder.clone();
+                    async move {
+                        let path = request.uri().path_and_query().unwrap().to_string();
+                        let authorization = request
+                            .headers()
+                            .get(AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned();
+                        let account_id = request
+                            .headers()
+                            .get("chatgpt-account-id")
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned();
+                        let encrypted_tool_arguments = request
+                            .headers()
+                            .get("x-openai-encrypted-tool-arguments")
+                            .and_then(|value| value.to_str().ok())
+                            .map(str::to_owned);
+                        let tool_output_truncation_policy = request
+                            .headers()
+                            .get("x-openai-tool-output-truncation-policy")
+                            .and_then(|value| value.to_str().ok())
+                            .map(str::to_owned);
+                        let body = request.into_body().collect().await.unwrap().to_bytes();
+                        let observed = SeenRequest {
+                            path,
+                            authorization,
+                            account_id,
+                            encrypted_tool_arguments,
+                            tool_output_truncation_policy,
+                            body,
+                        };
+                        let (status, response) = responder(&observed);
+                        seen.lock().unwrap().push(observed);
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(status)
+                                .header(CONTENT_TYPE, "application/json")
+                                .body(Full::new(Bytes::from(
+                                    serde_json::to_vec(&response).unwrap(),
+                                )))
+                                .unwrap(),
+                        )
+                    }
+                });
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+    MockUpstream {
+        address,
+        seen,
+        task,
+    }
+}
+
+struct ContextTestApp {
+    app: Arc<App>,
+    listener: ListenerConfig,
+    account_a: PathBuf,
+}
+
+fn test_token(workspace: &str, user: &str) -> String {
+    let payload = URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&json!({
+            "exp": 4_102_444_800_u64,
+            "sub": user,
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": workspace,
+                "chatgpt_user_id": user
+            }
+        }))
+        .unwrap(),
+    );
+    format!("e30.{payload}.sig")
+}
+
+fn context_identity(workspace: &str, user: &str) -> String {
+    serde_json::to_string(&(workspace, user)).unwrap()
+}
+
+fn write_auth(home: &Path, workspace: &str, user: &str) {
+    fs::create_dir_all(home).unwrap();
+    fs::write(
+        home.join("auth.json"),
+        serde_json::to_vec(&json!({
+            "tokens": {
+                "access_token": test_token(workspace, user),
+                "account_id": workspace
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn context_test_app(dir: &Path, upstream: std::net::SocketAddr) -> ContextTestApp {
+    let account_a = dir.join("a");
+    let account_b = dir.join("b");
+    write_auth(&account_a, "workspace-a", "user-a");
+    write_auth(&account_b, "workspace-b", "user-b");
+    let listener = ListenerConfig {
+        address: "127.0.0.1:0".parse().unwrap(),
+        pool: "default".into(),
+    };
+    let config = Arc::new(Config {
+        proxy: ProxyConfig {
+            upstream: format!("http://{upstream}/backend-api/codex"),
+            installation_secret: SECRET.into(),
+            affinity_key: AFFINITY_KEY.into(),
+            state_dir: Some(dir.join("state")),
+            ..ProxyConfig::default()
+        },
+        listeners: BTreeMap::from([("default".into(), listener.clone())]),
+        pools: BTreeMap::from([(
+            "default".into(),
+            PoolConfig {
+                members: vec!["a".into(), "b".into()],
+                preferred: None,
+            },
+        )]),
+        accounts: BTreeMap::from([
+            (
+                "a".into(),
+                AccountConfig::CodexHome {
+                    path: account_a.clone(),
+                },
+            ),
+            ("b".into(), AccountConfig::CodexHome { path: account_b }),
+        ]),
+    });
+    let affinity = Arc::new(
+        AffinityStore::load(
+            dir.join("affinity.json"),
+            &config.proxy.affinity_key,
+            Duration::from_secs(60),
+        )
+        .unwrap(),
+    );
+    let router = Arc::new(Router::new(&config, affinity));
+    let app = App::new_unvalidated(config, router.clone(), Arc::new(Stats::default())).unwrap();
+    ContextTestApp {
+        app,
+        listener,
+        account_a,
+    }
+}
+
+fn replay(app: &App, body: Bytes) -> ReplayBody {
+    ReplayBody::from_bytes(
+        body,
+        app.config.proxy.max_request_bytes,
+        app.config.proxy.max_spool_bytes,
+        app.stats.clone(),
+    )
+    .unwrap()
+}
+
+async fn post(
+    app: &App,
+    listener: &ListenerConfig,
+    path: &str,
+    headers: hyper::HeaderMap,
+    body: Bytes,
+) -> (StatusCode, Bytes) {
+    let response = app
+        .handle_http_replay(
+            headers,
+            Method::POST,
+            listener,
+            path.to_owned(),
+            replay(app, body),
+            ServingLane::Http,
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    (status, body)
+}
+
+fn expanded_encrypted_content(body: &Value) -> Vec<&str> {
+    body["input"][0]["output"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|part| part["encrypted_content"].as_str())
+        .collect()
+}
+
+async fn establish_owner_and_fetch_note_wrapper(test: &ContextTestApp) -> Value {
+    let inference = Bytes::from_static(
+        br#"{"client_metadata":{"session_id":"123e4567-e89b-12d3-a456-426614174000"},"reasoning":{"context":"all_turns"},"input":"first"}"#,
+    );
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/responses",
+        hyper::HeaderMap::new(),
+        inference,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, wrapper) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    serde_json::from_slice(&wrapper).unwrap()
+}
+
+fn response_with_context_wrapper(wrapper: &Value, include_unrelated_reasoning: bool) -> Bytes {
+    let mut input = vec![
+        json!({
+            "type": "function_call",
+            "call_id": "call_context",
+            "name": "read_file",
+            "arguments": "{}"
+        }),
+        json!({
+            "type": "function_call_output",
+            "call_id": "call_context",
+            "output": [{
+                "type": "encrypted_content",
+                "encrypted_content": wrapper["encrypted_output"]
+            }]
+        }),
+    ];
+    if include_unrelated_reasoning {
+        input.push(json!({
+            "type": "reasoning",
+            "id": "reasoning_from_elsewhere",
+            "encrypted_content": "unrelated-native-ciphertext"
+        }));
+    }
+    Bytes::from(
+        serde_json::to_vec(&json!({
+            "model": "gpt-test",
+            "client_metadata": {"session_id": SESSION},
+            "input": input
+        }))
+        .unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn notes_stay_with_owner_and_history_fans_out_to_all_inference_participants() {
+    let upstream = start_upstream(Arc::new(|request| {
+        let response = if request.path.contains("/alpha/") {
+            json!({"encrypted_output": format!("cipher-{}", request.account_id)})
+        } else {
+            json!({"ok": true})
+        };
+        (StatusCode::OK, response)
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+
+    let inference = Bytes::from_static(
+        br#"{"client_metadata":{"session_id":"123e4567-e89b-12d3-a456-426614174000"},"reasoning":{"context":"all_turns"},"input":"first"}"#,
+    );
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/responses",
+        hyper::HeaderMap::new(),
+        inference,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let stored = test
+        .app
+        .context_store
+        .lookup("default", SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.owner.alias, "a");
+    assert_eq!(stored.participants.len(), 1);
+
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "b",
+            &context_identity("workspace-b", "user-b"),
+        )
+        .await
+        .unwrap();
+
+    let note_body = Bytes::from_static(
+        br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"},"arguments":{"encrypted":"opaque"}}"#,
+    );
+    let mut headers = hyper::HeaderMap::new();
+    headers.insert(
+        "x-openai-encrypted-tool-arguments",
+        "encrypted-arguments".parse().unwrap(),
+    );
+    headers.insert(
+        "x-openai-tool-output-truncation-policy",
+        "truncate-after-8192".parse().unwrap(),
+    );
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file?cursor=opaque%2Bvalue",
+        headers,
+        note_body.clone(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let note = upstream.seen.lock().unwrap().last().unwrap().clone();
+    assert_eq!(
+        note.authorization,
+        format!("Bearer {}", test_token("workspace-a", "user-a"))
+    );
+    assert_eq!(note.account_id, "workspace-a");
+    assert_eq!(
+        note.encrypted_tool_arguments.as_deref(),
+        Some("encrypted-arguments")
+    );
+    assert_eq!(
+        note.tool_output_truncation_policy.as_deref(),
+        Some("truncate-after-8192")
+    );
+    assert_eq!(
+        note.path,
+        "/backend-api/codex/alpha/notes/v2/read_file?cursor=opaque%2Bvalue"
+    );
+    assert_eq!(note.body, note_body);
+
+    let history_body = Bytes::from_static(
+        br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"},"query":{"encrypted":"history-query"}}"#,
+    );
+    let (status, packed) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/history/v2/list_items",
+        hyper::HeaderMap::new(),
+        history_body,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let packed: Value = serde_json::from_slice(&packed).unwrap();
+    assert!(
+        packed["encrypted_output"]
+            .as_str()
+            .unwrap()
+            .starts_with("comradex-context-v1:")
+    );
+
+    let mut continuation = json!({
+        "client_metadata": {"session_id": SESSION},
+        "input": [{
+            "type": "function_call_output",
+            "output": [{
+                "type": "encrypted_content",
+                "encrypted_content": packed["encrypted_output"]
+            }]
+        }]
+    });
+    assert!(
+        test.app
+            .expand_context(&mut continuation, "default")
+            .unwrap()
+    );
+    assert_eq!(
+        expanded_encrypted_content(&continuation),
+        vec!["cipher-workspace-a", "cipher-workspace-b"]
+    );
+}
+
+#[tokio::test]
+async fn signed_context_wrapper_can_rotate_inference_without_moving_notes_owner() {
+    let upstream = start_upstream(Arc::new(|request| {
+        if request.path.contains("/alpha/notes/") {
+            return (
+                StatusCode::OK,
+                json!({"encrypted_output": "cipher-workspace-a"}),
+            );
+        }
+        if request
+            .body
+            .windows(b"call_context".len())
+            .any(|window| window == b"call_context")
+            && request.account_id == "workspace-a"
+        {
+            return (StatusCode::TOO_MANY_REQUESTS, json!({"error": "quota"}));
+        }
+        (StatusCode::OK, json!({"ok": true}))
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    let wrapper = establish_owner_and_fetch_note_wrapper(&test).await;
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/responses",
+        hyper::HeaderMap::new(),
+        response_with_context_wrapper(&wrapper, false),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let seen = upstream.seen.lock().unwrap().clone();
+    let rotated: Vec<_> = seen
+        .iter()
+        .filter(|request| {
+            request.path.ends_with("/responses")
+                && request
+                    .body
+                    .windows(b"call_context".len())
+                    .any(|window| window == b"call_context")
+        })
+        .collect();
+    assert_eq!(rotated.len(), 2);
+    assert_eq!(rotated[0].account_id, "workspace-a");
+    assert_eq!(rotated[1].account_id, "workspace-b");
+    assert!(
+        rotated[1]
+            .body
+            .windows(b"cipher-workspace-a".len())
+            .any(|window| window == b"cipher-workspace-a")
+    );
+    assert!(
+        !rotated[1]
+            .body
+            .windows(b"comradex-context-v1:".len())
+            .any(|window| window == b"comradex-context-v1:")
+    );
+    drop(seen);
+
+    let stored = test
+        .app
+        .context_store
+        .lookup("default", SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.owner.alias, "a");
+    assert_eq!(
+        stored
+            .participants
+            .iter()
+            .map(|account| account.alias.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "b"]
+    );
+
+    let before = upstream.seen.lock().unwrap().len();
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let seen = upstream.seen.lock().unwrap();
+    assert_eq!(seen.len(), before + 1);
+    assert_eq!(seen.last().unwrap().account_id, "workspace-a");
+}
+
+#[tokio::test]
+async fn unrelated_encrypted_reasoning_keeps_signed_context_replay_on_first_account() {
+    let upstream = start_upstream(Arc::new(|request| {
+        if request.path.contains("/alpha/notes/") {
+            return (
+                StatusCode::OK,
+                json!({"encrypted_output": "cipher-workspace-a"}),
+            );
+        }
+        if request
+            .body
+            .windows(b"call_context".len())
+            .any(|window| window == b"call_context")
+            && request.account_id == "workspace-a"
+        {
+            return (StatusCode::TOO_MANY_REQUESTS, json!({"error": "quota"}));
+        }
+        (StatusCode::OK, json!({"ok": true}))
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    let wrapper = establish_owner_and_fetch_note_wrapper(&test).await;
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/responses",
+        hyper::HeaderMap::new(),
+        response_with_context_wrapper(&wrapper, true),
+    )
+    .await;
+    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+
+    let seen = upstream.seen.lock().unwrap();
+    let attempted: Vec<_> = seen
+        .iter()
+        .filter(|request| {
+            request.path.ends_with("/responses")
+                && request
+                    .body
+                    .windows(b"call_context".len())
+                    .any(|window| window == b"call_context")
+        })
+        .collect();
+    assert_eq!(attempted.len(), 1);
+    assert_eq!(attempted[0].account_id, "workspace-a");
+    assert!(
+        attempted[0]
+            .body
+            .windows(b"unrelated-native-ciphertext".len())
+            .any(|window| window == b"unrelated-native-ciphertext")
+    );
+}
+
+#[tokio::test]
+async fn notes_owner_quota_failure_never_calls_an_alternate_account() {
+    let upstream = start_upstream(Arc::new(|request| {
+        if request.account_id == "workspace-a" {
+            (StatusCode::TOO_MANY_REQUESTS, json!({"error": "quota"}))
+        } else {
+            (StatusCode::OK, json!({"encrypted_output": "wrong-owner"}))
+        }
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "a",
+            &context_identity("workspace-a", "user-a"),
+        )
+        .await
+        .unwrap();
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let seen = upstream.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].account_id, "workspace-a");
+}
+
+#[tokio::test]
+async fn first_context_read_ignores_inference_quota_cooldowns() {
+    let upstream = start_upstream(Arc::new(|request| {
+        (
+            StatusCode::OK,
+            json!({"encrypted_output": format!("cipher-{}", request.account_id)}),
+        )
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    let mut quota_headers = hyper::HeaderMap::new();
+    quota_headers.insert("retry-after", "3600".parse().unwrap());
+    test.app.router.quota_failure("a", &quota_headers).await;
+    test.app.router.quota_failure("b", &quota_headers).await;
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let seen = upstream.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].account_id, "workspace-a");
+}
+
+#[tokio::test]
+async fn context_owner_in_login_is_unavailable_without_upstream_fallback() {
+    let upstream = start_upstream(Arc::new(|_| {
+        (StatusCode::OK, json!({"encrypted_output": "must-not-run"}))
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "a",
+            &context_identity("workspace-a", "user-a"),
+        )
+        .await
+        .unwrap();
+    assert!(test.app.router.begin_login("a").await);
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(upstream.seen.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn history_requires_every_participant_to_be_available() {
+    let mode = Arc::new(Mutex::new("partial"));
+    let responder_mode = mode.clone();
+    let upstream = start_upstream(Arc::new(move |request| {
+        let mode = *responder_mode.lock().unwrap();
+        match (mode, request.account_id.as_str()) {
+            ("partial", "workspace-a") => (
+                StatusCode::OK,
+                json!({"encrypted_output": "cipher-workspace-a"}),
+            ),
+            _ => (StatusCode::SERVICE_UNAVAILABLE, json!({"error": "down"})),
+        }
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "a",
+            &context_identity("workspace-a", "user-a"),
+        )
+        .await
+        .unwrap();
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "b",
+            &context_identity("workspace-b", "user-b"),
+        )
+        .await
+        .unwrap();
+    let request_body = Bytes::from_static(
+        br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+    );
+
+    let (status, failed) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/history/v2/list_windows",
+        hyper::HeaderMap::new(),
+        request_body.clone(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let failed = String::from_utf8(failed.to_vec()).unwrap();
+    assert!(!failed.contains("cipher-workspace-a"));
+    assert!(!failed.contains("encrypted_output"));
+    assert!(!failed.contains("comradex-context-v1:"));
+
+    *mode.lock().unwrap() = "unavailable";
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/history/v2/list_windows",
+        hyper::HeaderMap::new(),
+        request_body,
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn owner_alias_with_same_workspace_but_different_user_fails_closed() {
+    let upstream = start_upstream(Arc::new(|_| {
+        (StatusCode::OK, json!({"encrypted_output": "must-not-run"}))
+    }))
+    .await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+    test.app
+        .context_store
+        .record_dispatch(
+            "default",
+            SESSION,
+            "a",
+            &context_identity("workspace-a", "user-a"),
+        )
+        .await
+        .unwrap();
+    write_auth(&test.account_a, "workspace-a", "different-user");
+
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/read_file",
+        hyper::HeaderMap::new(),
+        Bytes::from_static(
+            br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(upstream.seen.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn backend_alias_requires_exact_install_secret_and_path_segment() {
+    let upstream = start_upstream(Arc::new(|_| (StatusCode::OK, json!({"ok": true})))).await;
+    let dir = tempfile::tempdir().unwrap();
+    let test = context_test_app(dir.path(), upstream.address);
+
+    let aliased: Uri =
+        format!("/{SECRET}/backend-api/codex/alpha/history/v2/list_items?cursor=opaque")
+            .parse()
+            .unwrap();
+    assert_eq!(
+        test.app.authorized_path(&aliased).as_deref(),
+        Some("/alpha/history/v2/list_items?cursor=opaque")
+    );
+    let legacy: Uri = format!("/{SECRET}/v1/responses").parse().unwrap();
+    assert_eq!(
+        test.app.authorized_path(&legacy).as_deref(),
+        Some("/responses")
+    );
+
+    for rejected in [
+        "/wrong-secret/backend-api/codex/responses".to_owned(),
+        format!("/{SECRET}/backend-api/codexevil/responses"),
+        format!("/{SECRET}/backend-api/responses"),
+    ] {
+        assert_eq!(test.app.authorized_path(&rejected.parse().unwrap()), None);
+    }
+}
+
+#[tokio::test]
+async fn context_401_retries_refreshed_credentials_on_the_same_physical_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("a");
+    let newer_token = test_token("workspace-a", "user-a").replacen("e30.", "e31.", 1);
+    let next_token = newer_token.clone();
+    let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let seen = requests.clone();
+    let upstream = start_upstream(Arc::new(move |_| {
+        if seen.fetch_add(1, Ordering::SeqCst) == 0 {
+            // Model a concurrent successful refresh; force_refresh must reuse the new credential.
+            fs::write(
+                home.join("auth.json"),
+                serde_json::to_vec(&json!({
+                    "tokens": {"access_token": next_token, "account_id": "workspace-a"}
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+            (StatusCode::UNAUTHORIZED, json!({"error":"expired"}))
+        } else {
+            (StatusCode::OK, json!({"encrypted_output":"native-note"}))
+        }
+    }))
+    .await;
+    let test = context_test_app(dir.path(), upstream.address);
+    let (status, _) = post(
+        &test.app,
+        &test.listener,
+        "/alpha/notes/v2/write_file",
+        hyper::HeaderMap::new(),
+        serde_json::to_vec(&json!({
+            "context":{"session_id":SESSION,"current_agent_name":"/root"},
+            "path":"note", "text":"encrypted-argument"
+        }))
+        .unwrap()
+        .into(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let seen = upstream.seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    assert!(
+        seen.iter()
+            .all(|request| request.account_id == "workspace-a")
+    );
+    assert_eq!(seen[1].authorization, format!("Bearer {newer_token}"));
+    assert_eq!(seen[0].body, seen[1].body);
+}

--- a/src/proxy/context_ws_tests.rs
+++ b/src/proxy/context_ws_tests.rs
@@ -1,0 +1,568 @@
+use super::*;
+use crate::config::{AccountConfig, ProxyConfig};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use bytes::Bytes;
+use http_body_util::{BodyExt, Full};
+use hyper::{body::Incoming, server::conn::http1};
+use hyper_util::rt::TokioIo;
+use serde_json::{Value, json};
+use std::{
+    collections::BTreeMap,
+    convert::Infallible,
+    fs,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{Message, client::IntoClientRequest, protocol::Role},
+};
+
+const SESSION: &str = "123e4567-e89b-12d3-a456-426614174000";
+const SECRET: &str = "0123456789abcdef";
+const AFFINITY_KEY: &str = "0123456789abcdef0123456789abcdef";
+const NATIVE_NOTE: &str = "native-encrypted-note-from-a";
+
+#[derive(Clone, Debug)]
+struct SeenRequest {
+    transport: &'static str,
+    authorization: String,
+    path: String,
+    body: Value,
+}
+
+struct ContextWebSocketUpstream {
+    address: std::net::SocketAddr,
+    seen: Arc<Mutex<Vec<SeenRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for ContextWebSocketUpstream {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+fn test_token(workspace: &str, user: &str) -> String {
+    let payload = URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&json!({
+            "exp": 4_102_444_800_u64,
+            "sub": user,
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": workspace,
+                "chatgpt_user_id": user
+            }
+        }))
+        .unwrap(),
+    );
+    format!("e30.{payload}.sig")
+}
+
+fn write_auth(home: &Path, workspace: &str, user: &str) {
+    fs::create_dir_all(home).unwrap();
+    fs::write(
+        home.join("auth.json"),
+        serde_json::to_vec(&json!({
+            "tokens": {
+                "access_token": test_token(workspace, user),
+                "account_id": workspace
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn authorization(request: &Request<Incoming>) -> String {
+    request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+fn response_events(id: &str) -> [Value; 2] {
+    [
+        json!({
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {"id": id, "status": "in_progress"}
+        }),
+        json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": {"id": id, "status": "completed", "output": []}
+        }),
+    ]
+}
+
+fn is_continuation(body: &Value) -> bool {
+    body["input"].as_array().is_some_and(|input| {
+        input
+            .iter()
+            .any(|item| item["type"] == "function_call_output")
+    })
+}
+
+async fn run_direct_connection(
+    upgraded: hyper::upgrade::Upgraded,
+    authorization: String,
+    path: String,
+    seen: Arc<Mutex<Vec<SeenRequest>>>,
+) {
+    let mut websocket =
+        WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Server, None).await;
+    while let Some(Ok(message)) = websocket.next().await {
+        let Message::Text(text) = message else {
+            if matches!(message, Message::Close(_)) {
+                break;
+            }
+            continue;
+        };
+        let body: Value = serde_json::from_str(text.as_str()).unwrap();
+        let continuation = is_continuation(&body);
+        seen.lock().unwrap().push(SeenRequest {
+            transport: "websocket",
+            authorization: authorization.clone(),
+            path: path.clone(),
+            body,
+        });
+        if continuation
+            && authorization == format!("Bearer {}", test_token("workspace-a", "user-a"))
+        {
+            websocket
+                .send(Message::Text(
+                    json!({
+                        "type": "error",
+                        "error": {
+                            "type": "rate_limit_exceeded",
+                            "code": "rate_limit_exceeded",
+                            "message": "usage limit reached"
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            continue;
+        }
+        let id = if continuation {
+            "resp_replayed"
+        } else {
+            "resp_initial"
+        };
+        for event in response_events(id) {
+            websocket
+                .send(Message::Text(event.to_string().into()))
+                .await
+                .unwrap();
+        }
+    }
+}
+
+async fn start_context_upstream() -> ContextWebSocketUpstream {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let task_seen = seen.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let seen = task_seen.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |mut request: Request<Incoming>| {
+                    let seen = seen.clone();
+                    async move {
+                        let path = request.uri().path_and_query().unwrap().to_string();
+                        let auth = authorization(&request);
+                        if request.method() == Method::GET
+                            && request
+                                .headers()
+                                .get(UPGRADE)
+                                .and_then(|value| value.to_str().ok())
+                                .is_some_and(|value| value.eq_ignore_ascii_case("websocket"))
+                        {
+                            let accept =
+                                tokio_tungstenite::tungstenite::handshake::derive_accept_key(
+                                    request.headers()[SEC_WEBSOCKET_KEY].as_bytes(),
+                                );
+                            let upgrade = hyper::upgrade::on(&mut request);
+                            tokio::spawn(async move {
+                                run_direct_connection(upgrade.await.unwrap(), auth, path, seen)
+                                    .await;
+                            });
+                            return Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::SWITCHING_PROTOCOLS)
+                                    .header(CONNECTION, "Upgrade")
+                                    .header(UPGRADE, "websocket")
+                                    .header(SEC_WEBSOCKET_ACCEPT, accept)
+                                    .body(Full::new(Bytes::new()))
+                                    .unwrap(),
+                            );
+                        }
+
+                        let bytes = request.into_body().collect().await.unwrap().to_bytes();
+                        let body: Value = serde_json::from_slice(&bytes).unwrap();
+                        let continuation = is_continuation(&body);
+                        seen.lock().unwrap().push(SeenRequest {
+                            transport: "http",
+                            authorization: auth.clone(),
+                            path: path.clone(),
+                            body,
+                        });
+                        if path.contains("/alpha/notes/") {
+                            return Ok(Response::builder()
+                                .status(StatusCode::OK)
+                                .header(CONTENT_TYPE, "application/json")
+                                .body(Full::new(Bytes::from(
+                                    serde_json::to_vec(&json!({
+                                        "encrypted_output": NATIVE_NOTE
+                                    }))
+                                    .unwrap(),
+                                )))
+                                .unwrap());
+                        }
+                        if continuation
+                            && auth == format!("Bearer {}", test_token("workspace-a", "user-a"))
+                        {
+                            return Ok(Response::builder()
+                                .status(StatusCode::TOO_MANY_REQUESTS)
+                                .header(CONTENT_TYPE, "application/json")
+                                .body(Full::new(Bytes::from_static(
+                                    br#"{"error":{"type":"rate_limit_exceeded","code":"rate_limit_exceeded","message":"usage limit reached"}}"#,
+                                )))
+                                .unwrap());
+                        }
+                        let id = if continuation {
+                            "resp_replayed"
+                        } else {
+                            "resp_initial"
+                        };
+                        let body = response_events(id)
+                            .into_iter()
+                            .map(|event| format!("data: {event}\n\n"))
+                            .collect::<String>();
+                        Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/event-stream")
+                            .body(Full::new(Bytes::from(body)))
+                            .unwrap())
+                    }
+                });
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+    ContextWebSocketUpstream {
+        address,
+        seen,
+        task,
+    }
+}
+
+struct ContextWebSocketProxy {
+    address: std::net::SocketAddr,
+    app: Arc<App>,
+    task: tokio::task::JoinHandle<Result<()>>,
+}
+
+impl Drop for ContextWebSocketProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn start_context_proxy(
+    dir: &Path,
+    upstream: std::net::SocketAddr,
+    mode: ResponsesWebsocketMode,
+) -> ContextWebSocketProxy {
+    let account_a = dir.join("a");
+    let account_b = dir.join("b");
+    write_auth(&account_a, "workspace-a", "user-a");
+    write_auth(&account_b, "workspace-b", "user-b");
+    let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = tcp.local_addr().unwrap();
+    let listener = ListenerConfig {
+        address,
+        pool: "default".into(),
+    };
+    let config = Arc::new(Config {
+        proxy: ProxyConfig {
+            upstream: format!("http://{upstream}/backend-api/codex"),
+            responses_websocket_mode: mode,
+            installation_secret: SECRET.into(),
+            affinity_key: AFFINITY_KEY.into(),
+            state_dir: Some(dir.join("state")),
+            ..ProxyConfig::default()
+        },
+        listeners: BTreeMap::from([("default".into(), listener.clone())]),
+        pools: BTreeMap::from([(
+            "default".into(),
+            PoolConfig {
+                members: vec!["a".into(), "b".into()],
+                preferred: None,
+            },
+        )]),
+        accounts: BTreeMap::from([
+            ("a".into(), AccountConfig::CodexHome { path: account_a }),
+            ("b".into(), AccountConfig::CodexHome { path: account_b }),
+        ]),
+    });
+    let affinity = Arc::new(
+        AffinityStore::load(
+            dir.join("affinity.json"),
+            &config.proxy.affinity_key,
+            Duration::from_secs(60),
+        )
+        .unwrap(),
+    );
+    let router = Arc::new(Router::new(&config, affinity));
+    let app = App::new_unvalidated(config, router, Arc::new(Stats::default())).unwrap();
+    let task = tokio::spawn(app.clone().serve_tcp("default".into(), listener, tcp));
+    ContextWebSocketProxy { address, app, task }
+}
+
+async fn connect_proxy(address: std::net::SocketAddr) -> WebSocketStream<TcpStream> {
+    let stream = TcpStream::connect(address).await.unwrap();
+    let request = format!("ws://{address}/{SECRET}/backend-api/codex/responses")
+        .into_client_request()
+        .unwrap();
+    tokio_tungstenite::client_async(request, stream)
+        .await
+        .unwrap()
+        .0
+}
+
+async fn send_turn(websocket: &mut WebSocketStream<TcpStream>, body: Value) -> Vec<Value> {
+    websocket
+        .send(Message::Text(body.to_string().into()))
+        .await
+        .unwrap();
+    let mut events = Vec::new();
+    for _ in 0..4 {
+        let message = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let event: Value = serde_json::from_str(message.into_text().unwrap().as_ref()).unwrap();
+        let terminal = matches!(
+            event["type"].as_str(),
+            Some("response.completed" | "response.failed" | "error")
+        );
+        events.push(event);
+        if terminal {
+            return events;
+        }
+    }
+    panic!("turn did not produce a terminal event: {events:?}");
+}
+
+async fn post_proxy(address: std::net::SocketAddr, path: &str, body: Value) -> (StatusCode, Value) {
+    let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+        .build_http::<Full<Bytes>>();
+    let response = client
+        .request(
+            Request::builder()
+                .method(Method::POST)
+                .uri(format!("http://{address}/{SECRET}/backend-api/codex{path}"))
+                .header(CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::from(serde_json::to_vec(&body).unwrap())))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    (status, serde_json::from_slice(&body).unwrap())
+}
+
+fn initial_create() -> Value {
+    json!({
+        "type": "response.create",
+        "model": "gpt-test",
+        "client_metadata": {"session_id": SESSION},
+        "reasoning": {"context": "all_turns"},
+        "input": []
+    })
+}
+
+fn continuation(encrypted_content: &str) -> Value {
+    json!({
+        "type": "response.create",
+        "model": "gpt-test",
+        "client_metadata": {"session_id": SESSION},
+        "input": [{
+            "type": "function_call_output",
+            "call_id": "call_notes",
+            "output": [{
+                "type": "encrypted_content",
+                "encrypted_content": encrypted_content
+            }]
+        }]
+    })
+}
+
+fn is_native_note(body: &Value) -> bool {
+    body["input"].as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item["output"].as_array().is_some_and(|parts| {
+                parts.iter().any(|part| {
+                    part["type"] == "encrypted_content" && part["encrypted_content"] == NATIVE_NOTE
+                })
+            })
+        })
+    })
+}
+
+async fn exercise_trusted_context_replay(mode: ResponsesWebsocketMode) {
+    let upstream = start_context_upstream().await;
+    let dir = tempfile::tempdir().unwrap();
+    let proxy = start_context_proxy(dir.path(), upstream.address, mode).await;
+    let mut websocket = connect_proxy(proxy.address).await;
+
+    let initial = send_turn(&mut websocket, initial_create()).await;
+    assert_eq!(initial.last().unwrap()["type"], "response.completed");
+    let stored = proxy
+        .app
+        .context_store
+        .lookup("default", SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.owner.alias, "a");
+    assert_eq!(stored.participants.len(), 1);
+
+    let (status, note) = post_proxy(
+        proxy.address,
+        "/alpha/notes/v2/read_file",
+        json!({
+            "context": {"session_id": SESSION, "current_agent_name": "/root"}
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let wrapper = note["encrypted_output"].as_str().unwrap();
+    assert!(wrapper.starts_with("comradex-context-v1:"));
+
+    let replayed = send_turn(&mut websocket, continuation(wrapper)).await;
+    assert_eq!(replayed.last().unwrap()["type"], "response.completed");
+    assert!(
+        replayed
+            .iter()
+            .all(|event| event["response"]["id"] != "resp_quota")
+    );
+
+    let stored = proxy
+        .app
+        .context_store
+        .lookup("default", SESSION)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.owner.alias, "a");
+    assert_eq!(
+        stored
+            .participants
+            .iter()
+            .map(|participant| participant.alias.as_str())
+            .collect::<Vec<_>>(),
+        ["a", "b"]
+    );
+
+    let (status, _) = post_proxy(
+        proxy.address,
+        "/alpha/notes/v2/read_file",
+        json!({
+            "context": {"session_id": SESSION, "current_agent_name": "/root"}
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let seen = upstream.seen.lock().unwrap();
+    let expected_transport = match mode {
+        ResponsesWebsocketMode::Direct => "websocket",
+        ResponsesWebsocketMode::HttpBridge => "http",
+        ResponsesWebsocketMode::Raw => unreachable!(),
+    };
+    let inference = seen
+        .iter()
+        .filter(|request| request.path.ends_with("/responses"))
+        .collect::<Vec<_>>();
+    assert!(
+        inference
+            .iter()
+            .all(|request| request.transport == expected_transport)
+    );
+    let replay_to_b = inference
+        .iter()
+        .find(|request| {
+            request.authorization == format!("Bearer {}", test_token("workspace-b", "user-b"))
+                && is_continuation(&request.body)
+        })
+        .expect("trusted continuation replayed to account b");
+    assert!(is_native_note(&replay_to_b.body));
+    assert!(
+        !replay_to_b
+            .body
+            .to_string()
+            .contains("comradex-context-v1:")
+    );
+    let notes = seen
+        .iter()
+        .filter(|request| request.path.contains("/alpha/notes/"))
+        .collect::<Vec<_>>();
+    assert_eq!(notes.len(), 2);
+    assert!(notes.iter().all(|request| {
+        request.authorization == format!("Bearer {}", test_token("workspace-a", "user-a"))
+    }));
+}
+
+async fn exercise_untrusted_ciphertext_is_not_replayed(mode: ResponsesWebsocketMode) {
+    let upstream = start_context_upstream().await;
+    let dir = tempfile::tempdir().unwrap();
+    let proxy = start_context_proxy(dir.path(), upstream.address, mode).await;
+    let mut websocket = connect_proxy(proxy.address).await;
+    assert_eq!(
+        send_turn(&mut websocket, initial_create())
+            .await
+            .last()
+            .unwrap()["type"],
+        "response.completed"
+    );
+
+    let failed = send_turn(
+        &mut websocket,
+        continuation("untrusted-native-encrypted-content"),
+    )
+    .await;
+    assert_ne!(failed.last().unwrap()["type"], "response.completed");
+
+    let seen = upstream.seen.lock().unwrap();
+    assert!(!seen.iter().any(|request| {
+        request.path.ends_with("/responses")
+            && request.authorization == format!("Bearer {}", test_token("workspace-b", "user-b"))
+    }));
+}
+
+#[tokio::test]
+async fn direct_websocket_context_replay_preserves_native_context_ownership() {
+    exercise_trusted_context_replay(ResponsesWebsocketMode::Direct).await;
+    exercise_untrusted_ciphertext_is_not_replayed(ResponsesWebsocketMode::Direct).await;
+}
+
+#[tokio::test]
+async fn http_bridge_websocket_context_replay_preserves_native_context_ownership() {
+    exercise_trusted_context_replay(ResponsesWebsocketMode::HttpBridge).await;
+    exercise_untrusted_ciphertext_is_not_replayed(ResponsesWebsocketMode::HttpBridge).await;
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -975,7 +975,10 @@ impl App {
         {
             let bytes = replay.into_bytes().await?;
             let mut value: serde_json::Value = serde_json::from_slice(&bytes)?;
-            let routing_value = match self.context_routing_view(&value, &listener.pool).await {
+            let routing_value = match self
+                .context_routing_view(&value, listener, &inbound_headers)
+                .await
+            {
                 Ok(value) => value,
                 Err(_) => {
                     return Ok(error_response(
@@ -2276,7 +2279,7 @@ impl App {
                                 continue;
                             }
                             let mut value = parsed.expect("response.create was checked");
-                            let routing_value = match self.context_routing_view(&value, &listener.pool).await {
+                            let routing_value = match self.context_routing_view(&value, &listener, &headers).await {
                                 Ok(value) => value,
                                 Err(_) => {
                                     send_direct_error(&mut client, "context_result_invalid", "invalid context result").await?;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,3 +1,10 @@
+mod context;
+mod context_codec;
+mod context_store;
+#[cfg(test)]
+mod context_tests;
+#[cfg(test)]
+mod context_ws_tests;
 mod headers;
 mod replay_body;
 #[allow(dead_code)]
@@ -106,6 +113,7 @@ struct DirectTurn {
     route: WebSocketFrameRoute,
     request: Message,
     value: serde_json::Value,
+    routing_value: serde_json::Value,
 }
 
 struct DirectUpstream {
@@ -600,6 +608,8 @@ pub struct App {
     live_calls: LiveCallStore,
     auth: auth::Resolver,
     file_owners: Arc<AffinityStore>,
+    context_store: context_store::ContextStore,
+    context_codec: context_codec::ContextCodec,
     tasks: AsyncMutex<JoinSet<()>>,
     shutting_down: AtomicBool,
     service_nonce: Option<String>,
@@ -656,6 +666,11 @@ impl App {
             ),
             auth: auth::Resolver::new(&config),
             file_owners,
+            context_store: context_store::ContextStore::open(
+                &state_dir.join("context.sqlite3"),
+                &config.proxy.affinity_key,
+            )?,
+            context_codec: context_codec::ContextCodec::new(&config.proxy.affinity_key),
             config,
             router,
             client,
@@ -864,8 +879,11 @@ impl App {
     }
 
     fn authorized_path(&self, uri: &Uri) -> Option<String> {
-        let prefix = format!("/{}/v1", self.config.proxy.installation_secret);
-        let suffix = uri.path().strip_prefix(&prefix)?;
+        let root = format!("/{}/", self.config.proxy.installation_secret);
+        let authenticated = uri.path().strip_prefix(&root)?;
+        let suffix = authenticated
+            .strip_prefix("backend-api/codex")
+            .or_else(|| authenticated.strip_prefix("v1"))?;
         if !suffix.is_empty() && !suffix.starts_with('/') {
             return None;
         }
@@ -945,6 +963,61 @@ impl App {
             previous_response_id: routing_previous_response_id,
             lane,
         } = context;
+        if path.starts_with("/alpha/history/") || path.starts_with("/alpha/notes/") {
+            return self
+                .handle_context(method, &path, &inbound_headers, listener, replay)
+                .await;
+        }
+        let context_body = if is_native_responses(&path)
+            && (replay.context_session_id().is_some()
+                || replay.has_nonportable_state()
+                || replay.has_context_envelope())
+        {
+            let bytes = replay.into_bytes().await?;
+            let mut value: serde_json::Value = serde_json::from_slice(&bytes)?;
+            let routing_value = match self.context_routing_view(&value, &listener.pool).await {
+                Ok(value) => value,
+                Err(_) => {
+                    return Ok(error_response(
+                        StatusCode::BAD_REQUEST,
+                        "context_result_invalid",
+                        "invalid context result",
+                    ));
+                }
+            };
+            let changed = match self.expand_context(&mut value, &listener.pool) {
+                Ok(changed) => changed,
+                Err(_) => {
+                    return Ok(error_response(
+                        StatusCode::BAD_REQUEST,
+                        "context_result_invalid",
+                        "invalid context result",
+                    ));
+                }
+            };
+            replay = ReplayBody::from_bytes(
+                if changed {
+                    serde_json::to_vec(&value)?.into()
+                } else {
+                    bytes
+                },
+                self.config.proxy.max_request_bytes,
+                self.config.proxy.max_spool_bytes,
+                self.stats.clone(),
+            )?;
+            if changed {
+                let routing_replay = ReplayBody::from_bytes(
+                    serde_json::to_vec(&routing_value)?.into(),
+                    self.config.proxy.max_request_bytes,
+                    self.config.proxy.max_spool_bytes,
+                    self.stats.clone(),
+                )?;
+                replay.use_context_routing_metadata(&routing_replay);
+            }
+            Some(value)
+        } else {
+            None
+        };
         let legacy_compact = method == Method::POST && is_legacy_compact_path(&path);
         if legacy_compact {
             let bytes = replay.into_bytes().await?;
@@ -1098,6 +1171,18 @@ impl App {
                 }
             };
             let _inflight = InflightGuard::new(counter);
+            if let Some(body) = &context_body
+                && self
+                    .record_context_dispatch(body, &listener.pool, &account, &credentials)
+                    .await
+                    .is_err()
+            {
+                return Ok(error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "context_backend_unavailable",
+                    "context ownership could not be recorded",
+                ));
+            }
             self.router.begin(&account).await;
             let mut request_lease = DirectAccountLease::new(self.router.clone(), account.clone());
             let (body, upload_progress) = progress_body(replay.body(attempt)?);
@@ -2190,8 +2275,21 @@ impl App {
                                 send_direct_error(&mut client, "invalid_request_error", "response.create exceeds configured request limit").await?;
                                 continue;
                             }
+                            let mut value = parsed.expect("response.create was checked");
+                            let routing_value = match self.context_routing_view(&value, &listener.pool).await {
+                                Ok(value) => value,
+                                Err(_) => {
+                                    send_direct_error(&mut client, "context_result_invalid", "invalid context result").await?;
+                                    continue;
+                                }
+                            };
+                            if self.expand_context(&mut value, &listener.pool).is_err() {
+                                send_direct_error(&mut client, "context_result_invalid", "invalid context result").await?;
+                                continue;
+                            }
+                            let client_message = Message::Text(serde_json::to_string(&value)?.into());
                             let replay = ReplayBody::from_bytes(
-                                bytes::Bytes::copy_from_slice(text.as_bytes()),
+                                serde_json::to_vec(&routing_value)?.into(),
                                 self.config.proxy.max_request_bytes,
                                 self.config.proxy.max_spool_bytes,
                                 self.stats.clone(),
@@ -2241,9 +2339,8 @@ impl App {
                                 upstream = replacement.socket;
                                 upstream_credentials = replacement.credentials;
                             }
-                            let value = parsed.expect("response.create was checked");
                             let analysis = match analyze_response_create(
-                                &value,
+                                &routing_value,
                                 ProtocolLimits::default(),
                             ) {
                                 Ok(analysis) => analysis,
@@ -2257,7 +2354,7 @@ impl App {
                                     continue;
                                 }
                             };
-                            let turn_id = match protocol.admit_response_create(&value) {
+                            let turn_id = match protocol.admit_response_create(&routing_value) {
                                 Ok(turn_id) => turn_id,
                                 Err(error) => {
                                     send_direct_error(
@@ -2269,6 +2366,7 @@ impl App {
                                     continue;
                                 }
                             };
+                            self.record_context_dispatch(&value, &listener.pool, &account, &upstream_credentials).await?;
                             upstream.send(client_message.clone()).await?;
                             if analysis.has_nonportable_state {
                                 route.hard_owner = true;
@@ -2282,6 +2380,7 @@ impl App {
                                 route,
                                 request: client_message,
                                 value,
+                                routing_value,
                             });
                             continue;
                         }
@@ -2701,8 +2800,17 @@ impl App {
         let replay_value = match mode {
             ReplayMode::OriginalRequest => turn.value.clone(),
             ReplayMode::FreshRequestWithoutPreviousResponse => {
-                fresh_replay_without_previous_response(&turn.value, ProtocolLimits::default())
-                    .map_err(|error| anyhow::anyhow!("prepare fresh direct replay: {error:?}"))?
+                fresh_replay_without_previous_response(
+                    &turn.routing_value,
+                    ProtocolLimits::default(),
+                )
+                .map_err(|error| anyhow::anyhow!("prepare fresh direct replay: {error:?}"))?;
+                let mut value = turn.value.clone();
+                value
+                    .as_object_mut()
+                    .context("invalid direct replay")?
+                    .remove("previous_response_id");
+                value
             }
         };
         let replay_message = match mode {
@@ -2717,6 +2825,13 @@ impl App {
         if committed != plan {
             anyhow::bail!("direct replay plan changed before commit")
         }
+        self.record_context_dispatch(
+            &replay_value,
+            &listener.pool,
+            &replacement_account,
+            &replacement.credentials,
+        )
+        .await?;
         if let Err(error) = replacement.socket.send(replay_message.clone()).await {
             warn!(%error, account = replacement_account, "safe direct replay send failed");
             return Ok(None);
@@ -2726,6 +2841,10 @@ impl App {
             turn.value = replay_value;
             turn.route.account_id = replacement_account.clone();
             if mode == ReplayMode::FreshRequestWithoutPreviousResponse {
+                turn.routing_value
+                    .as_object_mut()
+                    .expect("validated response.create")
+                    .remove("previous_response_id");
                 turn.route.hard_owner = turn.route.non_previous_hard_owner;
             }
         }
@@ -3039,7 +3158,9 @@ impl App {
                 let headers = inbound_headers.clone();
                 let direct = !forced_live
                     && is_native_responses(&path)
-                    && self.config.proxy.responses_websocket_mode == ResponsesWebsocketMode::Direct;
+                    && (self.config.proxy.responses_websocket_mode
+                        == ResponsesWebsocketMode::Direct
+                        || req.uri().path().contains("/backend-api/codex/"));
                 stats.open_upgrades.fetch_add(1, Ordering::Relaxed);
                 let upgrade_guard = OpenUpgradeGuard(stats.clone());
                 let spawned = self
@@ -5571,6 +5692,7 @@ mod tests {
             DirectTurn {
                 route,
                 request: Message::Text(value.to_string().into()),
+                routing_value: value.clone(),
                 value,
             },
         )]);

--- a/src/proxy/replay_body.rs
+++ b/src/proxy/replay_body.rs
@@ -26,6 +26,8 @@ pub struct ReplayBody {
     len: usize,
     stats: Arc<Stats>,
     thread_id: Option<String>,
+    context_session_id: Option<String>,
+    context_envelope: bool,
     previous_response_id: Option<String>,
     prompt_cache_key: Option<String>,
     file_ids: Vec<String>,
@@ -37,6 +39,7 @@ pub struct ReplayBody {
 enum KeyKind {
     ClientMetadata,
     ThreadId,
+    SessionId,
     PreviousResponseId,
     PromptCacheKey,
     FileId,
@@ -64,6 +67,8 @@ struct MetadataScanner {
     key: Option<KeyKind>,
     pending_value: Option<KeyKind>,
     thread_id: Option<String>,
+    context_session_id: Option<String>,
+    context_envelope: bool,
     previous_response_id: Option<String>,
     prompt_cache_key: Option<String>,
     file_ids: Vec<String>,
@@ -117,6 +122,7 @@ impl MetadataScanner {
                         matches!(
                             kind,
                             KeyKind::ThreadId
+                                | KeyKind::SessionId
                                 | KeyKind::PreviousResponseId
                                 | KeyKind::PromptCacheKey
                                 | KeyKind::FileId
@@ -134,6 +140,7 @@ impl MetadataScanner {
                 }
                 b'{' => {
                     if self.containers.len() >= 128 {
+                        self.nonportable_state = true;
                         self.disabled = true;
                         continue;
                     }
@@ -151,6 +158,7 @@ impl MetadataScanner {
                 }
                 b'[' => {
                     if self.containers.len() >= 128 {
+                        self.nonportable_state = true;
                         self.disabled = true;
                         continue;
                     }
@@ -201,11 +209,16 @@ impl MetadataScanner {
 
     fn finish_string(&mut self) {
         self.in_string = false;
+        self.context_envelope |=
+            !self.string_is_key && self.token.starts_with(b"comradex-context-v1:");
+        // Also inspect an all-turns request without session metadata so it fails closed.
+        self.context_envelope |= !self.string_is_key && self.token == b"all_turns";
         if let Some(kind) = self.capture_value {
             if !self.token_overflow && !self.token.is_empty() {
                 let value = String::from_utf8(self.token.clone()).ok();
                 match kind {
                     KeyKind::ThreadId => self.thread_id = value,
+                    KeyKind::SessionId => self.context_session_id = value,
                     KeyKind::PreviousResponseId => self.previous_response_id = value,
                     KeyKind::PromptCacheKey => self.prompt_cache_key = value,
                     KeyKind::FileId => {
@@ -258,6 +271,8 @@ impl MetadataScanner {
                 Some(KeyKind::ClientMetadata)
             } else if in_client && !self.token_overflow && self.token == b"thread_id" {
                 Some(KeyKind::ThreadId)
+            } else if in_client && !self.token_overflow && self.token == b"session_id" {
+                Some(KeyKind::SessionId)
             } else if at_root && !self.token_overflow && self.token == b"previous_response_id" {
                 Some(KeyKind::PreviousResponseId)
             } else if at_root && !self.token_overflow && self.token == b"prompt_cache_key" {
@@ -339,6 +354,8 @@ impl ReplayBody {
             storage: Storage::Memory(bytes),
             stats,
             thread_id: metadata.thread_id,
+            context_session_id: metadata.context_session_id,
+            context_envelope: metadata.context_envelope,
             previous_response_id: metadata.previous_response_id,
             prompt_cache_key: metadata.prompt_cache_key,
             file_ids: metadata.file_ids,
@@ -416,6 +433,8 @@ impl ReplayBody {
             len,
             stats,
             thread_id: metadata.thread_id,
+            context_session_id: metadata.context_session_id,
+            context_envelope: metadata.context_envelope,
             previous_response_id: metadata.previous_response_id,
             prompt_cache_key: metadata.prompt_cache_key,
             file_ids: metadata.file_ids,
@@ -426,6 +445,18 @@ impl ReplayBody {
 
     pub fn thread_id(&self) -> Option<&str> {
         self.thread_id.as_deref()
+    }
+
+    pub fn context_session_id(&self) -> Option<&str> {
+        self.context_session_id.as_deref()
+    }
+
+    pub fn has_context_envelope(&self) -> bool {
+        self.context_envelope
+    }
+
+    pub fn use_context_routing_metadata(&mut self, view: &Self) {
+        self.nonportable_state = view.nonportable_state;
     }
 
     pub fn previous_response_id(&self) -> Option<&str> {
@@ -529,6 +560,26 @@ fn never_to_io(never: std::convert::Infallible) -> std::io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn nesting_limit_does_not_hide_later_account_owned_state() {
+        for opening in *b"[{" {
+            let mut scanner = MetadataScanner::default();
+            let mut nested = "null".to_owned();
+            for _ in 0..129 {
+                nested = if opening == b'[' {
+                    format!("[{nested}]")
+                } else {
+                    format!("{{\"padding\":{nested}}}")
+                };
+            }
+            let request = format!(
+                "{{\"padding\":{nested},\"input\":[{{\"encrypted_content\":\"opaque\"}}]}}"
+            );
+            scanner.feed(request.as_bytes());
+            assert!(scanner.nonportable_state);
+        }
+    }
 
     #[test]
     fn finds_body_thread_id_across_chunks_without_retaining_other_strings() {

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -319,6 +319,17 @@ impl Router {
             .collect()
     }
 
+    /// Native context tools use account-local storage independently of inference quota.
+    pub async fn context_account_available(&self, pool: &PoolConfig, account: &str) -> bool {
+        pool.members.iter().any(|member| member == account)
+            && self
+                .accounts
+                .lock()
+                .await
+                .get(account)
+                .is_some_and(|runtime| !runtime.needs_login && !runtime.login_in_progress)
+    }
+
     pub async fn begin(&self, account: &str) {
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
             a.inflight += 1;


### PR DESCRIPTION
Adds native history and notes support across account rotation. Notes keep one durable physical-account owner, while history queries every session participant and fails if any participant is unavailable.

Preserves encrypted arguments and restores authenticated tool results before HTTP or WebSocket inference. Installation uses the backend URL only when experimental context management is already enabled.
