### PR TITLE
Route overload failures with bounded capacity backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ HTTP requests and the frame-aware WebSocket modes enforce file ownership found i
 
 Existing healthy bindings stay put even after usage crosses `switch_at`; the threshold controls only admission of new threads.
 
+Capacity rejections such as `server_is_overloaded` are tracked separately from quota and
+authentication failures. Three rejections within two minutes temporarily steer new work
+toward other eligible accounts, starting at one minute and increasing to a ten-minute cap.
+Existing owners remain usable, and an account in capacity backoff is still selected when
+no alternative is eligible. `comradex status --json` exposes the soft deadline as
+`routing.account_states.<account>.capacity_backoff_until_unix`.
+
 A pre-output quota response, account-scoped connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Responses bodies carrying encrypted reasoning, hosted operation state, or durable operation metadata become bound to the first account that actually receives them; a proven pre-dispatch connection failure does not create that binding. Shared DNS and network-reachability failures remain account-neutral and do not rotate credentials. Successful or ambiguous Live Voice creation is never replayed. On HTTP, a managed-account 401 gets one same-account refresh retry, and a 401/403 never crosses accounts. No response is retried after visible output. When no alternate is eligible, the original upstream rejection and its `Retry-After` or reset headers are preserved; primary, secondary, and tertiary reset windows bound quota cooldowns.
 
 Quota cooldowns recover automatically on the next selection or status request. When upstream reports several quota windows, only windows explicitly reported at 100% constrain a quota rejection; unrelated longer windows do not keep the account blocked. `comradex status` and `comradex status --json` expose each account's availability, retry deadline, usage, and blocking quota windows. Neither Comradex nor Codex needs to be restarted when a quota window resets.

