### PR TITLE
Classify quota from canonical terminal outcomes, not HTTP status alone

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -71,7 +71,8 @@ use sse::{ProtocolEvent, SseDecoder, responses_json_events};
 use websocket_protocol::{
     DownstreamEndAction, FailureClassification, FailureKind, ProtocolLimits, ProtocolState,
     ReplayContext, ReplayMode, ReplayTarget, Settlement, TerminalKind, TurnEndDisposition, TurnId,
-    UpstreamEnd, analyze_response_create, classify_failure, fresh_replay_without_previous_response,
+    UpstreamEnd, analyze_response_create, classify_http_json_body, classify_terminal_event,
+    fresh_replay_without_previous_response, terminal_permits_affinity,
 };
 
 const FILE_CREATE_RESPONSE_LIMIT: usize = 1024 * 1024;
@@ -1350,6 +1351,13 @@ impl App {
                         .observe_headers(&account, response.headers())
                         .await;
                     let status = response.status();
+                    // Defer success affinity for native Responses until the
+                    // body terminal confirms a non-quota outcome. Header-time
+                    // binds would otherwise poison affinity when a late body
+                    // (HTTP 200 + SSE `type:error` / quota-shaped
+                    // `incomplete`/`failed`) reclassifies as quota.
+                    let defer_affinity = status.is_success() && is_native_responses(&path);
+                    let mut deferred_affinity: Vec<crate::routing::ThreadKey> = Vec::new();
                     if status.is_success()
                         && let Some(turn_state) = response
                             .headers()
@@ -1361,7 +1369,11 @@ impl App {
                             .router
                             .affinity
                             .key(&format!("turn-state:{turn_state}"));
-                        self.router.bind(alias, &account).await;
+                        if defer_affinity {
+                            deferred_affinity.push(alias);
+                        } else {
+                            self.router.bind(alias, &account).await;
+                        }
                     }
                     if status == StatusCode::UNAUTHORIZED {
                         if attempt == 0 {
@@ -1417,6 +1429,7 @@ impl App {
                             self.router.clone(),
                             &selected,
                             false,
+                            Vec::new(),
                         ));
                     }
                     if status == StatusCode::FORBIDDEN {
@@ -1426,12 +1439,17 @@ impl App {
                             self.router.clone(),
                             &selected,
                             false,
+                            Vec::new(),
                         ));
                     }
                     if status.is_success() {
                         for (kind, key) in &affinity_keys {
                             if *kind != metadata::AffinityKind::File {
-                                self.router.bind(key.clone(), &account).await;
+                                if defer_affinity {
+                                    deferred_affinity.push(key.clone());
+                                } else {
+                                    self.router.bind(key.clone(), &account).await;
+                                }
                             }
                         }
                     }
@@ -1490,11 +1508,17 @@ impl App {
                         return map_legacy_compact_response(response).await;
                     }
                     request_lease.disarm();