--- a/src/proxy/capacity_tests.rs
+++ b/src/proxy/capacity_tests.rs
@@ -1,0 +1,380 @@
+async fn capacity_http_upstream(
+    status: StatusCode,
+    payload: Bytes,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let payload = payload.clone();
+            tokio::spawn(async move {
+                let service = service_fn(move |_req: Request<Incoming>| {
+                    let payload = payload.clone();
+                    async move {
+                        Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(status)
+                                .header(CONTENT_TYPE, "application/json")
+                                .header("retry-after", "17")
+                                .header("x-upstream-marker", "unchanged")
+                                .body(Full::new(payload))
+                                .unwrap(),
+                        )
+                    }
+                });
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+    (address, task)
+}
+
+#[tokio::test]
+async fn capacity_http_status_and_late_terminals_preserve_body_and_owner_health() {
+    let json = Bytes::from_static(br#"{"id":"resp_capacity","status":"failed","error":{"code":"server_is_overloaded","message":"Please try again later"}}"#);
+    let sse = Bytes::from_static(b"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_capacity\"}}\n\ndata: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_capacity\",\"error\":{\"code\":\"model_at_capacity\"}}}\n\n");
+    for (status, payload) in [
+        (StatusCode::TOO_MANY_REQUESTS, json.clone()),
+        (StatusCode::SERVICE_UNAVAILABLE, json.clone()),
+        (StatusCode::OK, json),
+        (StatusCode::OK, sse),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let (upstream, server) = capacity_http_upstream(status, payload.clone()).await;
+        let (address, proxy, router) = start_caller_proxy_with_router(
+            dir.path(),
+            format!("http://{upstream}/backend-api/codex"),
+            ResponsesWebsocketMode::Raw,
+        )
+        .await;
+        let owner = router.affinity.key("previous-response:existing_owner");
+        router.bind(owner.clone(), "caller").await;
+        let client: TestClient<HttpConnector, Full<Bytes>> =
+            TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+        for attempt in 0..3 {
+            let response = client
+                .request(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri(format!("http://{address}/0123456789abcdef/v1/responses"))
+                        .header(AUTHORIZATION, "Bearer caller-token")
+                        .body(Full::new(Bytes::from_static(
+                            br#"{"input":[],"previous_response_id":"existing_owner"}"#,
+                        )))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), status);
+            assert_eq!(response.headers()["retry-after"], "17");
+            assert_eq!(response.headers()["x-upstream-marker"], "unchanged");
+            assert_eq!(
+                response.into_body().collect().await.unwrap().to_bytes(),
+                payload
+            );
+            let snapshot = router.routing_snapshot().await;
+            let account = &snapshot.account_states["caller"];
+            assert!(account.available, "{status}: {account:?}");
+            assert!(account.quota_windows.is_empty());
+            assert_eq!(account.capacity_backoff_until_unix.is_some(), attempt == 2);
+            assert!(router.affinity.get(&owner).await.is_some());
+            assert!(
+                router
+                    .affinity
+                    .get(&router.affinity.key("previous-response:resp_capacity"))
+                    .await
+                    .is_none()
+            );
+        }
+        proxy.abort();
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn capacity_bridge_forwards_original_error_without_double_counting() {
+    let payload = Bytes::from_static(b"data: {\"type\":\"error\",\"error\":{\"code\":\"server_is_overloaded\",\"message\":\"try again\"}}\n\n");
+    let dir = tempfile::tempdir().unwrap();
+    let (upstream, server) = capacity_http_upstream(StatusCode::OK, payload).await;
+    let (address, proxy, router) = start_caller_proxy_with_router(
+        dir.path(),
+        format!("http://{upstream}/backend-api/codex"),
+        ResponsesWebsocketMode::HttpBridge,
+    )
+    .await;
+    let mut websocket = connect_test_websocket(address).await;
+    for attempt in 0..3 {
+        websocket
+            .send(Message::Text(
+                serde_json::json!({"type":"response.create","input":[]})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        let message = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(message.to_text().unwrap()).unwrap();
+        assert_eq!(
+            value,
+            serde_json::json!({"type":"error","error":{"code":"server_is_overloaded","message":"try again"}})
+        );
+        let snapshot = router.routing_snapshot().await;
+        let account = &snapshot.account_states["caller"];
+        assert!(account.available);
+        assert_eq!(account.capacity_backoff_until_unix.is_some(), attempt == 2);
+    }
+    proxy.abort();
+    server.abort();
+}
+
+#[tokio::test]
+async fn capacity_direct_terminal_keeps_warm_socket_and_account_available() {
+    let dir = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+        for index in 0..3 {
+            let message = socket.next().await.unwrap().unwrap();
+            assert!(message.is_text());
+            for event in [
+                serde_json::json!({"type":"response.created","response":{"id":format!("resp_{index}"),"status":"in_progress"}}),
+                serde_json::json!({"type":"response.failed","response":{"id":format!("resp_{index}"),"status":"failed","error":{"code":"overloaded_error"}}}),
+            ] {
+                socket
+                    .send(Message::Text(event.to_string().into()))
+                    .await
+                    .unwrap();
+            }
+        }
+        // Keep the warm connection alive until the test closes it.
+        while socket.next().await.is_some() {}
+    });
+    let (address, proxy, router) = start_caller_proxy_with_router(
+        dir.path(),
+        format!("http://{upstream}/backend-api/codex"),
+        ResponsesWebsocketMode::Direct,
+    )
+    .await;
+    let mut websocket = connect_test_websocket(address).await;
+    for attempt in 0..3 {
+        websocket
+            .send(Message::Text(
+                serde_json::json!({"type":"response.create","input":[]})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        for expected in ["response.created", "response.failed"] {
+            let message = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            let event: serde_json::Value =
+                serde_json::from_str(message.to_text().unwrap()).unwrap();
+            assert_eq!(event["type"], expected);
+        }
+        let snapshot = router.routing_snapshot().await;
+        let account = &snapshot.account_states["caller"];
+        assert!(account.available);
+        assert_eq!(account.capacity_backoff_until_unix.is_some(), attempt == 2);
+    }
+    proxy.abort();
+    server.abort();
+}
+
+#[tokio::test]
+async fn capacity_upgrade_rejection_preserves_status_and_body_without_alternate() {
+    let dir = tempfile::tempdir().unwrap();
+    let payload = Bytes::from_static(br#"{"error":{"code":"model_at_capacity"}}"#);
+    let (upstream, server) =
+        capacity_http_upstream(StatusCode::TOO_MANY_REQUESTS, payload.clone()).await;
+    let (address, proxy, router) = start_caller_proxy_with_router(
+        dir.path(),
+        format!("http://{upstream}/backend-api/codex"),
+        ResponsesWebsocketMode::Raw,
+    )
+    .await;
+    for _ in 0..3 {
+        let stream = TcpStream::connect(address).await.unwrap();
+        let mut request = format!("ws://{address}/0123456789abcdef/v1/responses")
+            .into_client_request()
+            .unwrap();
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION, "Bearer caller-token".parse().unwrap());
+        let error = tokio_tungstenite::client_async(request, stream)
+            .await
+            .unwrap_err();
+        let tokio_tungstenite::tungstenite::Error::Http(response) = error else {
+            panic!("unexpected error: {error}");
+        };
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()["retry-after"], "17");
+        assert_eq!(response.body().as_ref().unwrap(), &payload.to_vec());
+        assert!(router.routing_snapshot().await.account_states["caller"].available);
+    }
+    assert!(
+        router.routing_snapshot().await.account_states["caller"]
+            .capacity_backoff_until_unix
+            .is_some()
+    );
+    proxy.abort();
+    server.abort();
+}
+
+#[tokio::test]
+async fn capacity_body_inspection_leaves_auth_status_and_oversized_body_untouched() {
+    let client: TestClient<HttpConnector, Full<Bytes>> =
+        TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+    for (status, payload) in [
+        (
+            StatusCode::UNAUTHORIZED,
+            Bytes::from_static(br#"{"error":{"code":"model_at_capacity"}}"#),
+        ),
+        (
+            StatusCode::FORBIDDEN,
+            Bytes::from_static(br#"{"error":{"code":"model_at_capacity"}}"#),
+        ),
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Bytes::from(vec![b'x'; FILE_CREATE_RESPONSE_LIMIT + 1024]),
+        ),
+    ] {
+        let (address, server) = capacity_http_upstream(status, payload.clone()).await;
+        let response = client
+            .request(
+                Request::builder()
+                    .uri(format!("http://{address}/"))
+                    .body(Full::new(Bytes::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let (response, failure) = inspect_rejection_body(response).await.unwrap();
+        assert_eq!(failure, None);
+        assert_eq!(response.status(), status);
+        assert_eq!(response.headers()["x-upstream-marker"], "unchanged");
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            payload
+        );
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn capacity_inspection_deadline_resumes_body_and_preserves_trailers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let service = service_fn(|_req: Request<Incoming>| async move {
+            let stream = futures_util::stream::unfold(0, |index| async move {
+                let frame = match index {
+                    0 => Frame::data(Bytes::from_static(b"{\"error\":")),
+                    1 => {
+                        tokio::time::sleep(Duration::from_millis(1500)).await;
+                        Frame::data(Bytes::from_static(b"{\"code\":\"model_at_capacity\"}}"))
+                    }
+                    2 => {
+                        let mut trailers = hyper::HeaderMap::new();
+                        trailers.insert("x-final-marker", "preserved".parse().unwrap());
+                        Frame::trailers(trailers)
+                    }
+                    _ => return None,
+                };
+                Some((Ok::<_, std::io::Error>(frame), index + 1))
+            });
+            Ok::<_, Infallible>(
+                Response::builder()
+                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                    .header("trailer", "x-final-marker")
+                    .body(http_body_util::StreamBody::new(stream))
+                    .unwrap(),
+            )
+        });
+        let _ = hyper::server::conn::http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .await;
+    });
+    let client: TestClient<HttpConnector, Full<Bytes>> =
+        TestClient::builder(TokioExecutor::new()).build(HttpConnector::new());
+    let response = client
+        .request(
+            Request::builder()
+                .uri(format!("http://{address}/"))
+                .header("te", "trailers")
+                .body(Full::new(Bytes::new()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (response, failure) = inspect_rejection_body(response).await.unwrap();
+    assert_eq!(
+        failure, None,
+        "inspection must end before the delayed terminal arrives"
+    );
+    let collected = response.into_body().collect().await.unwrap();
+    assert_eq!(collected.trailers().unwrap()["x-final-marker"], "preserved");
+    assert_eq!(
+        collected.to_bytes(),
+        Bytes::from_static(br#"{"error":{"code":"model_at_capacity"}}"#)
+    );
+    server.abort();
+}
+
+#[tokio::test]
+async fn capacity_bridge_auth_status_never_records_body_capacity() {
+    for status in [StatusCode::UNAUTHORIZED, StatusCode::FORBIDDEN] {
+        let dir = tempfile::tempdir().unwrap();
+        let (upstream, server) = capacity_http_upstream(
+            status,
+            Bytes::from_static(br#"{"error":{"code":"model_at_capacity"}}"#),
+        )
+        .await;
+        let (address, proxy, router) = start_caller_proxy_with_router(
+            dir.path(),
+            format!("http://{upstream}/backend-api/codex"),
+            ResponsesWebsocketMode::HttpBridge,
+        )
+        .await;
+        for _ in 0..3 {
+            let mut websocket = connect_test_websocket(address).await;
+            websocket
+                .send(Message::Text(
+                    serde_json::json!({"type":"response.create","input":[]})
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+            let message = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            let value: serde_json::Value =
+                serde_json::from_str(message.to_text().unwrap()).unwrap();
+            assert_eq!(value["status"], status.as_u16());
+            assert_eq!(value["error"]["code"], "model_at_capacity");
+            assert!(
+                router.routing_snapshot().await.account_states["caller"]
+                    .capacity_backoff_until_unix
+                    .is_none()
+            );
+        }
+        proxy.abort();
+        server.abort();
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -386,7 +386,11 @@ fn materialize_http_bridge_continuation(
     Ok(materialized)
 }
 
+#[derive(Clone, Default)]
+struct CapacityObservation(Arc<AtomicBool>);
+
 struct HttpBridgeCapture {
+    capacity_observation: CapacityObservation,
     input: Vec<serde_json::Value>,
     response_id: Option<String>,
     output: Vec<serde_json::Value>,
@@ -1364,6 +1368,14 @@ impl App {
             // collectors below. Streaming responses release it when this function returns.
             match result {
                 Ok(response) => {
+                    let (mut response, body_failure) = inspect_rejection_body(response).await?;
+                    let capacity = body_failure == Some(FailureKind::Capacity);
+                    if capacity {
+                        self.router.capacity_failure(&account).await;
+                        response
+                            .extensions_mut()
+                            .insert(CapacityObservation(Arc::new(AtomicBool::new(true))));
+                    }
                     if nonportable_payload {
                         payload_dispatch_owner.get_or_insert_with(|| account.clone());
                     }
@@ -1395,7 +1407,7 @@ impl App {
                             self.router.bind(alias, &account).await;
                         }
                     }
-                    if status == StatusCode::UNAUTHORIZED {
+                    if status == StatusCode::UNAUTHORIZED && !capacity {
                         if attempt == 0 {
                             match self
                                 .auth
@@ -1503,7 +1515,7 @@ impl App {
                             .await;
                     }
                     let retry = retryable_http_status(status, &method, &path);
-                    if retry {
+                    if retry && !capacity {
                         if status == StatusCode::TOO_MANY_REQUESTS
                             || status == StatusCode::PAYMENT_REQUIRED
                         {
@@ -1593,7 +1605,7 @@ impl App {
 
     async fn map_file_create_response(
         &self,
-        response: Response<Incoming>,
+        response: Response<ProxyBody>,
         account: &str,
     ) -> Result<Response<ProxyBody>> {
         let (mut parts, mut body) = response.into_parts();
@@ -1634,7 +1646,7 @@ impl App {
 
     async fn map_file_finalize_response(
         &self,
-        response: Response<Incoming>,
+        response: Response<ProxyBody>,
         account: &str,
         file_id: &str,
     ) -> Result<Response<ProxyBody>> {
@@ -2412,9 +2424,14 @@ impl App {
                     }
                 }
             }
+            let (response, body_failure) = inspect_rejection_body(response).await?;
+            let capacity = body_failure == Some(FailureKind::Capacity);
             let status = response.status();
             self.router.end(account).await;
-            if status == StatusCode::UNAUTHORIZED && attempt == 0 {
+            if capacity {
+                self.router.capacity_failure(account).await;
+            }
+            if !capacity && status == StatusCode::UNAUTHORIZED && attempt == 0 {
                 match self
                     .auth
                     .force_refresh(&self.config.accounts[account], &credentials)
@@ -2445,7 +2462,9 @@ impl App {
                     }
                 }
             }
-            if is_quota_status(status) {
+            if capacity {
+                // The body classification takes precedence over quota/gateway status.
+            } else if is_quota_status(status) {
                 self.router.quota_failure(account, response.headers()).await;
             } else if is_selected_gateway_failure(status) {
                 self.router.soft_failure(account).await;
@@ -2788,6 +2807,9 @@ impl App {
                                             .quota_failure(&account, &hyper::HeaderMap::new())
                                             .await;
                                     }
+                                    FailureKind::Capacity => {
+                                        self.router.capacity_failure(&account).await;
+                                    }
                                     FailureKind::Authentication { .. } => {
                                         self.router.auth_failure(&account).await;
                                     }
@@ -2855,6 +2877,7 @@ impl App {
                                 }
                             }
                             if let Some(response_id) = association.response_id.as_deref()
+                                && terminal_permits_affinity(&association.failure)
                                 && !association.turn_ids.is_empty()
                             {
                                 let key = self.router.affinity.key(&format!("previous-response:{response_id}"));
@@ -2984,6 +3007,7 @@ impl App {
                     .quota_failure(account, &hyper::HeaderMap::new())
                     .await;
             }
+            FailureKind::Capacity => self.router.capacity_failure(account).await,
             FailureKind::Transient => self.router.soft_failure(account).await,
             _ => {}
         }
@@ -3614,7 +3638,12 @@ impl App {
                 return Ok(map_upgrade_response(response));
             }
             self.router.end(&selection.account_id).await;
-            if response.status() == StatusCode::UNAUTHORIZED && attempt == 0 {
+            let (response, body_failure) = inspect_rejection_body(response).await?;
+            let capacity = body_failure == Some(FailureKind::Capacity);
+            if capacity {
+                self.router.capacity_failure(&selection.account_id).await;
+            }
+            if !capacity && response.status() == StatusCode::UNAUTHORIZED && attempt == 0 {
                 match self
                     .auth
                     .force_refresh(&self.config.accounts[&selection.account_id], &credentials)
@@ -3651,12 +3680,14 @@ impl App {
                         self.router.auth_failure(&selection.account_id).await;
                     }
                 }
-            } else if response.status() == StatusCode::UNAUTHORIZED {
+            } else if !capacity && response.status() == StatusCode::UNAUTHORIZED {
                 self.router.auth_failure(&selection.account_id).await;
             }
             let retry = is_quota_status(response.status())
                 || is_selected_gateway_failure(response.status());
-            if matches!(
+            if capacity {
+                // The body classification takes precedence over quota/gateway status.
+            } else if matches!(
                 response.status(),
                 StatusCode::TOO_MANY_REQUESTS | StatusCode::PAYMENT_REQUIRED
             ) {
@@ -3667,7 +3698,7 @@ impl App {
                 self.router.soft_failure(&selection.account_id).await;
             }
             if retry && !forced_live && !hard_owner && attempt == 0 {
-                selection = self
+                let alternate = self
                     .router
                     .select(
                         &listener.pool,
@@ -3675,14 +3706,18 @@ impl App {
                         key.clone(),
                         Some(&selection.account_id),
                     )
-                    .await
-                    .context("no alternate account")?;
+                    .await;
+                if capacity && alternate.is_none() {
+                    return Ok(response);
+                }
+                selection = alternate.context("no alternate account")?;
                 for (_, alias) in &affinity_keys {
                     self.router.bind(alias.clone(), &selection.account_id).await;
                 }
                 continue;
             }
-            if response.status() == StatusCode::UNAUTHORIZED
+            if !capacity
+                && response.status() == StatusCode::UNAUTHORIZED
                 && matches!(
                     self.config.accounts[&selection.account_id],
                     crate::config::AccountConfig::CodexHome { .. }
@@ -3690,7 +3725,7 @@ impl App {
             {
                 self.router.auth_failure(&selection.account_id).await;
             }
-            return Ok(map_http_response(response));
+            return Ok(response);
         }
         unreachable!()
     }
@@ -3907,7 +3942,7 @@ fn mark_compaction_request(headers: &mut hyper::HeaderMap) -> Result<()> {
     Ok(())
 }
 
-async fn map_legacy_compact_response(response: Response<Incoming>) -> Result<Response<ProxyBody>> {
+async fn map_legacy_compact_response(response: Response<ProxyBody>) -> Result<Response<ProxyBody>> {
     let (mut parts, mut body) = response.into_parts();
     let mut decoder = SseDecoder::default();
     let mut created_id = None;
@@ -4067,19 +4102,119 @@ fn is_shared_network_io_error(error: &std::io::Error) -> bool {
     })
 }
 
+/// Inspect a bounded rejection prefix before interpreting its HTTP status. Replay every
+/// frame unchanged, including trailers and any read error, to the downstream body.
+async fn inspect_rejection_body(
+    response: Response<Incoming>,
+) -> Result<(Response<ProxyBody>, Option<FailureKind>)> {
+    if response.status().is_success()
+        || matches!(
+            response.status(),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+        )
+    {
+        return Ok((map_http_response(response), None));
+    }
+    let (mut parts, mut body) = response.into_parts();
+    let mut frames = std::collections::VecDeque::new();
+    let mut bytes = Vec::new();
+    let mut complete = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while bytes.len() <= FILE_CREATE_RESPONSE_LIMIT && frames.len() < 128 {
+        let next = tokio::time::timeout_at(deadline, body.frame()).await;
+        match next {
+            Ok(Some(Ok(frame))) => {
+                let oversized = frame.data_ref().is_some_and(|data| {
+                    bytes.len().saturating_add(data.len()) > FILE_CREATE_RESPONSE_LIMIT
+                });
+                if !oversized && let Some(data) = frame.data_ref() {
+                    bytes.extend_from_slice(data);
+                }
+                let terminal = frame.is_trailers() || body.is_end_stream();
+                frames.push_back(Ok(frame));
+                if oversized {
+                    break;
+                }
+                if terminal {
+                    complete = true;
+                    break;
+                }
+            }
+            Ok(None) => {
+                complete = true;
+                break;
+            }
+            Ok(Some(Err(error))) => {
+                frames.push_back(Err(std::io::Error::other(error)));
+                break;
+            }
+            // Exhausting the inspection budget is not a transport failure. Resume
+            // forwarding the untouched remaining stream under its normal body timeout.
+            Err(_) => break,
+        }
+    }
+    let failure = complete
+        .then(|| {
+            let mut observer = HttpResponseObserver::new(response_observer_for_content_type(None));
+            observer.observe(&bytes);
+            observer.finish().failure.map(|failure| failure.kind)
+        })
+        .flatten();
+    headers::strip_hop_by_hop(&mut parts.headers);
+    Ok((
+        Response::from_parts(
+            parts,
+            ReplayedIncoming {
+                frames,
+                inner: incoming_body(body),
+            }
+            .boxed(),
+        ),
+        failure,
+    ))
+}
+
+struct ReplayedIncoming {
+    frames: std::collections::VecDeque<std::io::Result<Frame<bytes::Bytes>>>,
+    inner: ProxyBody,
+}
+
+impl Body for ReplayedIncoming {
+    type Data = bytes::Bytes;
+    type Error = std::io::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+    ) -> Poll<Option<std::io::Result<Frame<bytes::Bytes>>>> {
+        if let Some(frame) = self.frames.pop_front() {
+            return Poll::Ready(Some(frame));
+        }
+        Pin::new(&mut self.inner).poll_frame(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.frames.is_empty() && self.inner.is_end_stream()
+    }
+}
+
 fn map_http_response(response: Response<Incoming>) -> Response<ProxyBody> {
     let (mut parts, body) = response.into_parts();
     headers::strip_hop_by_hop(&mut parts.headers);
     Response::from_parts(parts, incoming_body(body))
 }
 
-fn map_http_response_leased(
-    response: Response<Incoming>,
+fn map_http_response_leased<B>(
+    response: Response<B>,
     router: Arc<Router>,
     selection: &Selection,
     observe_response_ids: bool,
     deferred_affinity: Vec<crate::routing::ThreadKey>,
-) -> Response<ProxyBody> {
+) -> Response<ProxyBody>
+where
+    B: Body<Data = bytes::Bytes> + Send + Sync + 'static,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
     let (mut parts, body) = response.into_parts();
     headers::strip_hop_by_hop(&mut parts.headers);
     parts.extensions.insert(SelectedAccount {
@@ -4087,6 +4222,12 @@ fn map_http_response_leased(
         generation: selection.account_generation,
         seq: selection.seq,
     });
+    let capacity_observation = parts
+        .extensions
+        .get::<CapacityObservation>()
+        .cloned()
+        .unwrap_or_default();
+    parts.extensions.insert(capacity_observation.clone());
     let account = selection.account_id.clone();
     let response_headers = parts.headers.clone();
     let observer = observe_response_ids.then(|| {
@@ -4097,7 +4238,8 @@ fn map_http_response_leased(
     Response::from_parts(
         parts,
         BodyExt::boxed(LeasedIncoming {
-            inner: body,
+            inner: body.map_err(std::io::Error::other).boxed(),
+            capacity_observation,
             router,
             account: Some(account),
             observer,
@@ -4112,7 +4254,8 @@ fn map_http_response_leased(
 }
 
 struct LeasedIncoming {
-    inner: Incoming,
+    inner: ProxyBody,
+    capacity_observation: CapacityObservation,
     router: Arc<Router>,
     account: Option<String>,
     observer: Option<HttpResponseObserver>,
@@ -4140,7 +4283,7 @@ enum HttpResponseObserverKind {
 struct HttpResponseObserver {
     kind: HttpResponseObserverKind,
     deferred_ids: Vec<String>,
-    quota: Option<FailureClassification>,
+    failure: Option<FailureClassification>,
     terminal: Option<sse::TerminalStatus>,
 }
 
@@ -4149,7 +4292,7 @@ impl HttpResponseObserver {
         Self {
             kind,
             deferred_ids: Vec::new(),
-            quota: None,
+            failure: None,
             terminal: None,
         }
     }
@@ -4219,8 +4362,11 @@ impl HttpResponseObserver {
             // `event.response.error`, narrow `incomplete_details`, numeric
             // `status`/`status_code` fallback.
             let classification = classify_terminal_event(&event.value);
-            if classification.kind == FailureKind::Quota {
-                self.quota = Some(classification);
+            if matches!(
+                classification.kind,
+                FailureKind::Quota | FailureKind::Capacity
+            ) {
+                self.failure = Some(classification);
                 self.terminal = event.terminal.or(self.terminal);
                 // Quota terminals never bind previous-response IDs; drop any
                 // IDs buffered from earlier non-terminal events in the same
@@ -4266,8 +4412,11 @@ impl HttpResponseObserver {
                             message: None,
                             response_id: None,
                         });
-                    if classification.kind == FailureKind::Quota {
-                        self.quota = Some(classification);
+                    if matches!(
+                        classification.kind,
+                        FailureKind::Quota | FailureKind::Capacity
+                    ) {
+                        self.failure = Some(classification);
                         self.deferred_ids.clear();
                     } else {
                         self.deferred_ids = response_ids_from_json(&bytes);
@@ -4300,8 +4449,11 @@ impl HttpResponseObserver {
                         message: None,
                         response_id: None,
                     });
-                if classification.kind == FailureKind::Quota {
-                    self.quota = Some(classification);
+                if matches!(
+                    classification.kind,
+                    FailureKind::Quota | FailureKind::Capacity
+                ) {
+                    self.failure = Some(classification);
                 } else {
                     self.deferred_ids = response_ids_from_json(&bytes);
                 }
@@ -4309,7 +4461,7 @@ impl HttpResponseObserver {
         }
         HttpObservedBody {
             ids: std::mem::take(&mut self.deferred_ids),
-            quota: self.quota,
+            failure: self.failure,
             terminal: self.terminal,
         }
     }
@@ -4317,7 +4469,7 @@ impl HttpResponseObserver {
 
 struct HttpObservedBody {
     ids: Vec<String>,
-    quota: Option<FailureClassification>,
+    failure: Option<FailureClassification>,
     terminal: Option<sse::TerminalStatus>,
 }
 
@@ -4443,14 +4595,20 @@ impl LeasedIncoming {
         let router = self.router.clone();
         let headers = self.response_headers.clone();
         let deferred_affinity = self.deferred_affinity.clone();
+        let capacity_observation = self.capacity_observation.clone();
         Some(Box::pin(async move {
-            if let Some(quota) = observed.quota {
+            if let Some(quota) = observed.failure {
                 // Late body reclassification as quota: feed
                 // `quota_failure(headers)` preserving retry-after and bind
                 // nothing (no previous-response IDs, no deferred affinity,
                 // no continuation).
-                let _ = quota;
-                router.quota_failure(&account, &headers).await;
+                if quota.kind == FailureKind::Capacity {
+                    if !capacity_observation.0.swap(true, Ordering::AcqRel) {
+                        router.capacity_failure(&account).await;
+                    }
+                } else {
+                    router.quota_failure(&account, &headers).await;
+                }
                 return;
             }
             // Bind deferred success affinity only behind a non-quota
@@ -4865,6 +5023,11 @@ async fn pump_http_response_to_websocket(
     upstream_idle_timeout: Duration,
 ) -> std::result::Result<(), HttpBridgePumpFailure> {
     let mut capture = HttpBridgeCapture {
+        capacity_observation: response
+            .extensions()
+            .get::<CapacityObservation>()
+            .cloned()
+            .unwrap_or_default(),
         input: request_input,
         response_id: None,
         output: Vec::new(),
@@ -4914,7 +5077,8 @@ async fn pump_http_response_to_websocket(
         // a quota-shaped error body (numeric 429, quota code/message)
         // feeds `quota_failure(headers)` even when the transport status is
         // not itself 429/402.
-        if let Some(account) = selected_account.as_deref()
+        if !matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN)
+            && let Some(account) = selected_account.as_deref()
             && let Some(body_value) = parsed.as_ref()
         {
             let body_classification = if body_value.get("type").is_some() {
@@ -4922,8 +5086,14 @@ async fn pump_http_response_to_websocket(
             } else {
                 classify_http_json_body(body_value)
             };
-            if body_classification.kind == FailureKind::Quota {
-                app.router.quota_failure(account, &response_headers).await;
+            if matches!(body_classification.kind, FailureKind::Quota | FailureKind::Capacity) {
+                if body_classification.kind == FailureKind::Capacity {
+                    if !capture.capacity_observation.0.swap(true, Ordering::AcqRel) {
+                        app.router.capacity_failure(account).await;
+                    }
+                } else {
+                    app.router.quota_failure(account, &response_headers).await;
+                }
             }
         }
         let error = parsed
@@ -5126,17 +5296,24 @@ async fn send_protocol_events(
         // inside `classify_terminal_event`).
         let classification = classify_terminal_event(&event.value);
         let is_quota = classification.kind == FailureKind::Quota;
-        if is_quota {
+        if is_quota || classification.kind == FailureKind::Capacity {
             if let Some(account) = account {
-                app.router.quota_failure(account, response_headers).await;
+                if is_quota {
+                    app.router.quota_failure(account, response_headers).await;
+                } else if !capture.capacity_observation.0.swap(true, Ordering::AcqRel) {
+                    app.router.capacity_failure(account).await;
+                }
             }
             // Never bind previous-response affinity nor cache a continuation
             // for quota terminals; the account is cooling down.
             let previous_response_id = capture.response_id.clone();
             capture.observe(&event.value);
             capture.response_id = previous_response_id;
-            let payload =
-                enrich_bridge_quota_payload(&event.payload, &event.value, response_headers);
+            let payload = if is_quota {
+                enrich_bridge_quota_payload(&event.payload, &event.value, response_headers)
+            } else {
+                event.payload.clone()
+            };
             if !outbound.send(Message::Text(payload.into())).await {
                 capture.delivery_failed = true;
                 anyhow::bail!("downstream WebSocket writer stopped before event delivery")
@@ -5339,6 +5516,7 @@ async fn collect_proxy_body_with_initial(
 
 #[cfg(test)]
 mod tests {
+    include!("capacity_tests.rs");
     use super::*;
     use crate::{
         config::{AccountConfig, ProxyConfig, ResponsesWebsocketMode},
@@ -5601,7 +5779,7 @@ mod tests {
         observer.observe(br#"{"id":"resp_missing_type","object":"response","status":"completed"}"#);
         let observed = observer.finish();
         assert_eq!(observed.ids, ["resp_missing_type"]);
-        assert!(observed.quota.is_none());
+        assert!(observed.failure.is_none());
         assert_eq!(observed.terminal, Some(sse::TerminalStatus::Completed));
     }
 
@@ -5617,7 +5795,7 @@ mod tests {
         observer.observe(br#"{"response":{"id":"resp_generic_type","status":"completed"}}"#);
         let observed = observer.finish();
         assert_eq!(observed.ids, ["resp_generic_type"]);
-        assert!(observed.quota.is_none());
+        assert!(observed.failure.is_none());
     }
 
     #[test]
@@ -5645,7 +5823,7 @@ mod tests {
         let observed = observer.finish();
         assert_eq!(observed.ids, ["resp_stream"]);
         assert_eq!(observed.terminal, Some(sse::TerminalStatus::Completed));
-        assert!(observed.quota.is_none());
+        assert!(observed.failure.is_none());
 
         // A mislabeled stream takes the dual path, but still discovers the ID
         // from the current frame instead of waiting for EOF/JSON parsing.
@@ -5678,7 +5856,7 @@ mod tests {
         malformed.observe(br#"{"id":"resp_broken""#);
         let observed = malformed.finish();
         assert!(observed.ids.is_empty());
-        assert!(observed.quota.is_none());
+        assert!(observed.failure.is_none());
 
         let generic = hyper::header::HeaderValue::from_static("text/plain");
         let mut unrelated =
@@ -5686,7 +5864,7 @@ mod tests {
         unrelated.observe(br#"{"ok":true,"items":[]}"#);
         let observed = unrelated.finish();
         assert!(observed.ids.is_empty());
-        assert!(observed.quota.is_none());
+        assert!(observed.failure.is_none());
     }
 
     #[test]
@@ -5732,7 +5910,7 @@ mod tests {
         let observed = observer.finish();
         assert!(observed.ids.is_empty());
         assert_eq!(
-            observed.quota.as_ref().map(|quota| &quota.kind),
+            observed.failure.as_ref().map(|quota| &quota.kind),
             Some(&FailureKind::Quota)
         );
 
@@ -7168,21 +7346,30 @@ mod tests {
                 .is_ok()
         );
 
-        // Old slow-path product: re-select excluding slow-but-healthy A.
+        // A normal fresh selection still retains the healthy preferred account;
+        // credential latency alone must never introduce an exclusion.
+        let fresh = router.select("default", pool, None, None).await.unwrap();
+        assert_eq!(fresh.account_id, "a");
+        assert!(
+            router
+                .validate_selection(&fresh, "default", pool)
+                .await
+                .is_ok()
+        );
+
+        // An explicit retry exclusion is different: its stamped choice must remain
+        // valid even while A is preferred. The former fence contradicted this
+        // deliberate failover decision by immediately selecting A again.
         let reselected = router
             .select("default", pool, None, Some(&selected.account_id))
             .await
             .unwrap();
         assert_eq!(reselected.account_id, "b");
-
-        // Attempt 1 fence: B is unwirable while A remains healthy+preferred, so the
-        // final attempt would end in `continuity_owner_unavailable` (503) with no
-        // budget left. The fixed slow path keeps A instead of excluding it.
-        assert_eq!(
+        assert!(
             router
                 .validate_selection(&reselected, "default", pool)
-                .await,
-            Err(SelectionStaleReason::PreferredSuperseded)
+                .await
+                .is_ok()
         );
         assert!(
             router

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -237,6 +237,7 @@ pub struct EventAssociation {
 pub enum FailureKind {
     None,
     Quota,
+    Capacity,
     Authentication { requires_reauthentication: bool },
     PreviousResponseNotFound,
     Transient,
@@ -310,8 +311,7 @@ pub enum ReplayDecision {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReplayContext {
     /// True when the failure event being classified carries a response ID.
-    /// Quota failures may still be pre-created capacity rejection envelopes;
-    /// other failures with an ID are treated as accepted work.
+    /// An assigned ID is treated as accepted work, even for quota or capacity failures.
     pub current_event_has_response_id: bool,
 }
 
@@ -560,6 +560,7 @@ impl ProtocolState {
         let supported = matches!(
             failure,
             FailureKind::Quota
+                | FailureKind::Capacity
                 | FailureKind::Authentication { .. }
                 | FailureKind::PreviousResponseNotFound
                 | FailureKind::Transient
@@ -943,22 +944,31 @@ fn is_quota_code(code: &str) -> bool {
             | "insufficient_quota"
             | "quota_exceeded"
             | "usage_not_included"
-            | "overloaded_error"
-            | "server_is_overloaded"
     )
 }
 
 fn is_quota_message(message: &str) -> bool {
-    message.contains("usage limit")
-        || message.contains("insufficient quota")
-        || message.contains("server is overloaded")
+    message.contains("usage limit") || message.contains("insufficient quota")
 }
 
-/// Narrow quota signals from `response.incomplete_details` and
-/// `response.error.message` for quota-shaped `incomplete`/`failed` terminals.
-/// Only exact codes and the existing narrow substrings count; bare
-/// `limit|usage|quota|overloaded` substrings never match.
-fn incomplete_quota_signal(event: &Value) -> (Option<String>, Option<String>) {
+fn is_capacity_code(code: &str) -> bool {
+    matches!(
+        code,
+        "server_is_overloaded" | "overloaded_error" | "model_at_capacity"
+    )
+}
+
+fn is_capacity_message(message: &str) -> bool {
+    message.contains("server is overloaded") || message.contains("model is at capacity")
+}
+
+/// Narrow quota or capacity evidence from failed/incomplete terminal details.
+/// Bare `limit|usage|quota|overloaded` substrings never match.
+fn incomplete_failure_signal(
+    event: &Value,
+    matches_code: fn(&str) -> bool,
+    matches_message: fn(&str) -> bool,
+) -> (Option<String>, Option<String>) {
     let event_type = event.get("type").and_then(Value::as_str);
     if !matches!(
         event_type,
@@ -974,10 +984,10 @@ fn incomplete_quota_signal(event: &Value) -> (Option<String>, Option<String>) {
     let mut matched_message: Option<String> = None;
     let mut check_text = |text: &str| {
         let normalized = text.to_ascii_lowercase();
-        if matched_code.is_none() && is_quota_code(normalized.as_str()) {
+        if matched_code.is_none() && matches_code(normalized.as_str()) {
             matched_code = Some(bounded_owned(text, MAX_CLASSIFIED_CODE_BYTES));
         }
-        if is_quota_message(normalized.as_str()) {
+        if matches_message(normalized.as_str()) {
             matched_message
                 .get_or_insert_with(|| bounded_owned(text, MAX_CLASSIFIED_MESSAGE_BYTES));
         }
@@ -1105,10 +1115,17 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
     // Quota-shaped `incomplete`/`failed` terminals carry the signal in
     // `response.incomplete_details` or `response.error.message` rather than
     // the primary error object.
-    let (incomplete_code, incomplete_message) = incomplete_quota_signal(event);
+    let (incomplete_code, incomplete_message) =
+        incomplete_failure_signal(event, is_quota_code, is_quota_message);
     if incomplete_code.is_some() || incomplete_message.is_some() {
         quota = true;
     }
+    let (capacity_code, capacity_message) =
+        incomplete_failure_signal(event, is_capacity_code, is_capacity_message);
+    let capacity = is_capacity_code(normalized_code)
+        || is_capacity_message(&normalized_message)
+        || capacity_code.is_some()
+        || capacity_message.is_some();
 
     // Numeric fallback: envelope or nested error `status`/`status_code` as
     // numbers or numeric strings. Only 429/402 act as failure signals; a body
@@ -1121,9 +1138,6 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
         Some(402) => quota || incomplete_code.is_some() || incomplete_message.is_some(),
         _ => false,
     };
-    if numeric_quota {
-        quota = true;
-    }
     let numeric_auth = matches!(numeric, Some(401 | 403));
     let authentication = authentication || numeric_auth;
 
@@ -1133,6 +1147,8 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
         && numeric.is_none()
         && incomplete_code.is_none()
         && incomplete_message.is_none()
+        && capacity_code.is_none()
+        && capacity_message.is_none()
     {
         return FailureClassification::none();
     }
@@ -1145,6 +1161,12 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
         }
     } else if quota {
         FailureKind::Quota
+    } else if capacity {
+        // Explicit capacity evidence overrides a generic numeric 429. Actual quota
+        // evidence above remains fail-closed even if an envelope also mentions capacity.
+        FailureKind::Capacity
+    } else if numeric_quota {
+        FailureKind::Quota
     } else if transient {
         FailureKind::Transient
     } else {
@@ -1153,8 +1175,12 @@ pub fn classify_failure(event: &Value) -> FailureClassification {
     // Prefer the primary error code/message; fall back to the narrow
     // incomplete signal so quota terminals without an error object still
     // carry evidence.
-    let code = code.or_else(|| incomplete_code.map(|value| value.to_ascii_lowercase()));
-    let message = message.or(incomplete_message);
+    let code = code.or_else(|| {
+        incomplete_code
+            .or(capacity_code)
+            .map(|value| value.to_ascii_lowercase())
+    });
+    let message = message.or(incomplete_message).or(capacity_message);
     FailureClassification {
         kind,
         code,
@@ -1174,7 +1200,7 @@ pub fn response_id(event: &Value) -> Option<&str> {
 
 /// Canonical terminal classification shared by Direct, Bridge, and HTTP
 /// lanes. Only terminal event types (`response.failed`,
-/// `response.incomplete`, `error`) can yield a quota failure; a quota-shaped
+/// `response.incomplete`, `error`) can yield quota or capacity failures; such a
 /// signal on any other terminal (completed/cancelled/non-terminal) is
 /// downgraded to `Other` so normal `incomplete` (max_tokens/length/
 /// content_filter) and success affinity stay intact.
@@ -1182,7 +1208,7 @@ pub fn classify_terminal_event(event: &Value) -> FailureClassification {
     let terminal = terminal_kind(event.get("type").and_then(Value::as_str));
     let classification = classify_failure(event);
     match classification.kind {
-        FailureKind::Quota => match terminal {
+        FailureKind::Quota | FailureKind::Capacity => match terminal {
             Some(TerminalKind::Failed) | Some(TerminalKind::Incomplete) => classification,
             _ => FailureClassification {
                 kind: FailureKind::Other,
@@ -1196,10 +1222,13 @@ pub fn classify_terminal_event(event: &Value) -> FailureClassification {
 }
 
 /// Whether a terminal classification permits success-affinity binding and
-/// continuation caching. Quota terminals must never bind previous-response
+/// continuation caching. Quota and capacity terminals must never bind previous-response
 /// IDs nor cache continuations.
 pub fn terminal_permits_affinity(classification: &FailureClassification) -> bool {
-    !matches!(classification.kind, FailureKind::Quota)
+    !matches!(
+        classification.kind,
+        FailureKind::Quota | FailureKind::Capacity
+    )
 }
 
 /// Classifies a non-streaming Responses JSON body (`value.response ?? value`).
@@ -2097,6 +2126,73 @@ mod tests {
             classify_failure(&json!({"type":"error","status_code":502})).kind,
             FailureKind::Quota
         );
+    }
+
+    #[test]
+    fn capacity_is_distinct_from_quota_across_terminal_shapes() {
+        for code in [
+            "server_is_overloaded",
+            "overloaded_error",
+            "model_at_capacity",
+        ] {
+            for event in [
+                json!({"type":"error", "error":{"code":code}}),
+                json!({"type":"error", "status":429, "error":{"code":code}}),
+                json!({"type":"error", "status":503, "error":{"code":code}}),
+                json!({"type":"response.failed", "response":{"id":"resp_busy", "error":{"code":code}}}),
+                json!({"type":"response.incomplete", "response":{"incomplete_details":{"reason":code}}}),
+            ] {
+                let failure = classify_terminal_event(&event);
+                assert_eq!(failure.kind, FailureKind::Capacity, "{event}");
+                assert!(!terminal_permits_affinity(&failure));
+            }
+            let json = json!({"status":"failed", "error":{"code":code}});
+            assert_eq!(classify_http_json_body(&json).kind, FailureKind::Capacity);
+        }
+        for message in [
+            "The server is overloaded. Please try again later.",
+            "The selected model is at capacity",
+        ] {
+            let event = json!({"type":"error", "error":{"message":message}});
+            assert_eq!(classify_terminal_event(&event).kind, FailureKind::Capacity);
+        }
+        for message in ["overloaded", "capacity", "the tool returned overloaded"] {
+            let event = json!({"type":"error", "error":{"message":message}});
+            assert_eq!(classify_terminal_event(&event).kind, FailureKind::Other);
+        }
+        // Never downgrade actual auth or quota evidence to a capacity hint.
+        let auth = json!({"type":"error", "status":401, "error":{"code":"server_is_overloaded"}});
+        assert!(matches!(
+            classify_terminal_event(&auth).kind,
+            FailureKind::Authentication { .. }
+        ));
+        let quota = json!({"type":"error", "error":{"code":"usage_limit_reached", "message":"server is overloaded"}});
+        assert_eq!(classify_terminal_event(&quota).kind, FailureKind::Quota);
+        let completed =
+            json!({"type":"response.completed", "response":{"error":{"code":"model_at_capacity"}}});
+        assert_eq!(classify_terminal_event(&completed).kind, FailureKind::Other);
+    }
+
+    #[test]
+    fn capacity_replay_still_requires_precreated_turn() {
+        let mut protocol = state();
+        let turn = protocol
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        assert_eq!(
+            protocol.replay_decision(turn, FailureKind::Capacity, ReplayContext::default()),
+            ReplayDecision::Eligible(ReplayMode::OriginalRequest)
+        );
+        protocol
+            .observe_upstream_event(
+                &json!({"type":"response.created", "response":{"id":"resp_busy"}}),
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            protocol.replay_decision(turn, FailureKind::Capacity, ReplayContext::default()),
+            ReplayDecision::Refused(_)
+        ));
     }
 
     #[test]

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -10,7 +10,7 @@ use std::{
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     config::{Config, PoolConfig},
@@ -27,6 +27,8 @@ pub struct Selection {
     pub account_generation: u64,
     /// Monotonic selection id for `selected vs wired` post-hoc log correlation.
     pub seq: u64,
+    /// A retry's excluded account must not supersede its alternate during validation.
+    excluded_account: Option<String>,
 }
 
 /// How long credential resolution may take before a fresh (unbound) selection is treated as
@@ -93,6 +95,9 @@ pub struct AccountRoutingStatus {
     pub inflight: u64,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub quota_windows: BTreeMap<String, QuotaWindowStatus>,
+    /// Soft preference for fresh admissions only; the account remains available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capacity_backoff_until_unix: Option<i64>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,6 +120,56 @@ struct AccountRuntime {
     quota_reset_at: Option<DateTime<Utc>>,
     quota_evidence: Option<QuotaEvidence>,
     avoid_until: Option<Instant>,
+    capacity: CapacityBackoff,
+}
+
+const CAPACITY_REJECTION_WINDOW: Duration = Duration::from_secs(120);
+const CAPACITY_BACKOFF_DECAY: Duration = Duration::from_secs(30 * 60);
+const CAPACITY_REJECTION_THRESHOLD: usize = 3;
+
+/// Bounded, process-local admission evidence. Successful warm sessions do not erase
+/// repeated fresh-admission failures, and capacity never changes quota or auth health.
+#[derive(Debug, Default)]
+struct CapacityBackoff {
+    rejections: VecDeque<Instant>,
+    until: Option<Instant>,
+    last_trip: Option<Instant>,
+    level: u32,
+}
+
+impl CapacityBackoff {
+    fn active(&self, now: Instant) -> bool {
+        self.until.is_some_and(|until| until > now)
+    }
+
+    fn record(&mut self, now: Instant) -> Option<Duration> {
+        while self
+            .rejections
+            .front()
+            .is_some_and(|at| now.saturating_duration_since(*at) >= CAPACITY_REJECTION_WINDOW)
+        {
+            self.rejections.pop_front();
+        }
+        self.rejections.push_back(now);
+        if self.rejections.len() < CAPACITY_REJECTION_THRESHOLD {
+            return None;
+        }
+        self.rejections.clear();
+        if self
+            .last_trip
+            .is_some_and(|at| now.saturating_duration_since(at) >= CAPACITY_BACKOFF_DECAY)
+        {
+            self.level = 0;
+        }
+        let delay = Duration::from_secs((60_u64 << self.level).min(600));
+        self.until = Some(
+            self.until
+                .map_or(now + delay, |until| until.max(now + delay)),
+        );
+        self.last_trip = Some(now);
+        self.level = (self.level + 1).min(4);
+        Some(delay)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -242,6 +297,7 @@ impl Router {
                     thread,
                     account_generation: binding_epoch.unwrap_or(binding.account_generation),
                     seq,
+                    excluded_account: exclude.map(str::to_owned),
                 });
             }
         }
@@ -256,6 +312,15 @@ impl Router {
                         && a.avoid_until.is_none_or(|v| v <= now)
                 })
         };
+        // Apply the soft capacity preference only after normal eligibility. An
+        // unavailable sibling must never turn this preference into an empty pool.
+        let has_capacity_alternative = pool
+            .members
+            .iter()
+            .any(|id| eligible(id) && !accounts[id].capacity.active(now));
+        let preferred_for_capacity =
+            |id: &str| !has_capacity_alternative || !accounts[id].capacity.active(now);
+        let eligible = |id: &str| eligible(id) && preferred_for_capacity(id);
         let below_switch_at = |id: &str| {
             accounts
                 .get(id)
@@ -313,6 +378,7 @@ impl Router {
                 thread,
                 account_generation: generation,
                 seq,
+                excluded_account: exclude.map(str::to_owned),
             });
         }
         let account_generation = self.affinity.account_epoch(&selected).await;
@@ -322,6 +388,7 @@ impl Router {
             thread,
             account_generation,
             seq,
+            excluded_account: exclude.map(str::to_owned),
         })
     }
 
@@ -498,6 +565,7 @@ impl Router {
             let configured = self.preferred.lock().await.get(pool_name).cloned();
             if let Some(preferred_id) = configured
                 && preferred_id != selection.account_id
+                && selection.excluded_account.as_deref() != Some(preferred_id.as_str())
                 && pool.members.contains(&preferred_id)
             {
                 let preferred_eligible = {
@@ -507,6 +575,10 @@ impl Router {
                             && !runtime.login_in_progress
                             && runtime.quota_until.is_none_or(|until| until <= now)
                             && runtime.avoid_until.is_none_or(|until| until <= now)
+                            && (!runtime.capacity.active(now)
+                                || accounts
+                                    .get(&selection.account_id)
+                                    .is_some_and(|selected| selected.capacity.active(now)))
                     })
                 };
                 if preferred_eligible {
@@ -649,6 +721,7 @@ impl Router {
             thread: None,
             account_generation,
             seq,
+            excluded_account: None,
         })
     }
     pub async fn end(&self, account: &str) {
@@ -677,6 +750,17 @@ impl Router {
     pub async fn soft_failure(&self, account: &str) {
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
             a.avoid_until = Some(Instant::now() + Duration::from_secs(5));
+        }
+    }
+    pub async fn capacity_failure(&self, account: &str) {
+        if let Some(runtime) = self.accounts.lock().await.get_mut(account)
+            && let Some(delay) = runtime.capacity.record(Instant::now())
+        {
+            info!(
+                account,
+                backoff_seconds = delay.as_secs(),
+                "upstream capacity backoff for fresh work"
+            );
         }
     }
     pub async fn auth_failure(&self, account: &str) {
@@ -843,6 +927,13 @@ fn account_routing_status(
         usage_percent: runtime.usage,
         inflight: runtime.inflight,
         quota_windows,
+        capacity_backoff_until_unix: runtime.capacity.until.filter(|until| *until > now).map(
+            |until| {
+                wall_now.timestamp()
+                    + i64::try_from(until.saturating_duration_since(now).as_secs())
+                        .unwrap_or(i64::MAX)
+            },
+        ),
     }
 }
 
@@ -1683,6 +1774,192 @@ mod tests {
         let pool = cfg.pools["default"].clone();
         let router = Router::new(&cfg, affinity.clone());
         (cfg, affinity, router, pool)
+    }
+
+    #[test]
+    fn capacity_window_is_bounded_and_backoff_caps_and_decays() {
+        let now = Instant::now();
+        let mut capacity = CapacityBackoff::default();
+        assert_eq!(capacity.record(now), None);
+        assert_eq!(capacity.record(now + Duration::from_secs(1)), None);
+        assert!(!capacity.active(now));
+        // Old observations do not combine with a new burst.
+        let later = now + CAPACITY_REJECTION_WINDOW + Duration::from_secs(1);
+        assert_eq!(capacity.record(later), None);
+        assert_eq!(capacity.record(later), None);
+        assert_eq!(capacity.record(later), Some(Duration::from_secs(60)));
+        assert!(capacity.active(later + Duration::from_secs(59)));
+        assert!(!capacity.active(later + Duration::from_secs(60)));
+
+        for seconds in [120, 240, 480, 600, 600, 600] {
+            let previous = capacity.until;
+            assert_eq!(capacity.record(later), None);
+            assert_eq!(capacity.record(later), None);
+            assert_eq!(capacity.record(later), Some(Duration::from_secs(seconds)));
+            assert!(capacity.until >= previous);
+            assert!(capacity.rejections.is_empty());
+        }
+        let quiet = later + CAPACITY_BACKOFF_DECAY;
+        assert_eq!(capacity.record(quiet), None);
+        assert_eq!(capacity.record(quiet), None);
+        assert_eq!(capacity.record(quiet), Some(Duration::from_secs(60)));
+    }
+
+    #[tokio::test]
+    async fn capacity_backoff_changes_fresh_admissions_but_preserves_owners() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_cfg, affinity, router, pool) = stale_test_router(dir.path());
+        router.set_preferred("default", Some("a".into())).await;
+        let owner_key = affinity.key("warm-owner");
+        assert!(router.bind(owner_key.clone(), "a").await);
+        for _ in 0..CAPACITY_REJECTION_THRESHOLD {
+            router.capacity_failure("a").await;
+        }
+        // A successful warm session does not erase fresh admission pressure.
+        let mut usage = HeaderMap::new();
+        usage.insert(
+            "x-codex-primary-used-percent",
+            HeaderValue::from_static("1"),
+        );
+        router.observe_headers("a", &usage).await;
+        let snapshot = router.routing_snapshot().await;
+        let status = &snapshot.account_states["a"];
+        assert!(status.available);
+        assert!(status.unavailable_reason.is_none());
+        assert!(status.retry_at_unix.is_none());
+        assert!(status.capacity_backoff_until_unix.is_some());
+        assert!(status.quota_windows.is_empty());
+        assert!(router.accounts_needing_login().await.is_empty());
+
+        let owner = router
+            .select("default", &pool, Some(owner_key), None)
+            .await
+            .unwrap();
+        assert!(owner.bound);
+        assert_eq!(owner.account_id, "a");
+        assert!(
+            router
+                .validate_selection(&owner, "default", &pool)
+                .await
+                .is_ok()
+        );
+        let exact = router.select_exact(&pool, "a").await.unwrap();
+        assert!(
+            router
+                .validate_selection(&exact, "default", &pool)
+                .await
+                .is_ok()
+        );
+        assert!(
+            router
+                .validate_account_wirable("a", Some(exact.account_generation))
+                .await
+                .is_ok()
+        );
+
+        let fresh = router
+            .select("default", &pool, Some(affinity.key("new-thread")), None)
+            .await
+            .unwrap();
+        assert_eq!(fresh.account_id, "b");
+        assert!(
+            router
+                .validate_selection(&fresh, "default", &pool)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            router
+                .select_preferred("default", &pool, "a")
+                .await
+                .unwrap()
+                .account_id,
+            "b"
+        );
+
+        // Once the soft deadline elapses, the configured preference applies again.
+        router
+            .accounts
+            .lock()
+            .await
+            .get_mut("a")
+            .unwrap()
+            .capacity
+            .until = Some(Instant::now());
+        assert_eq!(
+            router
+                .select("default", &pool, None, None)
+                .await
+                .unwrap()
+                .account_id,
+            "a"
+        );
+    }
+
+    #[tokio::test]
+    async fn capacity_preference_never_excludes_the_only_eligible_account() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_cfg, _affinity, router, pool) = stale_test_router(dir.path());
+        router.set_preferred("default", Some("a".into())).await;
+        for account in ["a", "b"] {
+            for _ in 0..CAPACITY_REJECTION_THRESHOLD {
+                router.capacity_failure(account).await;
+            }
+        }
+        let fallback = router.select("default", &pool, None, None).await.unwrap();
+        assert_eq!(fallback.account_id, "a");
+        assert!(
+            router
+                .validate_selection(&fallback, "default", &pool)
+                .await
+                .is_ok()
+        );
+
+        // Even a capacity-free sibling cannot suppress A when that sibling is
+        // actually unavailable through quota, auth or a transport failure.
+        router.accounts.lock().await.get_mut("b").unwrap().capacity = CapacityBackoff::default();
+        for failure in ["quota", "auth", "transport"] {
+            router
+                .accounts
+                .lock()
+                .await
+                .insert("b".into(), AccountRuntime::default());
+            match failure {
+                "quota" => router.quota_failure("b", &HeaderMap::new()).await,
+                "auth" => router.reauth_required("b").await,
+                _ => router.soft_failure("b").await,
+            }
+            let fallback = router.select("default", &pool, None, None).await.unwrap();
+            assert_eq!(fallback.account_id, "a", "{failure}");
+            assert!(
+                router
+                    .validate_selection(&fallback, "default", &pool)
+                    .await
+                    .is_ok()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn excluded_preferred_account_cannot_cancel_capacity_failover() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_cfg, _affinity, router, pool) = stale_test_router(dir.path());
+        router.set_preferred("default", Some("a".into())).await;
+        // Before the soft-backoff threshold, an explicit one-turn retry may
+        // already select B. Validation must honor that selection's exclusion.
+        router.capacity_failure("a").await;
+        let alternate = router
+            .select("default", &pool, None, Some("a"))
+            .await
+            .unwrap();
+        assert_eq!(alternate.account_id, "b");
+        assert!(
+            router
+                .validate_selection(&alternate, "default", &pool)
+                .await
+                .is_ok()
+        );
+        assert!(router.select_exact(&pool, "a").await.is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Explicit upstream capacity errors now use a separate routing signal from quota and authentication failures. Repeated capacity rejection temporarily lowers an account's priority for fresh work, while established owners and the last eligible account remain usable.

HTTP, bridge, and direct WebSocket paths share the classification without changing response bodies. Retry remains limited to the existing pre-created, portable-request rules; capacity failures do not establish response affinity or cached continuations.