+                    let observe = status.is_success() && is_native_responses(&path);
                     return Ok(map_http_response_leased(
                         response,
                         self.router.clone(),
                         &selected,
-                        status.is_success() && is_native_responses(&path),
+                        observe,
+                        if observe {
+                            deferred_affinity
+                        } else {
+                            Vec::new()
+                        },
                     ));
                 }
                 Err(e) => {
@@ -2686,7 +2710,7 @@ impl App {
                                 client.send(message).await?;
                                 continue;
                             };
-                            let failure = classify_failure(&event);
+                            let failure = classify_terminal_event(&event);
                             if failure.kind != FailureKind::None
                                 && matches!(
                                     event.get("type").and_then(serde_json::Value::as_str),
@@ -4034,6 +4058,7 @@ fn map_http_response_leased(
     router: Arc<Router>,
     selection: &Selection,
     observe_response_ids: bool,
+    deferred_affinity: Vec<crate::routing::ThreadKey>,
 ) -> Response<ProxyBody> {
     let (mut parts, body) = response.into_parts();
     headers::strip_hop_by_hop(&mut parts.headers);
@@ -4043,8 +4068,12 @@ fn map_http_response_leased(
         seq: selection.seq,
     });
     let account = selection.account_id.clone();
-    let observer = observe_response_ids
-        .then(|| response_observer_for_content_type(parts.headers.get(CONTENT_TYPE)));
+    let response_headers = parts.headers.clone();
+    let observer = observe_response_ids.then(|| {
+        HttpResponseObserver::new(response_observer_for_content_type(
+            parts.headers.get(CONTENT_TYPE),
+        ))
+    });
     Response::from_parts(
         parts,
         BodyExt::boxed(LeasedIncoming {
@@ -4052,6 +4081,8 @@ fn map_http_response_leased(
             router,
             account: Some(account),
             observer,
+            response_headers,
+            deferred_affinity,
             pending_frame: None,
             pending_binding: None,
             pending_end: false,
@@ -4065,13 +4096,15 @@ struct LeasedIncoming {
     router: Arc<Router>,
     account: Option<String>,
     observer: Option<HttpResponseObserver>,
+    response_headers: hyper::HeaderMap,
+    deferred_affinity: Vec<crate::routing::ThreadKey>,
     pending_frame: Option<Frame<bytes::Bytes>>,
     pending_binding: Option<Pin<Box<dyn Future<Output = ()> + Send + Sync>>>,
     pending_end: bool,
     idle: Pin<Box<tokio::time::Sleep>>,
 }
 
-enum HttpResponseObserver {
+enum HttpResponseObserverKind {
     Sse(SseDecoder),
     Json(Option<Vec<u8>>),
     /// Wire bytes, not Content-Type, select the observer. At most the small
@@ -4080,78 +4113,198 @@ enum HttpResponseObserver {
     Undecided(Vec<u8>),
 }
 
-fn response_observer_for_content_type(
-    _content_type: Option<&hyper::header::HeaderValue>,
-) -> HttpResponseObserver {
-    HttpResponseObserver::Undecided(Vec::new())
+/// Canonical body observer for the HTTP lane. It defers all success-affinity
+/// binds (previous-response IDs plus header-time affinity keys) until the
+/// body terminal confirms a non-quota outcome, and records a quota-terminal
+/// classification for `quota_failure(headers)` with retry-after preserved.
+struct HttpResponseObserver {
+    kind: HttpResponseObserverKind,
+    deferred_ids: Vec<String>,
+    quota: Option<FailureClassification>,
+    terminal: Option<sse::TerminalStatus>,
 }
 
 impl HttpResponseObserver {
-    fn observe(&mut self, data: &[u8]) -> Vec<String> {
-        match self {
-            Self::Sse(decoder) => observe_sse_response_ids(decoder, data),
-            Self::Json(json) => {
-                if let Some(bytes) = json {
-                    if bytes.len().saturating_add(data.len()) <= RESPONSES_JSON_RESPONSE_LIMIT {
-                        bytes.extend_from_slice(data);
+    fn new(kind: HttpResponseObserverKind) -> Self {
+        Self {
+            kind,
+            deferred_ids: Vec::new(),
+            quota: None,
+            terminal: None,
+        }
+    }
+
+    fn observe(&mut self, data: &[u8]) {
+        if matches!(self.kind, HttpResponseObserverKind::Sse(_)) {
+            let batched = {
+                let HttpResponseObserverKind::Sse(decoder) = &mut self.kind else {
+                    unreachable!("checked Sse kind")
+                };
+                let mut batched = Vec::new();
+                for slice in data.chunks(SSE_DECODE_SLICE_BYTES) {
+                    match decoder.push(slice) {
+                        Ok(events) => batched.extend(events),
+                        Err(_) => continue,
+                    };
+                }
+                batched
+            };
+            if !batched.is_empty() {
+                self.observe_events(batched);
+            }
+            return;
+        }
+        if matches!(self.kind, HttpResponseObserverKind::Json(_)) {
+            if let HttpResponseObserverKind::Json(json) = &mut self.kind
+                && let Some(bytes) = json
+            {
+                if bytes.len().saturating_add(data.len()) <= RESPONSES_JSON_RESPONSE_LIMIT {
+                    bytes.extend_from_slice(data);
+                } else {
+                    *json = None;
+                }
+            }
+            return;
+        }
+        // Undecided: decide from a bounded wire prefix without holding the
+        // borrow across the recursive `observe` calls below.
+        let (decided, previous) = {
+            let HttpResponseObserverKind::Undecided(buffered) = &mut self.kind else {
+                unreachable!("checked Undecided kind")
+            };
+            let mut probe = buffered.clone();
+            let remaining = UNKNOWN_CONTENT_SNIFF_BYTES.saturating_sub(probe.len());
+            probe.extend_from_slice(&data[..data.len().min(remaining)]);
+            let kind = sniffed_body_kind(&probe).or_else(|| {
+                (probe.len() >= UNKNOWN_CONTENT_SNIFF_BYTES).then_some(SniffedBodyKind::Json)
+            });
+            let Some(kind) = kind else {
+                *buffered = probe;
+                return;
+            };
+            let previous = std::mem::take(buffered);
+            (kind, previous)
+        };
+        self.kind = match decided {
+            SniffedBodyKind::Json => HttpResponseObserverKind::Json(Some(Vec::new())),
+            SniffedBodyKind::Sse => HttpResponseObserverKind::Sse(SseDecoder::default()),
+        };
+        self.observe(&previous);
+        self.observe(data);
+    }
+
+    fn observe_events(&mut self, events: Vec<ProtocolEvent>) {
+        for event in events {
+            // Canonical terminal classification: unwrap `event.error OR
+            // `event.response.error`, narrow `incomplete_details`, numeric
+            // `status`/`status_code` fallback.
+            let classification = classify_terminal_event(&event.value);
+            if classification.kind == FailureKind::Quota {
+                self.quota = Some(classification);
+                self.terminal = event.terminal.or(self.terminal);
+                // Quota terminals never bind previous-response IDs; drop any
+                // IDs buffered from earlier non-terminal events in the same
+                // quota-failed body so a late quota reclassification does not
+                // leave success affinity behind.
+                self.deferred_ids.clear();
+                continue;
+            }
+            if let Some(id) = response_id_from_protocol_event(event.clone())
+                && !self.deferred_ids.contains(&id)
+            {
+                self.deferred_ids.push(id);
+            }
+            if event.terminal.is_some() {
+                self.terminal = event.terminal;
+            }
+        }
+    }
+
+    fn finish(mut self) -> HttpObservedBody {
+        // Collect trailing SSE events without holding the decoder borrow
+        // across `observe_events(&mut self)`.
+        let trailing = if matches!(self.kind, HttpResponseObserverKind::Sse(_)) {
+            let HttpResponseObserverKind::Sse(decoder) = &mut self.kind else {
+                unreachable!("checked Sse kind")
+            };
+            decoder.finish().unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        if !trailing.is_empty() {
+            self.observe_events(trailing);
+        }
+        match &mut self.kind {
+            HttpResponseObserverKind::Sse(_) => {}
+            HttpResponseObserverKind::Json(json) => {
+                if let Some(bytes) = json.take() {
+                    let classification = serde_json::from_slice::<serde_json::Value>(&bytes)
+                        .map(|value| classify_http_json_body(&value))
+                        .unwrap_or_else(|_| FailureClassification {
+                            kind: FailureKind::None,
+                            code: None,
+                            message: None,
+                            response_id: None,
+                        });
+                    if classification.kind == FailureKind::Quota {
+                        self.quota = Some(classification);
+                        self.deferred_ids.clear();
                     } else {
-                        *json = None;
+                        self.deferred_ids = response_ids_from_json(&bytes);
+                        // Record a non-quota terminal for affinity gating when
+                        // the JSON body implies one.
+                        if self.terminal.is_none() {
+                            self.terminal = serde_json::from_slice::<serde_json::Value>(&bytes)
+                                .ok()
+                                .and_then(|value| {
+                                    let response = value.get("response").unwrap_or(&value);
+                                    match response.get("status").and_then(serde_json::Value::as_str)
+                                    {
+                                        Some("completed") => Some(sse::TerminalStatus::Completed),
+                                        Some("failed") => Some(sse::TerminalStatus::Failed),
+                                        Some("incomplete") => Some(sse::TerminalStatus::Incomplete),
+                                        _ => None,
+                                    }
+                                });
+                        }
                     }
                 }
-                Vec::new()
             }
-            Self::Undecided(buffered) => {
-                let mut probe = buffered.clone();
-                let remaining = UNKNOWN_CONTENT_SNIFF_BYTES.saturating_sub(probe.len());
-                probe.extend_from_slice(&data[..data.len().min(remaining)]);
-                let kind = sniffed_body_kind(&probe).or_else(|| {
-                    (probe.len() >= UNKNOWN_CONTENT_SNIFF_BYTES).then_some(SniffedBodyKind::Json)
-                });
-                let Some(kind) = kind else {
-                    *buffered = probe;
-                    return Vec::new();
-                };
-                let previous = std::mem::take(buffered);
-                *self = match kind {
-                    SniffedBodyKind::Json => Self::Json(Some(Vec::new())),
-                    SniffedBodyKind::Sse => Self::Sse(SseDecoder::default()),
-                };
-                let mut ids = self.observe(&previous);
-                ids.extend(self.observe(data));
-                ids
+            HttpResponseObserverKind::Undecided(bytes) => {
+                let bytes = std::mem::take(bytes);
+                let classification = serde_json::from_slice::<serde_json::Value>(&bytes)
+                    .map(|value| classify_http_json_body(&value))
+                    .unwrap_or_else(|_| FailureClassification {
+                        kind: FailureKind::None,
+                        code: None,
+                        message: None,
+                        response_id: None,
+                    });
+                if classification.kind == FailureKind::Quota {
+                    self.quota = Some(classification);
+                } else {
+                    self.deferred_ids = response_ids_from_json(&bytes);
+                }
             }
         }
-    }
-
-    fn finish(self) -> Vec<String> {
-        match self {
-            Self::Sse(mut decoder) => response_ids_from_sse_finish(&mut decoder),
-            Self::Json(Some(bytes)) => response_ids_from_json(&bytes),
-            Self::Json(None) => Vec::new(),
-            Self::Undecided(bytes) => response_ids_from_json(&bytes),
+        HttpObservedBody {
+            ids: std::mem::take(&mut self.deferred_ids),
+            quota: self.quota,
+            terminal: self.terminal,
         }
     }
 }
 
-fn observe_sse_response_ids(decoder: &mut SseDecoder, data: &[u8]) -> Vec<String> {
-    let mut response_id = None;
-    for slice in data.chunks(SSE_DECODE_SLICE_BYTES) {
-        if let Ok(events) = decoder.push(slice)
-            && response_id.is_none()
-        {
-            response_id = events.into_iter().find_map(response_id_from_protocol_event);
-        }
-    }
-    response_id.into_iter().collect()
+struct HttpObservedBody {
+    ids: Vec<String>,
+    quota: Option<FailureClassification>,
+    terminal: Option<sse::TerminalStatus>,
 }
 
-fn response_ids_from_sse_finish(decoder: &mut SseDecoder) -> Vec<String> {
-    decoder
-        .finish()
-        .unwrap_or_default()
-        .into_iter()
-        .filter_map(response_id_from_protocol_event)
-        .collect()
+fn response_observer_for_content_type(
+    _content_type: Option<&hyper::header::HeaderValue>,
+) -> HttpResponseObserverKind {
+    HttpResponseObserverKind::Undecided(Vec::new())
 }
 
 impl Body for LeasedIncoming {
@@ -4192,29 +4345,65 @@ impl Body for LeasedIncoming {
                     self.idle
                         .as_mut()
                         .reset(tokio::time::Instant::now() + HTTP_RESPONSE_BODY_IDLE_TIMEOUT);
-                    let ids = frame
-                        .data_ref()
-                        .map(|data| self.observe_response_data(data))
-                        .unwrap_or_default();
-                    if ids.is_empty() {
+                    // Streaming chunks are only observed; all affinity binds
+                    // are deferred until the body terminal confirms a
+                    // non-quota outcome, so frames pass through without delay.
+                    if let Some(data) = frame.data_ref()
+                        && let Some(observer) = self.observer.as_mut()
+                    {
+                        observer.observe(data);
+                    }
+                    // A Content-Length terminal arrives as the final DATA frame
+                    // with `inner.is_end_stream() == true`; hyper's h1 dispatch
+                    // then calls `write_body_and_end` without polling again, and
+                    // trailers are terminal unconditionally. Finalizing only on
+                    // the subsequent `None` would therefore skip quota/affinity.
+                    // Finalize exactly once here, holding the terminal frame
+                    // until the binding completes.
+                    let terminal = frame.is_trailers() || self.inner.is_end_stream();
+                    if !terminal {
                         return Poll::Ready(Some(Ok(frame)));
                     }
-                    self.pending_frame = Some(frame);
-                    self.pending_binding = self.response_binding(ids);
+                    let Some(observer) = self.observer.take() else {
+                        return Poll::Ready(Some(Ok(frame)));
+                    };
+                    let observed = observer.finish();
+                    if let Some(binding) = self.finish_binding(observed) {
+                        self.pending_frame = Some(frame);
+                        self.pending_binding = Some(binding);
+                        continue;
+                    }
+                    return Poll::Ready(Some(Ok(frame)));
                 }
                 Poll::Ready(None) => {
-                    let ids = self.finish_response_observer();
-                    if ids.is_empty() {
+                    let Some(observer) = self.observer.take() else {
                         return Poll::Ready(None);
+                    };
+                    let observed = observer.finish();
+                    let binding = self.finish_binding(observed);
+                    if let Some(binding) = binding {
+                        self.pending_end = true;
+                        self.pending_binding = Some(binding);
+                        continue;
                     }
-                    self.pending_end = true;
-                    self.pending_binding = self.response_binding(ids);
+                    return Poll::Ready(None);
                 }
             }
         }
     }
 
     fn is_end_stream(&self) -> bool {
+        // Do not report end-of-stream while finalization is outstanding.
+        // Hyper's h1 dispatch ends the body without another poll once
+        // `is_end_stream()` is true after DATA (and always after trailers),
+        // so an unfinalized Content-Length terminal or a pending binding must
+        // keep this false to force the extra poll that drives finalization.
+        if self.pending_binding.is_some() || self.pending_frame.is_some() || self.pending_end {
+            return false;
+        }
+        if self.observer.is_some() && self.inner.is_end_stream() {
+            return false;
+        }
         self.inner.is_end_stream()
     }
 
@@ -4224,31 +4413,40 @@ impl Body for LeasedIncoming {
 }
 
 impl LeasedIncoming {
-    fn observe_response_data(&mut self, data: &[u8]) -> Vec<String> {
-        self.observer
-            .as_mut()
-            .map(|observer| observer.observe(data))
-            .unwrap_or_default()
-    }
-
-    fn finish_response_observer(&mut self) -> Vec<String> {
-        self.observer
-            .take()
-            .map(HttpResponseObserver::finish)
-            .unwrap_or_default()
-    }
-
-    fn response_binding(
+    fn finish_binding(
         &self,
-        ids: Vec<String>,
+        observed: HttpObservedBody,
     ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + Sync>>> {
         let account = self.account.clone()?;
+        // Without an observer there is no deferred work; immediate
+        // header-time binds (non-native paths) already ran.
         let router = self.router.clone();
+        let headers = self.response_headers.clone();
+        let deferred_affinity = self.deferred_affinity.clone();
         Some(Box::pin(async move {
-            for response_id in ids {
+            if let Some(quota) = observed.quota {
+                // Late body reclassification as quota: feed
+                // `quota_failure(headers)` preserving retry-after and bind
+                // nothing (no previous-response IDs, no deferred affinity,
+                // no continuation).
+                let _ = quota;
+                router.quota_failure(&account, &headers).await;
+                return;
+            }
+            // Bind deferred success affinity only behind a non-quota
+            // terminal. Normal `incomplete` (max_tokens/length/
+            // content_filter) keeps `terminal == Incomplete` with affinity
+            // intact; bodies without any terminal bind nothing.
+            if observed.terminal.is_none() {
+                return;
+            }
+            for response_id in observed.ids {
                 let key = router
                     .affinity
                     .key(&format!("previous-response:{response_id}"));
+                router.bind(key, &account).await;
+            }
+            for key in deferred_affinity {
                 router.bind(key, &account).await;
             }
         }))
@@ -4566,6 +4764,77 @@ async fn bind_response_id_from_event(app: &Arc<App>, event: &str, account: &str)
     app.router.bind(key, account).await;
 }
 
+fn bridge_safe_headers(headers: &hyper::HeaderMap) -> serde_json::Map<String, serde_json::Value> {
+    let mut safe_headers = serde_json::Map::new();
+    for name in [
+        "retry-after",
+        "x-request-id",
+        "openai-request-id",
+        "openai-model",
+        "x-models-etag",
+        "x-reasoning-included",
+        "x-codex-turn-state",
+        "x-codex-primary-used-percent",
+        "x-codex-secondary-used-percent",
+        "x-codex-primary-window-minutes",
+        "x-codex-secondary-window-minutes",
+    ] {
+        if let Some(value) = headers.get(name).and_then(|value| value.to_str().ok()) {
+            safe_headers.insert(name.to_owned(), serde_json::Value::String(value.to_owned()));
+        }
+    }
+    for (name, value) in headers {
+        let name = name.as_str();
+        if (name.starts_with("x-ratelimit-") || is_safe_codex_quota_header(name))
+            && let Ok(value) = value.to_str()
+        {
+            safe_headers.insert(name.to_owned(), serde_json::Value::String(value.to_owned()));
+        }
+    }
+    safe_headers
+}
+
+/// Enriches a quota-terminal payload forwarded on HTTP 200 with the upstream
+/// retry-after/quota headers so downstream observes the same cooldown signal
+/// that feeds `quota_failure(headers)`.
+fn enrich_bridge_quota_payload(
+    payload: &str,
+    value: &serde_json::Value,
+    headers: &hyper::HeaderMap,
+) -> String {
+    let Ok(mut rewritten) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return payload.to_owned();
+    };
+    let Some(object) = rewritten.as_object_mut() else {
+        return payload.to_owned();
+    };
+    // Preserve any existing headers object, filling only missing safe entries.
+    let mut merged = object
+        .get("headers")
+        .and_then(|headers| headers.as_object())
+        .cloned()
+        .unwrap_or_default();
+    for (name, header) in bridge_safe_headers(headers) {
+        merged.entry(name).or_insert(header);
+    }
+    object.insert("headers".to_owned(), serde_json::Value::Object(merged));
+    // Ensure a numeric status is present for quota terminals synthesized from
+    // SSE `type:error` or `response.failed/incomplete` without one.
+    if object.get("status").is_none_or(serde_json::Value::is_null) {
+        let numeric = value
+            .get("status")
+            .and_then(|status| status.as_u64())
+            .or_else(|| value.get("status_code").and_then(|status| status.as_u64()));
+        object.insert(
+            "status".to_owned(),
+            numeric
+                .map(serde_json::Value::from)
+                .unwrap_or_else(|| serde_json::Value::from(429)),
+        );
+    }
+    serde_json::to_string(&rewritten).unwrap_or_else(|_| payload.to_owned())
+}
+
 async fn pump_http_response_to_websocket(
     response: Response<ProxyBody>,
     outbound: &BridgeSender,
@@ -4621,6 +4890,22 @@ async fn pump_http_response_to_websocket(
             }
         };
         let parsed = serde_json::from_slice::<serde_json::Value>(&bytes).ok();
+        // Canonical body classification on the non-success Bridge path:
+        // a quota-shaped error body (numeric 429, quota code/message)
+        // feeds `quota_failure(headers)` even when the transport status is
+        // not itself 429/402.
+        if let Some(account) = selected_account.as_deref()
+            && let Some(body_value) = parsed.as_ref()
+        {
+            let body_classification = if body_value.get("type").is_some() {
+                classify_terminal_event(body_value)
+            } else {
+                classify_http_json_body(body_value)
+            };
+            if body_classification.kind == FailureKind::Quota {
+                app.router.quota_failure(account, &response_headers).await;
+            }
+        }
         let error = parsed
             .as_ref()
             .and_then(|value| value.get("error"))
@@ -4677,6 +4962,7 @@ async fn pump_http_response_to_websocket(
                 selected_account.as_deref(),
                 &mut capture,
                 continuation,
+                &response_headers,
             )
             .await?
             {
@@ -4721,6 +5007,7 @@ async fn pump_http_response_to_websocket(
                 selected_account.as_deref(),
                 &mut capture,
                 continuation,
+                &response_headers,
             )
             .await?
             {
@@ -4738,6 +5025,7 @@ async fn pump_http_response_to_websocket(
             selected_account.as_deref(),
             &mut capture,
             continuation,
+            &response_headers,
         )
         .await?
         {
@@ -4774,6 +5062,10 @@ async fn pump_http_response_to_websocket(
         let response = value.get("response").cloned().unwrap_or(value);
         responses_json_events(response)?
     };
+    // Canonical classification also runs on the synthesized non-streaming
+    // lifecycle: a quota-shaped `failed`/`incomplete` response feeds
+    // `quota_failure(headers)` with retry-after preserved, and suppresses
+    // continuation/affinity inside `send_protocol_events`.
     if !send_protocol_events(
         events,
         outbound,
@@ -4781,6 +5073,7 @@ async fn pump_http_response_to_websocket(
         selected_account.as_deref(),
         &mut capture,
         continuation,
+        &response_headers,
     )
     .await?
     {
@@ -4804,14 +5097,45 @@ async fn send_protocol_events(
     account: Option<&str>,
     capture: &mut HttpBridgeCapture,
     continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+    response_headers: &hyper::HeaderMap,
 ) -> Result<bool> {
     for event in events {
+        // Canonical terminal classification on the Bridge path: unwrap
+        // `event.error OR event.response.error` (plus narrow
+        // `incomplete_details` and numeric `status`/`status_code` fallbacks
+        // inside `classify_terminal_event`).
+        let classification = classify_terminal_event(&event.value);
+        let is_quota = classification.kind == FailureKind::Quota;
+        if is_quota {
+            if let Some(account) = account {
+                app.router.quota_failure(account, response_headers).await;
+            }
+            // Never bind previous-response affinity nor cache a continuation
+            // for quota terminals; the account is cooling down.
+            let previous_response_id = capture.response_id.clone();
+            capture.observe(&event.value);
+            capture.response_id = previous_response_id;
+            let payload =
+                enrich_bridge_quota_payload(&event.payload, &event.value, response_headers);
+            if !outbound.send(Message::Text(payload.into())).await {
+                capture.delivery_failed = true;
+                anyhow::bail!("downstream WebSocket writer stopped before event delivery")
+            }
+            capture.delivered_event = true;
+            if event.terminal.is_some() {
+                return Ok(true);
+            }
+            continue;
+        }
         capture.observe(&event.value);
-        if let Some(account) = account {
+        if let Some(account) = account
+            && terminal_permits_affinity(&classification)
+        {
             bind_response_id_from_event(app, &event.payload, account).await;
         }
         let terminal = event.terminal.is_some();
         if event.terminal == Some(sse::TerminalStatus::Completed)
+            && terminal_permits_affinity(&classification)
             && let Some(response_id) = capture.response_id.clone()
         {
             *continuation.lock().expect("bridge continuation") = Some(HttpBridgeContinuation {
@@ -4832,6 +5156,7 @@ async fn send_protocol_events(
     Ok(false)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_sse_data(
     decoder: &mut SseDecoder,
     data: &[u8],
@@ -4840,6 +5165,7 @@ async fn send_sse_data(
     account: Option<&str>,
     capture: &mut HttpBridgeCapture,
     continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+    response_headers: &hyper::HeaderMap,
 ) -> Result<bool> {
     for slice in data.chunks(SSE_DECODE_SLICE_BYTES) {
         if send_protocol_events(
@@ -4849,6 +5175,7 @@ async fn send_sse_data(
             account,
             capture,
             continuation,
+            response_headers,
         )
         .await?
         {
@@ -5246,71 +5573,631 @@ mod tests {
 
     #[test]
     fn response_observer_binds_json_without_content_type() {
-        let mut observer = response_observer_for_content_type(None);
-        assert!(matches!(observer, HttpResponseObserver::Undecided(_)));
-        assert!(
-            observer
-                .observe(br#"{"id":"resp_missing_type","object":"response"}"#)
-                .is_empty()
-        );
-        assert_eq!(observer.finish(), ["resp_missing_type"]);
+        let mut observer = HttpResponseObserver::new(response_observer_for_content_type(None));
+        assert!(matches!(
+            observer.kind,
+            HttpResponseObserverKind::Undecided(_)
+        ));
+        observer.observe(br#"{"id":"resp_missing_type","object":"response","status":"completed"}"#);
+        let observed = observer.finish();
+        assert_eq!(observed.ids, ["resp_missing_type"]);
+        assert!(observed.quota.is_none());
+        assert_eq!(observed.terminal, Some(sse::TerminalStatus::Completed));
     }
 
     #[test]
     fn response_observer_binds_json_with_generic_content_type() {
         let content_type = hyper::header::HeaderValue::from_static("application/octet-stream");
-        let mut observer = response_observer_for_content_type(Some(&content_type));
-        assert!(matches!(observer, HttpResponseObserver::Undecided(_)));
-        assert!(
-            observer
-                .observe(br#"{"response":{"id":"resp_generic_type"}}"#)
-                .is_empty()
-        );
-        assert_eq!(observer.finish(), ["resp_generic_type"]);
+        let mut observer =
+            HttpResponseObserver::new(response_observer_for_content_type(Some(&content_type)));
+        assert!(matches!(
+            observer.kind,
+            HttpResponseObserverKind::Undecided(_)
+        ));
+        observer.observe(br#"{"response":{"id":"resp_generic_type","status":"completed"}}"#);
+        let observed = observer.finish();
+        assert_eq!(observed.ids, ["resp_generic_type"]);
+        assert!(observed.quota.is_none());
     }
 
     #[test]
     fn response_observer_keeps_explicit_sse_streaming() {
         let content_type = hyper::header::HeaderValue::from_static("text/event-stream");
-        let mut observer = response_observer_for_content_type(Some(&content_type));
-        assert!(matches!(observer, HttpResponseObserver::Undecided(_)));
+        let mut observer =
+            HttpResponseObserver::new(response_observer_for_content_type(Some(&content_type)));
+        assert!(matches!(
+            observer.kind,
+            HttpResponseObserverKind::Undecided(_)
+        ));
         let event = br#"data: {"type":"response.created","response":{"id":"resp_stream"}}
 
 "#;
-        let ids = observer.observe(event);
-        assert_eq!(ids, ["resp_stream"]);
-        assert!(matches!(observer, HttpResponseObserver::Sse(_)));
-        assert!(observer.finish().is_empty());
+        // Streaming chunks are only buffered; binds happen at the body
+        // terminal, so no IDs are reported synchronously.
+        observer.observe(event);
+        assert!(matches!(observer.kind, HttpResponseObserverKind::Sse(_)));
+        // Feed the terminal to complete the lifecycle.
+        observer.observe(
+            br#"data: {"type":"response.completed","response":{"id":"resp_stream","status":"completed"}}
+
+"#,
+        );
+        let observed = observer.finish();
+        assert_eq!(observed.ids, ["resp_stream"]);
+        assert_eq!(observed.terminal, Some(sse::TerminalStatus::Completed));
+        assert!(observed.quota.is_none());
 
         // A mislabeled stream takes the dual path, but still discovers the ID
         // from the current frame instead of waiting for EOF/JSON parsing.
         let generic = hyper::header::HeaderValue::from_static("application/octet-stream");
-        let mut observer = response_observer_for_content_type(Some(&generic));
-        let ids = observer.observe(event);
-        assert_eq!(ids, ["resp_stream"]);
-        assert!(observer.finish().is_empty());
+        let mut observer =
+            HttpResponseObserver::new(response_observer_for_content_type(Some(&generic)));
+        observer.observe(event);
+        observer.observe(
+            br#"data: {"type":"response.completed","response":{"id":"resp_stream","status":"completed"}}
+
+"#,
+        );
+        let observed = observer.finish();
+        assert_eq!(observed.ids, ["resp_stream"]);
 
         // Content-Type cannot override a JSON wire body.
         let mislabeled = hyper::header::HeaderValue::from_static("text/event-stream");
-        let mut observer = response_observer_for_content_type(Some(&mislabeled));
-        assert!(
-            observer
-                .observe(b"  {\"id\":\"resp_mislabeled_json\",\"object\":\"response\"}")
-                .is_empty()
+        let mut observer =
+            HttpResponseObserver::new(response_observer_for_content_type(Some(&mislabeled)));
+        observer.observe(
+            b"  {\"id\":\"resp_mislabeled_json\",\"object\":\"response\",\"status\":\"completed\"}",
         );
-        assert_eq!(observer.finish(), ["resp_mislabeled_json"]);
+        let observed = observer.finish();
+        assert_eq!(observed.ids, ["resp_mislabeled_json"]);
     }
 
     #[test]
     fn response_observer_ignores_malformed_and_non_response_bodies() {
-        let mut malformed = response_observer_for_content_type(None);
-        assert!(malformed.observe(br#"{"id":"resp_broken""#).is_empty());
-        assert!(malformed.finish().is_empty());
+        let mut malformed = HttpResponseObserver::new(response_observer_for_content_type(None));
+        malformed.observe(br#"{"id":"resp_broken""#);
+        let observed = malformed.finish();
+        assert!(observed.ids.is_empty());
+        assert!(observed.quota.is_none());
 
         let generic = hyper::header::HeaderValue::from_static("text/plain");
-        let mut unrelated = response_observer_for_content_type(Some(&generic));
-        assert!(unrelated.observe(br#"{"ok":true,"items":[]}"#).is_empty());
-        assert!(unrelated.finish().is_empty());
+        let mut unrelated =
+            HttpResponseObserver::new(response_observer_for_content_type(Some(&generic)));
+        unrelated.observe(br#"{"ok":true,"items":[]}"#);
+        let observed = unrelated.finish();
+        assert!(observed.ids.is_empty());
+        assert!(observed.quota.is_none());
+    }
+
+    #[test]
+    fn http_observer_suppresses_affinity_for_quota_shaped_incomplete() {
+        // Task #2 (b): 200 + `response.incomplete` with quota phrasing in
+        // both `response.error.message` and `incomplete_details.reason`
+        // classifies Quota with no affinity bind.
+        for signal in [
+            serde_json::json!({
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_quota",
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": "The usage limit has been reached"},
+                    "error": {"message": "The usage limit has been reached"}
+                }
+            }),
+            serde_json::json!({
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_quota",
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": "usage_limit_reached"},
+                    "error": {"code": "usage_limit_reached"}
+                }
+            }),
+        ] {
+            let classification = classify_terminal_event(&signal);
+            assert_eq!(classification.kind, FailureKind::Quota);
+            assert!(!terminal_permits_affinity(&classification));
+        }
+
+        // Same envelope through the HTTP observer: IDs are dropped and quota
+        // is recorded for `quota_failure(headers)`.
+        let mut observer = HttpResponseObserver::new(response_observer_for_content_type(None));
+        let body = serde_json::json!({
+            "id": "resp_quota",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "The usage limit has been reached"},
+            "error": {"message": "The usage limit has been reached"}
+        });
+        observer.observe(&serde_json::to_vec(&body).unwrap());
+        let observed = observer.finish();
+        assert!(observed.ids.is_empty());
+        assert_eq!(
+            observed.quota.as_ref().map(|quota| &quota.kind),
+            Some(&FailureKind::Quota)
+        );
+
+        // SSE `type:error` on HTTP 200 with quota strings is a terminal
+        // quota failure (Task #2 (d)).
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(
+                b"data: {\"type\":\"error\",\"status_code\":429,\"error\":{\"code\":\"\",\"type\":\"\",\"message\":\"\"}}\n\n",
+            )
+            .unwrap();
+        assert_eq!(events[0].terminal, Some(sse::TerminalStatus::Failed));
+        let classification = classify_terminal_event(&events[0].value);
+        assert_eq!(classification.kind, FailureKind::Quota);
+
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(
+                b"data: {\"type\":\"error\",\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit exceeded\"}}\n\n",
+            )
+            .unwrap();
+        assert_eq!(events[0].terminal, Some(sse::TerminalStatus::Failed));
+        assert_eq!(
+            classify_terminal_event(&events[0].value).kind,
+            FailureKind::Quota
+        );
+    }
+
+    #[tokio::test]
+    async fn leased_content_length_quota_terminal_cools_down_without_second_poll() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_app, _listener, router, _stats) = direct_test_app(dir.path());
+        let pool = PoolConfig {
+            members: vec!["a".into(), "b".into()],
+            preferred: None,
+        };
+        let selection = router
+            .select_exact(&pool, "a")
+            .await
+            .expect("select account a");
+        let payload = Bytes::from_static(br#"{"id":"resp_quota","status":"incomplete","incomplete_details":{"reason":"The usage limit has been reached"},"error":{"message":"The usage limit has been reached"}}"#);
+
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = upstream.local_addr().unwrap();
+        let payload_clone = payload.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let body = payload_clone.clone();
+                tokio::spawn(async move {
+                    let svc = service_fn(move |_req: Request<Incoming>| {
+                        let b = body.clone();
+                        async move {
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "application/json")
+                                    .header("retry-after", "2")
+                                    .body(Full::new(b))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), svc)
+                        .await;
+                });
+            }
+        });
+
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let upstream_resp = client
+            .request(
+                Request::builder()
+                    .uri(format!("http://{addr}/v1/responses"))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let deferred = vec![router.affinity.key("thread:p1-quota")];
+        let leased = map_http_response_leased(
+            upstream_resp,
+            router.clone(),
+            &selection,
+            true,
+            deferred.clone(),
+        );
+        let mut body = leased.into_body();
+        // Mimic hyper h1 dispatch.rs: after a DATA frame, hyper checks
+        // `body.is_end_stream()` and, when true, calls `write_body_and_end`
+        // without polling again. A Content-Length terminal must therefore be
+        // finalized before that point.
+        let mut bytes = Vec::new();
+        loop {
+            let frame_opt = body.frame().await;
+            let Some(frame) = frame_opt else {
+                break;
+            };
+            let frame = frame.unwrap();
+            if let Ok(data) = frame.into_data() {
+                bytes.extend_from_slice(&data);
+            }
+            if body.is_end_stream() {
+                break;
+            }
+        }
+        assert_eq!(bytes, payload.to_vec());
+        assert!(
+            router.select_exact(&pool, "a").await.is_none(),
+            "quota-terminal Content-Length body must cool down account a"
+        );
+        for key in &deferred {
+            assert!(
+                router.affinity.get(key).await.is_none(),
+                "quota terminal must not bind deferred affinity"
+            );
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn leased_content_length_completed_binds_deferred_affinity() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_app, _listener, router, _stats) = direct_test_app(dir.path());
+        let pool = PoolConfig {
+            members: vec!["a".into(), "b".into()],
+            preferred: None,
+        };
+        let selection = router
+            .select_exact(&pool, "a")
+            .await
+            .expect("select account a");
+        let payload =
+            Bytes::from_static(br#"{"id":"resp_ok","object":"response","status":"completed"}"#);
+
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = upstream.local_addr().unwrap();
+        let payload_clone = payload.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let body = payload_clone.clone();
+                tokio::spawn(async move {
+                    let svc = service_fn(move |_req: Request<Incoming>| {
+                        let b = body.clone();
+                        async move {
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "application/json")
+                                    .body(Full::new(b))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), svc)
+                        .await;
+                });
+            }
+        });
+
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let upstream_resp = client
+            .request(
+                Request::builder()
+                    .uri(format!("http://{addr}/v1/responses"))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let deferred_key = router.affinity.key("thread:p1-success");
+        let leased = map_http_response_leased(
+            upstream_resp,
+            router.clone(),
+            &selection,
+            true,
+            vec![deferred_key.clone()],
+        );
+        let mut body = leased.into_body();
+        let mut bytes = Vec::new();
+        loop {
+            let frame_opt = body.frame().await;
+            let Some(frame) = frame_opt else {
+                break;
+            };
+            let frame = frame.unwrap();
+            if let Ok(data) = frame.into_data() {
+                bytes.extend_from_slice(&data);
+            }
+            if body.is_end_stream() {
+                break;
+            }
+        }
+        assert_eq!(bytes, payload.to_vec());
+        // Full drain (hyper may still poll for None after is_end_stream when
+        // finalization held the terminal frame); must end cleanly.
+        while body.frame().await.is_some() {}
+        assert!(body.is_end_stream());
+        assert!(
+            router.select_exact(&pool, "a").await.is_some(),
+            "completed body must not cool down the account"
+        );
+        assert_eq!(
+            router
+                .affinity
+                .get(&deferred_key)
+                .await
+                .map(|binding| binding.account_id),
+            Some("a".to_owned()),
+            "completed body must bind deferred affinity"
+        );
+        let previous_key = router.affinity.key("previous-response:resp_ok");
+        assert_eq!(
+            router
+                .affinity
+                .get(&previous_key)
+                .await
+                .map(|binding| binding.account_id),
+            Some("a".to_owned()),
+            "completed body must bind previous-response id"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn leased_chunked_sse_multi_frame_still_finalizes_on_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_app, _listener, router, _stats) = direct_test_app(dir.path());
+        let pool = PoolConfig {
+            members: vec!["a".into(), "b".into()],
+            preferred: None,
+        };
+        let selection = router
+            .select_exact(&pool, "a")
+            .await
+            .expect("select account a");
+        let chunk1 = Bytes::from_static(
+            b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_chunked\"}}\n\n",
+        );
+        let chunk2 = Bytes::from_static(
+            b"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_chunked\",\"status\":\"completed\"}}\n\n",
+        );
+
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = upstream.local_addr().unwrap();
+        let (c1, c2) = (chunk1.clone(), chunk2.clone());
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let (c1, c2) = (c1.clone(), c2.clone());
+                tokio::spawn(async move {
+                    let svc = service_fn(move |_req: Request<Incoming>| {
+                        let (c1, c2) = (c1.clone(), c2.clone());
+                        async move {
+                            let stream = futures_util::stream::iter(vec![
+                                Ok::<_, std::io::Error>(Frame::data(c1)),
+                                Ok::<_, std::io::Error>(Frame::data(c2)),
+                            ]);
+                            let body = BodyExt::boxed(http_body_util::StreamBody::new(stream));
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "text/event-stream")
+                                    .body(body)
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), svc)
+                        .await;
+                });
+            }
+        });
+
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let upstream_resp = client
+            .request(
+                Request::builder()
+                    .uri(format!("http://{addr}/v1/responses"))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let deferred_key = router.affinity.key("thread:p1-chunked");
+        let leased = map_http_response_leased(
+            upstream_resp,
+            router.clone(),
+            &selection,
+            true,
+            vec![deferred_key.clone()],
+        );
+        let mut body = leased.into_body();
+        // Chunked terminals arrive as `None` (inner never reports end after
+        // DATA), so hyper polls until `None`; collect everything.
+        let mut collected = Vec::new();
+        while let Some(frame) = body.frame().await {
+            let frame = frame.expect("chunked frame");
+            if let Ok(data) = frame.into_data() {
+                collected.extend_from_slice(&data);
+            }
+        }
+        assert!(collected.starts_with(&chunk1[..]));
+        assert!(collected.ends_with(&chunk2[..]));
+        // Chunked `Incoming` never reports `is_end_stream() == true`
+        // (`DecodedLength::CHUNKED != ZERO` even after `None`); end is the
+        // `None` itself, which must have driven affinity finalization.
+        assert!(body.frame().await.is_none());
+        assert!(
+            router.select_exact(&pool, "a").await.is_some(),
+            "chunked success must not cool down the account"
+        );
+        assert_eq!(
+            router
+                .affinity
+                .get(&deferred_key)
+                .await
+                .map(|binding| binding.account_id),
+            Some("a".to_owned()),
+            "chunked SSE terminal must bind deferred affinity via None path"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn leased_terminal_finalizes_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_app, _listener, router, _stats) = direct_test_app(dir.path());
+        let pool = PoolConfig {
+            members: vec!["a".into(), "b".into()],
+            preferred: None,
+        };
+        let selection = router
+            .select_exact(&pool, "a")
+            .await
+            .expect("select account a");
+        let payload = Bytes::from_static(br#"{"id":"resp_quota","status":"incomplete","incomplete_details":{"reason":"usage_limit_reached"},"error":{"code":"usage_limit_reached","message":"usage limit reached"}}"#);
+
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = upstream.local_addr().unwrap();
+        let payload_clone = payload.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let body = payload_clone.clone();
+                tokio::spawn(async move {
+                    let svc = service_fn(move |_req: Request<Incoming>| {
+                        let b = body.clone();
+                        async move {
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "application/json")
+                                    .header("retry-after", "2")
+                                    .body(Full::new(b))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), svc)
+                        .await;
+                });
+            }
+        });
+
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let upstream_resp = client
+            .request(
+                Request::builder()
+                    .uri(format!("http://{addr}/v1/responses"))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let deferred_key = router.affinity.key("thread:p1-once");
+        let leased = map_http_response_leased(
+            upstream_resp,
+            router.clone(),
+            &selection,
+            true,
+            vec![deferred_key.clone()],
+        );
+        let mut body = leased.into_body();
+        // Drive through data-end, trailers (none expected), and repeated
+        // `None` polls: finalization across all three paths must run once.
+        let mut frames = 0usize;
+        while let Some(frame) = body.frame().await {
+            frames += 1;
+            let _ = frame.unwrap();
+            if frames > 4 {
+                panic!("terminal body must end promptly");
+            }
+        }
+        assert_eq!(
+            frames, 1,
+            "single-frame body must yield exactly one data frame"
+        );
+        assert!(body.is_end_stream());
+        // Repeated end polls stay ended without side effects.
+        assert!(body.frame().await.is_none());
+        assert!(body.frame().await.is_none());
+        assert!(body.is_end_stream());
+        assert!(
+            router.select_exact(&pool, "a").await.is_none(),
+            "quota cooldown must persist after repeated end polls (exactly-once finalize)"
+        );
+        assert!(
+            router.affinity.get(&deferred_key).await.is_none(),
+            "quota terminal must never bind affinity, even across repeated ends"
+        );
+        server.abort();
+    }
+
+    #[test]
+    fn normal_incomplete_and_soft_failures_never_report_quota() {
+        // Task #2 (c): normal `incomplete` (max_tokens) stays
+        // success/Incomplete with affinity intact.
+        let normal = serde_json::json!({
+            "type": "response.incomplete",
+            "response": {
+                "id": "resp_normal",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"}
+            }
+        });
+        let classification = classify_terminal_event(&normal);
+        assert_ne!(classification.kind, FailureKind::Quota);
+        assert!(terminal_permits_affinity(&classification));
+
+        // Task #2 (e): 502/server_error stays soft, never quota.
+        let server_error = serde_json::json!({
+            "type": "response.failed",
+            "status": 502,
+            "response": {
+                "id": "resp_soft",
+                "status": "failed",
+                "error": {"code": "server_error", "message": "upstream unavailable"}
+            }
+        });
+        let classification = classify_terminal_event(&server_error);
+        assert_ne!(classification.kind, FailureKind::Quota);
+        assert!(terminal_permits_affinity(&classification));
+
+        // Bare `limit|usage|quota|overloaded` substrings never match.
+        for message in [
+            "limit reached",
+            "usage stats",
+            "quota info",
+            "overloaded",
+            "content_filter",
+            "length",
+        ] {
+            let event = serde_json::json!({
+                "type": "response.incomplete",
+                "response": {
+                    "id": "resp_bare",
+                    "status": "incomplete",
+                    "incomplete_details": {"reason": message}
+                }
+            });
+            assert_ne!(
+                classify_terminal_event(&event).kind,
+                FailureKind::Quota,
+                "bare substring must not match: {message}"
+            );
+        }
+
+        // Body numeric 200 never acts as a failure signal.
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "status": 200,
+            "status_code": 200,
+            "response": {"id": "resp_ok", "status": "completed"}
+        });
+        assert_ne!(classify_terminal_event(&completed).kind, FailureKind::Quota);
     }
 
     #[test]

--- a/src/proxy/sse.rs
+++ b/src/proxy/sse.rs
@@ -25,6 +25,10 @@ impl TerminalStatus {
             "response.completed" => Some(Self::Completed),
             "response.failed" => Some(Self::Failed),
             "response.incomplete" => Some(Self::Incomplete),
+            // Align with the Direct WS `terminal_kind` mapping (`error ->
+            // Failed`) so `HTTP 200 + SSE type:error` is a terminal failure
+            // rather than a forwarded non-terminal followed by PrematureEof.
+            "error" => Some(Self::Failed),
             _ => None,
         }
     }
@@ -577,6 +581,26 @@ mod tests {
                 .map(|event| event.event_type.as_str())
                 .collect::<Vec<_>>(),
             ["response.created", "response.completed"]
+        );
+    }
+
+    #[test]
+    fn type_error_is_terminal_failed_for_http_200_quota() {
+        // Task #2 (d): `SSE type:error` on HTTP 200 is a terminal failure
+        // (aligned with the WS `error -> Failed` mapping), so a quota-shaped
+        // error does not fall through to PrematureEof/generic close.
+        let mut decoder = SseDecoder::default();
+        let events = decoder
+            .push(b"data: {\"type\":\"error\",\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit exceeded\"}}\n\n")
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, "error");
+        assert_eq!(events[0].terminal, Some(TerminalStatus::Failed));
+        assert!(decoder.is_terminal());
+        assert_eq!(
+            decoder.finish().unwrap().len(),
+            0,
+            "trailing input after a terminal error is discarded"
         );
     }
 }

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -442,7 +442,7 @@ impl ProtocolState {
         if let Some(id) = response_id.as_deref() {
             validate_identifier(id, self.limits.max_identifier_bytes, "response_id")?;
         }
-        let failure = classify_failure(event);
+        let failure = classify_terminal_event(event);
         let terminal = terminal_kind(event_type.as_deref());
 
         let mut turn_ids = if event_type.as_deref() == Some("response.created") {
@@ -899,10 +899,129 @@ pub fn fresh_replay_without_previous_response(
     Ok(fresh)
 }
 
+fn numeric_status_value(value: &Value) -> Option<u16> {
+    if let Some(number) = value.as_u64()
+        && let Ok(status) = u16::try_from(number)
+    {
+        return Some(status);
+    }
+    if let Some(number) = value.as_i64()
+        && let Ok(status) = u16::try_from(number)
+    {
+        return Some(status);
+    }
+    value
+        .as_str()
+        .filter(|text| !text.is_empty())
+        .and_then(|text| text.trim().parse::<u16>().ok())
+}
+
+fn envelope_numeric_status(
+    event: &Value,
+    error: Option<&serde_json::Map<String, Value>>,
+) -> Option<u16> {
+    for key in ["status", "status_code"] {
+        if let Some(status) = event.get(key).and_then(numeric_status_value) {
+            return Some(status);
+        }
+    }
+    if let Some(error) = error {
+        for key in ["status", "status_code"] {
+            if let Some(status) = error.get(key).and_then(numeric_status_value) {
+                return Some(status);
+            }
+        }
+    }
+    None
+}
+
+fn is_quota_code(code: &str) -> bool {
+    matches!(
+        code,
+        "rate_limit_exceeded"
+            | "usage_limit_reached"
+            | "insufficient_quota"
+            | "quota_exceeded"
+            | "usage_not_included"
+            | "overloaded_error"
+            | "server_is_overloaded"
+    )
+}
+
+fn is_quota_message(message: &str) -> bool {
+    message.contains("usage limit")
+        || message.contains("insufficient quota")
+        || message.contains("server is overloaded")
+}
+
+/// Narrow quota signals from `response.incomplete_details` and
+/// `response.error.message` for quota-shaped `incomplete`/`failed` terminals.
+/// Only exact codes and the existing narrow substrings count; bare
+/// `limit|usage|quota|overloaded` substrings never match.
+fn incomplete_quota_signal(event: &Value) -> (Option<String>, Option<String>) {
+    let event_type = event.get("type").and_then(Value::as_str);
+    if !matches!(
+        event_type,
+        Some("response.incomplete" | "response.failed" | "error")
+    ) {
+        return (None, None);
+    }
+    let response = match event.get("response") {
+        Some(response) => response,
+        None => return (None, None),
+    };
+    let mut matched_code: Option<String> = None;
+    let mut matched_message: Option<String> = None;
+    let mut check_text = |text: &str| {
+        let normalized = text.to_ascii_lowercase();
+        if matched_code.is_none() && is_quota_code(normalized.as_str()) {
+            matched_code = Some(bounded_owned(text, MAX_CLASSIFIED_CODE_BYTES));
+        }
+        if is_quota_message(normalized.as_str()) {
+            matched_message
+                .get_or_insert_with(|| bounded_owned(text, MAX_CLASSIFIED_MESSAGE_BYTES));
+        }
+    };
+    if let Some(details) = response.get("incomplete_details") {
+        for key in ["reason", "details"] {
+            if let Some(text) = details.get(key).and_then(Value::as_str)
+                && !text.is_empty()
+            {
+                check_text(text);
+            }
+        }
+        // Some upstreams put the reason directly as a string.
+        if let Some(text) = details.as_str()
+            && !text.is_empty()
+        {
+            check_text(text);
+        }
+    }
+    // `response.error.message` may differ from the primary `event.error`
+    // object when the envelope carries both.
+    if let Some(text) = response
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        && !text.is_empty()
+    {
+        check_text(text);
+    }
+    if let Some(text) = response
+        .get("error")
+        .and_then(|error| error.get("code").or_else(|| error.get("type")))
+        .and_then(Value::as_str)
+        && !text.is_empty()
+    {
+        check_text(text);
+    }
+    (matched_code, matched_message)
+}
+
 pub fn classify_failure(event: &Value) -> FailureClassification {
     let response_id =
         response_id(event).map(|value| bounded_owned(value, DEFAULT_MAX_IDENTIFIER_BYTES));
-    let Some(error) = event
+    let error = event
         .get("error")
         .or_else(|| {
             event
@@ -914,13 +1033,10 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
             (event.get("type").and_then(Value::as_str) == Some("error"))
                 .then(|| event.as_object())
                 .flatten()
-        })
-    else {
-        return FailureClassification::none();
-    };
+        });
     let nonempty_string = |key| {
         error
-            .get(key)
+            .and_then(|error| error.get(key))
             .and_then(Value::as_str)
             .filter(|value| !value.is_empty())
     };
@@ -932,12 +1048,12 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
         .map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES).to_ascii_lowercase())
         .unwrap_or_default();
     let param = error
-        .get("param")
+        .and_then(|error| error.get("param"))
         .and_then(Value::as_str)
         .map(|value| bounded_owned(value, MAX_CLASSIFIED_CODE_BYTES).to_ascii_lowercase())
         .unwrap_or_default();
     let message = error
-        .get("message")
+        .and_then(|error| error.get("message"))
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
         .map(|value| bounded_owned(value, MAX_CLASSIFIED_MESSAGE_BYTES));
@@ -957,19 +1073,7 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
                 stale_message,
                 "invalid `previous_response_id`" | "invalid previous_response_id"
             ));
-    let quota = [
-        "rate_limit_exceeded",
-        "usage_limit_reached",
-        "insufficient_quota",
-        "usage_not_included",
-        "quota_exceeded",
-        "overloaded_error",
-        "server_is_overloaded",
-    ]
-    .contains(&normalized_code)
-        || normalized_message.contains("usage limit")
-        || normalized_message.contains("insufficient quota")
-        || normalized_message.contains("server is overloaded");
+    let mut quota = is_quota_code(normalized_code) || is_quota_message(normalized_message.as_str());
     let authentication = [
         "invalid_api_key",
         "authentication_error",
@@ -998,6 +1102,41 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
     ]
     .contains(&normalized_code);
 
+    // Quota-shaped `incomplete`/`failed` terminals carry the signal in
+    // `response.incomplete_details` or `response.error.message` rather than
+    // the primary error object.
+    let (incomplete_code, incomplete_message) = incomplete_quota_signal(event);
+    if incomplete_code.is_some() || incomplete_message.is_some() {
+        quota = true;
+    }
+
+    // Numeric fallback: envelope or nested error `status`/`status_code` as
+    // numbers or numeric strings. Only 429/402 act as failure signals; a body
+    // numeric 200 never overrides transport status. 402 counts as quota only
+    // alongside a quota-shaped string signal to avoid billing confusion.
+    // 401/403 stay authentication.
+    let numeric = envelope_numeric_status(event, error);
+    let numeric_quota = match numeric {
+        Some(429) => true,
+        Some(402) => quota || incomplete_code.is_some() || incomplete_message.is_some(),
+        _ => false,
+    };
+    if numeric_quota {
+        quota = true;
+    }
+    let numeric_auth = matches!(numeric, Some(401 | 403));
+    let authentication = authentication || numeric_auth;
+
+    // Without any error object, numeric signal, or narrow incomplete signal
+    // there is nothing to classify.
+    if error.is_none()
+        && numeric.is_none()
+        && incomplete_code.is_none()
+        && incomplete_message.is_none()
+    {
+        return FailureClassification::none();
+    }
+
     let kind = if previous_response_not_found {
         FailureKind::PreviousResponseNotFound
     } else if authentication {
@@ -1011,6 +1150,11 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
     } else {
         FailureKind::Other
     };
+    // Prefer the primary error code/message; fall back to the narrow
+    // incomplete signal so quota terminals without an error object still
+    // carry evidence.
+    let code = code.or_else(|| incomplete_code.map(|value| value.to_ascii_lowercase()));
+    let message = message.or(incomplete_message);
     FailureClassification {
         kind,
         code,
@@ -1026,6 +1170,90 @@ pub fn response_id(event: &Value) -> Option<&str> {
         .or_else(|| event.get("response_id"))
         .and_then(Value::as_str)
         .filter(|value| !value.is_empty())
+}
+
+/// Canonical terminal classification shared by Direct, Bridge, and HTTP
+/// lanes. Only terminal event types (`response.failed`,
+/// `response.incomplete`, `error`) can yield a quota failure; a quota-shaped
+/// signal on any other terminal (completed/cancelled/non-terminal) is
+/// downgraded to `Other` so normal `incomplete` (max_tokens/length/
+/// content_filter) and success affinity stay intact.
+pub fn classify_terminal_event(event: &Value) -> FailureClassification {
+    let terminal = terminal_kind(event.get("type").and_then(Value::as_str));
+    let classification = classify_failure(event);
+    match classification.kind {
+        FailureKind::Quota => match terminal {
+            Some(TerminalKind::Failed) | Some(TerminalKind::Incomplete) => classification,
+            _ => FailureClassification {
+                kind: FailureKind::Other,
+                code: classification.code,
+                message: classification.message,
+                response_id: classification.response_id,
+            },
+        },
+        _ => classification,
+    }
+}
+
+/// Whether a terminal classification permits success-affinity binding and
+/// continuation caching. Quota terminals must never bind previous-response
+/// IDs nor cache continuations.
+pub fn terminal_permits_affinity(classification: &FailureClassification) -> bool {
+    !matches!(classification.kind, FailureKind::Quota)
+}
+
+/// Classifies a non-streaming Responses JSON body (`value.response ?? value`).
+/// Event-shaped bodies classify directly; response-shaped bodies synthesize
+/// the terminal implied by `response.status` before classification so
+/// `incomplete_details`/`error` signals are evaluated in terminal context.
+/// A body numeric 200 never counts as success here; only the terminal
+/// classification matters to the caller.
+pub fn classify_http_json_body(value: &Value) -> FailureClassification {
+    if value.get("type").and_then(Value::as_str).is_some() {
+        return classify_terminal_event(value);
+    }
+    let response = value.get("response").unwrap_or(value);
+    let status = response
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let terminal_type = match status.as_str() {
+        "failed" => "response.failed",
+        "incomplete" => "response.incomplete",
+        "completed" => "response.completed",
+        "cancelled" => "response.cancelled",
+        _ => {
+            // No explicit terminal status. If the body carries an error
+            // object with quota/auth signals, evaluate it as a failure
+            // terminal; otherwise there is nothing to classify.
+            if response.get("error").is_some_and(|error| error.is_object())
+                || value.get("error").is_some_and(|error| error.is_object())
+            {
+                let synthetic = serde_json::json!({
+                    "type": "error",
+                    "status": value.get("status").cloned()
+                        .or_else(|| value.get("status_code").cloned())
+                        .unwrap_or(serde_json::Value::Null),
+                    "status_code": value.get("status_code").cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                    "error": value.get("error").cloned()
+                        .or_else(|| response.get("error").cloned())
+                        .unwrap_or(serde_json::Value::Null),
+                    "response": response.clone(),
+                });
+                return classify_terminal_event(&synthetic);
+            }
+            return FailureClassification::none();
+        }
+    };
+    let synthetic = serde_json::json!({
+        "type": terminal_type,
+        "status": value.get("status").cloned().unwrap_or(serde_json::Value::Null),
+        "status_code": value.get("status_code").cloned().unwrap_or(serde_json::Value::Null),
+        "response": response.clone(),
+    });
+    classify_terminal_event(&synthetic)
 }
 
 pub fn finite_sequence_number(event: &Value) -> Option<SequenceNumber> {
@@ -1823,6 +2051,140 @@ mod tests {
                 FailureKind::Other
             );
         }
+    }
+
+    #[test]
+    fn numeric_only_error_with_empty_strings_is_quota() {
+        // Task #2 (a): `{"type":"error","status_code":429}` with empty string
+        // fields must classify Quota via the numeric fallback.
+        for event in [
+            json!({"type":"error","status_code":429,"error":{"code":"","type":"","message":""}}),
+            json!({"type":"error","status_code":429}),
+            json!({"type":"error","status":429,"error":{"code":"","type":"","message":""}}),
+            json!({"type":"error","error":{"code":"","type":"","message":"","status_code":429}}),
+            json!({"type":"error","status_code":"429","error":{"code":"","message":""}}),
+        ] {
+            assert_eq!(classify_failure(&event).kind, FailureKind::Quota);
+            assert_eq!(classify_terminal_event(&event).kind, FailureKind::Quota);
+        }
+        // 402 needs quota-shaped string context to avoid billing confusion.
+        assert_eq!(
+            classify_failure(&json!({"type":"error","status_code":402})).kind,
+            FailureKind::Other
+        );
+        assert_eq!(
+            classify_failure(&json!({
+                "type":"error","status_code":402,
+                "error":{"code":"usage_limit_reached"}
+            }))
+            .kind,
+            FailureKind::Quota
+        );
+        // 401/403 stay authentication; 200 and 5xx never become quota.
+        assert!(matches!(
+            classify_failure(&json!({"type":"error","status_code":401})).kind,
+            FailureKind::Authentication { .. }
+        ));
+        assert!(matches!(
+            classify_failure(&json!({"type":"error","status_code":403})).kind,
+            FailureKind::Authentication { .. }
+        ));
+        assert_ne!(
+            classify_failure(&json!({"type":"error","status_code":200})).kind,
+            FailureKind::Quota
+        );
+        assert_ne!(
+            classify_failure(&json!({"type":"error","status_code":502})).kind,
+            FailureKind::Quota
+        );
+    }
+
+    #[test]
+    fn quota_shaped_incomplete_requires_narrow_signal_and_terminal() {
+        // Task #2 (b): quota phrasing in `response.error.message` and in
+        // `incomplete_details.reason` classifies Quota with no affinity bind.
+        for event in [
+            json!({
+                "type":"response.incomplete",
+                "response":{
+                    "id":"resp_q","status":"incomplete",
+                    "error":{"message":"The usage limit has been reached"}
+                }
+            }),
+            json!({
+                "type":"response.incomplete",
+                "response":{
+                    "id":"resp_q","status":"incomplete",
+                    "incomplete_details":{"reason":"The usage limit has been reached"}
+                }
+            }),
+            json!({
+                "type":"response.failed",
+                "response":{
+                    "id":"resp_q","status":"failed",
+                    "incomplete_details":{"reason":"usage_limit_reached"}
+                }
+            }),
+        ] {
+            let classification = classify_terminal_event(&event);
+            assert_eq!(classification.kind, FailureKind::Quota);
+            assert!(!terminal_permits_affinity(&classification));
+        }
+        // Task #2 (c): normal `incomplete` stays non-quota with affinity.
+        for reason in [
+            "max_output_tokens",
+            "max_tokens",
+            "length",
+            "content_filter",
+        ] {
+            let event = json!({
+                "type":"response.incomplete",
+                "response":{
+                    "id":"resp_n","status":"incomplete",
+                    "incomplete_details":{"reason":reason}
+                }
+            });
+            let classification = classify_terminal_event(&event);
+            assert_ne!(classification.kind, FailureKind::Quota);
+            assert!(terminal_permits_affinity(&classification));
+        }
+        // Quota signal on a non-terminal (completed) downgrades to Other.
+        let completed = json!({
+            "type":"response.completed",
+            "response":{
+                "id":"resp_c","status":"completed",
+                "error":{"code":"rate_limit_exceeded"}
+            }
+        });
+        assert_ne!(classify_terminal_event(&completed).kind, FailureKind::Quota);
+        // Task #2 (e): 502/server_error stays soft, never quota.
+        let soft = json!({
+            "type":"response.failed",
+            "status":502,
+            "response":{
+                "id":"resp_s","status":"failed",
+                "error":{"code":"server_error","message":"bad gateway"}
+            }
+        });
+        let classification = classify_terminal_event(&soft);
+        assert_ne!(classification.kind, FailureKind::Quota);
+        assert!(terminal_permits_affinity(&classification));
+        // Non-streaming JSON (`value.response ?? value`) with quota-shaped
+        // incomplete classifies Quota.
+        let body = json!({
+            "id":"resp_q","status":"incomplete",
+            "incomplete_details":{"reason":"insufficient_quota"},
+            "error":{"message":"insufficient quota"}
+        });
+        assert_eq!(classify_http_json_body(&body).kind, FailureKind::Quota);
+        let normal_body = json!({
+            "id":"resp_n","status":"incomplete",
+            "incomplete_details":{"reason":"max_output_tokens"}
+        });
+        assert_ne!(
+            classify_http_json_body(&normal_body).kind,
+            FailureKind::Quota
+        );
     }
 
     #[test]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>