### PR TITLE
Keep valid access tokens usable after refresh failure

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     error::Error as StdError,
     fmt, fs,
     io::Write,
@@ -45,6 +45,9 @@ const DEFAULT_OAUTH_EXPIRES_IN_SECONDS: u64 = 60 * 60;
 const MAX_OAUTH_EXPIRES_IN_SECONDS: u64 = 24 * 60 * 60;
 const ACCESS_TOKEN_EXPIRES_AT_KEY: &str = "comradex_access_token_expires_at";
 const REQUEST_AUTH_TIMEOUT: Duration = Duration::from_secs(15);
+// Retain recent rejected generations for already-resolved requests and open sockets. The
+// current rejected bearer has its own slot and cannot be evicted by late failures of old tokens.
+const RECENT_REJECTED_BEARERS_PER_HOME: usize = 16;
 
 type AuthClient = Client<HttpsConnector<HttpConnector>, Full<Bytes>>;
 
@@ -86,6 +89,95 @@ pub struct Resolver {
     client: AuthClient,
     locks: HashMap<PathBuf, Arc<Mutex<()>>>,
     refresh_url: hyper::Uri,
+    pub health: ManagedAuthHealth,
+}
+
+/// Failures belong to the credential that produced them, not to a configured alias. Comparing
+/// fingerprints with the current file also makes an external login supersede an old failure.
+#[derive(Clone, Default)]
+pub struct ManagedAuthHealth {
+    failures: Arc<std::sync::Mutex<HashMap<PathBuf, CredentialFailures>>>,
+}
+
+#[derive(Clone, Default)]
+struct CredentialFailures {
+    refresh_grant: Option<(blake3::Hash, String)>,
+    bearer: Option<blake3::Hash>,
+    recent_bearers: VecDeque<blake3::Hash>,
+}
+
+#[derive(Default)]
+pub struct ManagedAuthStatus {
+    pub reauth_required: bool,
+    pub bearer_unusable: bool,
+}
+
+fn bearer_fingerprint(credentials: &Credentials) -> blake3::Hash {
+    blake3::hash(credentials.authorization.as_bytes())
+}
+
+fn grant_fingerprint(value: &Value) -> Option<blake3::Hash> {
+    lookup(value, &["tokens", "refresh_token"]).map(|token| blake3::hash(token.as_bytes()))
+}
+
+impl ManagedAuthHealth {
+    fn failures(&self, home: &Path) -> CredentialFailures {
+        self.failures
+            .lock()
+            .unwrap()
+            .get(home)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn grant_error(&self, home: &Path, document: &AuthDocument) -> Option<anyhow::Error> {
+        self.failures(home).refresh_grant.and_then(|(grant, code)| {
+            (Some(grant) == grant_fingerprint(&document.value))
+                .then(|| ReauthRequired { code }.into())
+        })
+    }
+
+    fn rejected(&self, home: &Path, credentials: &Credentials) -> bool {
+        let fingerprint = bearer_fingerprint(credentials);
+        self.failures
+            .lock()
+            .unwrap()
+            .get(home)
+            .is_some_and(|failure| {
+                failure.bearer == Some(fingerprint) || failure.recent_bearers.contains(&fingerprint)
+            })
+    }
+
+    #[cfg(test)]
+    pub fn status(&self, home: &Path, now: u64) -> ManagedAuthStatus {
+        let Ok(home) = normalize_codex_home(home) else {
+            return ManagedAuthStatus::default();
+        };
+        self.status_normalized(&home, now)
+    }
+
+    pub fn status_normalized(&self, home: &Path, now: u64) -> ManagedAuthStatus {
+        // Healthy accounts need no filesystem reads on the routing hot path.
+        let failure = self.failures(home);
+        if failure.refresh_grant.is_none()
+            && failure.bearer.is_none()
+            && failure.recent_bearers.is_empty()
+        {
+            return ManagedAuthStatus::default();
+        }
+        let Ok(document) = read_auth(&home.join("auth.json")) else {
+            return ManagedAuthStatus {
+                reauth_required: true,
+                bearer_unusable: true,
+            };
+        };
+        let reauth_required = self.grant_error(home, &document).is_some();
+        ManagedAuthStatus {
+            reauth_required,
+            bearer_unusable: self.rejected(home, &document.credentials)
+                || (reauth_required && !access_token_unexpired_at(&document.value, now)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,6 +244,7 @@ impl Resolver {
             client: Client::builder(TokioExecutor::new()).build(https),
             locks,
             refresh_url: REFRESH_URL.parse().expect("static refresh URL is valid"),
+            health: ManagedAuthHealth::default(),
         }
     }
 
@@ -190,14 +283,30 @@ impl Resolver {
         match account {
             AccountConfig::Inbound => inbound_credentials(inbound),
             AccountConfig::CodexHome { path } => {
+                let path = &normalize_codex_home(path)?;
                 let document = read_auth(&path.join("auth.json"))?;
-                if access_token_needs_refresh(&document.value) {
+                if access_token_needs_refresh(&document.value)
+                    || self.health.rejected(path, &document.credentials)
+                {
                     let lock = self.lock(path)?;
                     let _guard = lock.lock().await;
                     let _home_guard = HomeAuthLock::acquire_async(path).await?;
                     let current = read_auth(&path.join("auth.json"))?;
-                    if access_token_needs_refresh(&current.value) {
-                        return self.refresh(path, current, unix_now()).await;
+                    if access_token_needs_refresh(&current.value)
+                        || self.health.rejected(path, &current.credentials)
+                    {
+                        let fallback = current.credentials.clone();
+                        let expiration = access_token_expiration(&current.value, unix_now());
+                        return match self.refresh(path, current, unix_now()).await {
+                            Err(error)
+                                if is_reauth_required(&error)
+                                    && expiration.is_some_and(|expires| expires > unix_now())
+                                    && !self.health.rejected(path, &fallback) =>
+                            {
+                                Ok(fallback)
+                            }
+                            result => result,
+                        };
                     }
                     return Ok(current.credentials);
                 }
@@ -234,6 +343,9 @@ impl Resolver {
         let AccountConfig::CodexHome { path } = account else {
             return Ok(None);
         };
+        // Endpoint evidence must survive even a timeout waiting for the refresh/login lock.
+        self.reject_bearer(account, previous).await?;
+        let path = &normalize_codex_home(path)?;
         let lock = self.lock(path)?;
         let _guard = lock.lock().await;
         let _home_guard = HomeAuthLock::acquire_async(path).await?;
@@ -241,9 +353,55 @@ impl Resolver {
         if auth_failure_recovery(&current.credentials, previous)
             == AuthFailureRecovery::ReuseCurrent
         {
+            anyhow::ensure!(
+                !self.health.rejected(path, &current.credentials),
+                "current bearer was rejected by upstream"
+            );
             return Ok(Some(current.credentials));
         }
         self.refresh(path, current, unix_now()).await.map(Some)
+    }
+
+    pub async fn reject_bearer(&self, account: &AccountConfig, failed: &Credentials) -> Result<()> {
+        let AccountConfig::CodexHome { path } = account else {
+            return Ok(());
+        };
+        let path = normalize_codex_home(path)?;
+        // This records an observation, without changing auth.json or waiting for its writer.
+        // Serialize the read and fingerprint update against other rejection observations. If a
+        // login replaces the file during this read, the stored old fingerprint cannot match it.
+        let mut failures = self.health.failures.lock().unwrap();
+        let failure = failures.entry(path.clone()).or_default();
+        let fingerprint = bearer_fingerprint(failed);
+        if !failure.recent_bearers.contains(&fingerprint) {
+            failure.recent_bearers.push_back(fingerprint);
+            if failure.recent_bearers.len() > RECENT_REJECTED_BEARERS_PER_HOME {
+                failure.recent_bearers.pop_front();
+            }
+        }
+        let current = read_auth(&path.join("auth.json"))?;
+        if auth_failure_recovery(&current.credentials, failed)
+            == AuthFailureRecovery::RefreshCurrent
+        {
+            failure.bearer = Some(fingerprint);
+        }
+        Ok(())
+    }
+
+    pub fn ensure_bearer_usable(
+        &self,
+        account: &AccountConfig,
+        credentials: &Credentials,
+    ) -> Result<()> {
+        if let AccountConfig::CodexHome { path } = account {
+            anyhow::ensure!(
+                !self
+                    .health
+                    .rejected(&normalize_codex_home(path)?, credentials),
+                "access bearer was rejected by upstream"
+            );
+        }
+        Ok(())
     }
 
     /// Refresh a managed account only when its access-token JWT is within the documented safety
@@ -257,11 +415,17 @@ impl Resolver {
         let AccountConfig::CodexHome { path } = account else {
             return Ok(None);
         };
+        let path = &normalize_codex_home(path)?;
         let lock = self.lock(path)?;
         let _guard = lock.lock().await;
         let _home_guard = HomeAuthLock::acquire_async(path).await?;
         let current = read_auth(&path.join("auth.json"))?;
-        if !access_token_needs_refresh_at(&current.value, now) {
+        if let Some(error) = self.health.grant_error(path, &current) {
+            return Err(error);
+        }
+        if !access_token_needs_refresh_at(&current.value, now)
+            && !self.health.rejected(path, &current.credentials)
+        {
             return Ok(Some(ProactiveRefresh::Fresh));
         }
         self.refresh(path, current, now)
@@ -328,6 +492,9 @@ impl Resolver {
         mut document: AuthDocument,
         now: u64,
     ) -> Result<Credentials> {
+        if let Some(error) = self.health.grant_error(home, &document) {
+            return Err(error);
+        }
         let refresh_token = lookup(&document.value, &["tokens", "refresh_token"])
             .filter(|value| !value.is_empty())
             .context("Codex auth has no refresh token")?
@@ -363,9 +530,20 @@ impl Resolver {
             if status == StatusCode::UNAUTHORIZED
                 || matches!(
                     code,
-                    "refresh_token_expired" | "refresh_token_reused" | "refresh_token_invalidated"
+                    "invalid_grant"
+                        | "refresh_token_expired"
+                        | "refresh_token_reused"
+                        | "refresh_token_invalidated"
                 )
             {
+                self.health
+                    .failures
+                    .lock()
+                    .unwrap()
+                    .entry(home.to_owned())
+                    .or_default()
+                    .refresh_grant =
+                    grant_fingerprint(&document.value).map(|grant| (grant, code.to_owned()));
                 return Err(ReauthRequired {
                     code: code.to_owned(),
                 }
@@ -413,7 +591,12 @@ impl Resolver {
             &home.join("auth.json"),
             &serde_json::to_vec_pretty(&document.value)?,
         )?;
-        credentials_from_value(&document.value)
+        let credentials = credentials_from_value(&document.value)?;
+        anyhow::ensure!(
+            !self.health.rejected(home, &credentials),
+            "OAuth refresh returned a rejected bearer"
+        );
+        Ok(credentials)
     }
 }
 
@@ -483,11 +666,20 @@ fn access_token_needs_refresh(value: &Value) -> bool {
 }
 
 fn access_token_needs_refresh_at(value: &Value, now: u64) -> bool {
+    access_token_expiration(value, now)
+        .is_some_and(|expiration| expiration <= now.saturating_add(REFRESH_WINDOW_SECONDS))
+}
+
+fn access_token_unexpired_at(value: &Value, now: u64) -> bool {
+    access_token_expiration(value, now).is_some_and(|expiration| expiration > now)
+}
+
+fn access_token_expiration(value: &Value, now: u64) -> Option<u64> {
     let token = lookup(value, &["tokens", "access_token"])
         .or_else(|| lookup(value, &["tokens", "accessToken"]));
     let Some(token) = token else {
         // Top-level API keys and legacy non-managed credential shapes are not refresh candidates.
-        return false;
+        return None;
     };
     let jwt_expiration = jwt_expiration(token);
     let fallback_value = value
@@ -501,12 +693,12 @@ fn access_token_needs_refresh_at(value: &Value, now: u64) -> bool {
         (Some(jwt), None) => jwt,
         (None, Some(fallback)) => fallback,
         // A persisted but malformed fallback came from a Comradex refresh and must fail closed.
-        (None, None) if fallback_value.is_some() => return true,
+        (None, None) if fallback_value.is_some() => return Some(0),
         // Preserve compatibility with existing opaque managed credentials. Every successful
         // Comradex refresh writes the bounded fallback, so only legacy/external tokens reach here.
-        (None, None) => return false,
+        (None, None) => return None,
     };
-    expiration <= now.saturating_add(REFRESH_WINDOW_SECONDS)
+    Some(expiration)
 }
 
 fn validated_expires_in(response: &Value) -> u64 {
@@ -580,16 +772,16 @@ fn lookup<'a>(value: &'a Value, path: &[&str]) -> Option<&'a str> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
-    fn jwt(expiration: u64, marker: &str) -> String {
+    pub(crate) fn jwt(expiration: u64, marker: &str) -> String {
         let payload = URL_SAFE_NO_PAD
             .encode(serde_json::to_vec(&json!({ "exp": expiration, "marker": marker })).unwrap());
         format!("e30.{payload}.sig")
     }
 
-    fn write_managed_auth(home: &Path, access_token: &str) {
+    pub(crate) fn write_managed_auth(home: &Path, access_token: &str) {
         fs::create_dir_all(home).unwrap();
         fs::write(
             home.join("auth.json"),
@@ -604,7 +796,7 @@ mod tests {
         .unwrap();
     }
 
-    fn test_resolver(homes: &[&Path], refresh_url: hyper::Uri) -> Resolver {
+    pub(crate) fn test_resolver(homes: &[&Path], refresh_url: hyper::Uri) -> Resolver {
         let https = hyper_rustls::HttpsConnectorBuilder::new()
             .with_webpki_roots()
             .https_or_http()
@@ -623,10 +815,11 @@ mod tests {
             client: Client::builder(TokioExecutor::new()).build(https),
             locks,
             refresh_url,
+            health: ManagedAuthHealth::default(),
         }
     }
 
-    async fn serve_refresh_response(status: &str, body: Value) -> hyper::Uri {
+    pub(crate) async fn serve_refresh_response(status: &str, body: Value) -> hyper::Uri {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1048,5 +1241,274 @@ mod tests {
             lookup(&written, &["tokens", "refresh_token"]),
             Some("replacement-refresh-token")
         );
+    }
+    #[tokio::test]
+    async fn permanent_preflight_failure_keeps_unexpired_bearer_until_exact_expiry() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let token = jwt(now + 60, "usable");
+        write_managed_auth(&home, &token);
+        let resolver = test_resolver(
+            &[&home],
+            serve_refresh_response(
+                "401 Unauthorized",
+                json!({"error": {"code": "refresh_token_expired"}}),
+            )
+            .await,
+        );
+        let account = AccountConfig::CodexHome { path: home.clone() };
+
+        // This is the request-time preflight, not just the scheduler's classifier.
+        let resolved = resolver.resolve(&account, &HeaderMap::new()).await.unwrap();
+        assert_eq!(resolved.authorization, format!("Bearer {token}"));
+        assert!(resolver.health.status(&home, now).reauth_required);
+        assert!(!resolver.health.status(&home, now + 59).bearer_unusable);
+        assert!(resolver.health.status(&home, now + 60).bearer_unusable);
+        // The one-shot OAuth server is gone. A repeated resolve must reuse the still-valid bearer.
+        assert_eq!(
+            resolver
+                .resolve(&account, &HeaderMap::new())
+                .await
+                .unwrap()
+                .authorization,
+            resolved.authorization
+        );
+        assert!(is_reauth_required(
+            &resolver
+                .proactive_refresh_at(&account, now)
+                .await
+                .unwrap_err()
+        ));
+
+        write_managed_auth(&home, &jwt(now - 1, "expired"));
+        assert!(is_reauth_required(
+            &resolver
+                .resolve(&account, &HeaderMap::new())
+                .await
+                .unwrap_err()
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_forced_refresh_quarantines_bearer_and_replacement_supersedes_failure() {
+        for status in ["401 Unauthorized", "503 Service Unavailable"] {
+            let now = unix_now();
+            let directory = tempfile::tempdir().unwrap();
+            let home = directory.path().join("managed");
+            let token = jwt(now + 3_600, "rejected");
+            write_managed_auth(&home, &token);
+            let resolver = test_resolver(
+                &[&home],
+                serve_refresh_response(status, json!({"error": {"code": "test_failure"}})).await,
+            );
+            let account = AccountConfig::CodexHome { path: home.clone() };
+            let failed = credentials(&token);
+            assert!(resolver.force_refresh(&account, &failed).await.is_err());
+            assert!(resolver.health.status(&home, now).bearer_unusable);
+            assert!(resolver.resolve(&account, &HeaderMap::new()).await.is_err());
+
+            let replacement = jwt(now + 7_200, "new-login");
+            write_managed_auth(&home, &replacement);
+            let mut value = read_auth(&home.join("auth.json")).unwrap().value;
+            value["tokens"]["refresh_token"] = json!("replacement-grant");
+            atomic_write_auth(
+                &home.join("auth.json"),
+                &serde_json::to_vec(&value).unwrap(),
+            )
+            .unwrap();
+            // A late terminal path after that login must not disable the new credential.
+            resolver.reject_bearer(&account, &failed).await.unwrap();
+            let health = resolver.health.status(&home, now);
+            assert!(!health.bearer_unusable);
+            assert!(!health.reauth_required);
+            assert_eq!(
+                resolver
+                    .force_refresh(&account, &failed)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .authorization,
+                format!("Bearer {replacement}")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn forced_refresh_timeout_keeps_exact_bearer_quarantined() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let token = jwt(now + 3_600, "rejected");
+        write_managed_auth(&home, &token);
+        let resolver = test_resolver(&[&home], serve_paused_refresh_response().await);
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                resolver.force_refresh_unbounded(&account, &credentials(&token))
+            )
+            .await
+            .is_err()
+        );
+        assert!(resolver.health.status(&home, now).bearer_unusable);
+        assert!(HomeAuthLock::try_acquire(&home).unwrap().is_some());
+        assert!(resolver.lock(&home).unwrap().try_lock().is_ok());
+    }
+
+    #[tokio::test]
+    async fn forced_refresh_reuses_login_that_won_the_home_lock() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let token = jwt(now + 3_600, "old");
+        write_managed_auth(&home, &token);
+        let resolver = test_resolver(
+            &[&home],
+            serve_refresh_response(
+                "401 Unauthorized",
+                json!({"error": "refresh_token_expired"}),
+            )
+            .await,
+        );
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        // Login owns the same cross-process lock the force-refresh path must acquire.
+        let login_guard = HomeAuthLock::acquire(&home).unwrap();
+        let recovery = {
+            let resolver = resolver.clone();
+            let account = account.clone();
+            let failed = credentials(&token);
+            tokio::spawn(async move { resolver.force_refresh(&account, &failed).await })
+        };
+        let mut recovery = Box::pin(recovery);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut recovery)
+                .await
+                .is_err()
+        );
+        let replacement = jwt(now + 7_200, "replacement");
+        write_managed_auth(&home, &replacement);
+        drop(login_guard);
+        let result = recovery.await.unwrap().unwrap().unwrap();
+        assert_eq!(result.authorization, format!("Bearer {replacement}"));
+        assert!(!resolver.health.status(&home, now).bearer_unusable);
+        assert!(!resolver.health.status(&home, now).reauth_required);
+    }
+    #[tokio::test]
+    async fn login_after_failed_forced_exchange_is_not_disabled_by_late_failure_handling() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let token = jwt(now + 3_600, "old");
+        write_managed_auth(&home, &token);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let oauth = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            assert!(stream.read(&mut request).await.unwrap() > 0);
+            started_tx.send(()).unwrap();
+            finish_rx.await.unwrap();
+            let body = br#"{"error":"invalid_grant"}"#;
+            stream.write_all(format!("HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\nConnection: close\r\n\r\n", body.len()).as_bytes()).await.unwrap();
+            stream.write_all(body).await.unwrap();
+        });
+        let resolver = test_resolver(
+            &[&home],
+            format!("http://{address}/oauth/token").parse().unwrap(),
+        );
+        let account = AccountConfig::CodexHome { path: home.clone() };
+        let failed = credentials(&token);
+        let recovery = {
+            let resolver = resolver.clone();
+            let account = account.clone();
+            let failed = failed.clone();
+            tokio::spawn(async move { resolver.force_refresh(&account, &failed).await })
+        };
+        started_rx.await.unwrap();
+        let login = {
+            let home = home.clone();
+            tokio::spawn(async move {
+                let _guard = HomeAuthLock::acquire_async(&home).await.unwrap();
+                atomic_write_auth(
+                    &home.join("auth.json"),
+                    &serde_json::to_vec(&json!({"tokens": {
+                        "access_token": jwt(now + 7200, "new-login"), "refresh_token": "new-grant"
+                    }}))
+                    .unwrap(),
+                )
+                .unwrap();
+            })
+        };
+        let mut login = Box::pin(login);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut login)
+                .await
+                .is_err()
+        );
+        finish_tx.send(()).unwrap();
+        assert!(is_reauth_required(&recovery.await.unwrap().unwrap_err()));
+        login.await.unwrap();
+        oauth.await.unwrap();
+        resolver.reject_bearer(&account, &failed).await.unwrap();
+        let health = resolver.health.status(&home, now);
+        assert!(!health.bearer_unusable);
+        assert!(!health.reauth_required);
+        assert_eq!(
+            resolver
+                .resolve(&account, &HeaderMap::new())
+                .await
+                .unwrap()
+                .authorization,
+            format!("Bearer {}", jwt(now + 7200, "new-login"))
+        );
+    }
+    #[tokio::test]
+    async fn forced_refresh_lock_timeout_quarantines_without_waiting_on_login() {
+        let now = unix_now();
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("managed");
+        let token = jwt(now + 3_600, "rejected");
+        write_managed_auth(&home, &token);
+        let resolver = test_resolver(&[&home], "http://127.0.0.1:9/oauth/token".parse().unwrap());
+        let account = AccountConfig::CodexHome {
+            path: home.join("."),
+        };
+        let failed = credentials(&token);
+        let login_guard = HomeAuthLock::acquire(&home).unwrap();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                resolver.force_refresh_unbounded(&account, &failed)
+            )
+            .await
+            .is_err()
+        );
+        assert!(resolver.health.status(&home, now).bearer_unusable);
+        // The terminal rejection path cannot depend on that same still-held home lock.
+        tokio::time::timeout(
+            Duration::from_millis(50),
+            resolver.reject_bearer(&account, &failed),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let replacement = jwt(now + 7200, "replacement");
+        write_managed_auth(&home, &replacement);
+        assert!(!resolver.health.status(&home, now).bearer_unusable);
+        let replacement = credentials(&replacement);
+        resolver
+            .reject_bearer(&account, &replacement)
+            .await
+            .unwrap();
+        resolver.reject_bearer(&account, &failed).await.unwrap();
+        assert!(
+            resolver.health.status(&home, now).bearer_unusable,
+            "late old rejection must not overwrite quarantine of a newer rejected bearer"
+        );
+        drop(login_guard);
     }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -103,6 +103,8 @@ pub struct UiStatus {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UiAccountStatus {
+    #[serde(default)]
+    pub reauth_required: bool,
     pub name: String,
     pub kind: UiAccountKind,
     pub signed_in: bool,
@@ -816,6 +818,10 @@ async fn build_ui_status(
                 ),
             };
             UiAccountStatus {
+                reauth_required: routing
+                    .account_states
+                    .get(name)
+                    .is_some_and(|state| state.reauth_required),
                 name: name.clone(),
                 kind,
                 signed_in,
@@ -1296,6 +1302,45 @@ path = "accounts/work"
                 .await
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn ui_status_keeps_valid_bearer_signed_in_while_renewal_needs_login() {
+        use crate::auth::tests::{jwt, serve_refresh_response, test_resolver, write_managed_auth};
+        let (_dir, config, router) = managed_login_fixture();
+        let home = managed_account_home(&config, "work").unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        write_managed_auth(home, &jwt(now + 120, "valid"));
+        let mut resolver = test_resolver(
+            &[home],
+            serve_refresh_response(
+                "401 Unauthorized",
+                serde_json::json!({"error": "refresh_token_expired"}),
+            )
+            .await,
+        );
+        resolver.health = router.auth_health.clone();
+        assert!(
+            resolver
+                .proactive_refresh_at(&config.accounts["work"], now)
+                .await
+                .is_err()
+        );
+        let manager = LoginManager::new(Arc::new(SystemLoginRunner), router.clone());
+        let status = build_ui_status(&config, &router, &Stats::default(), &manager).await;
+        let work = status
+            .accounts
+            .iter()
+            .find(|account| account.name == "work")
+            .unwrap();
+        assert!(work.signed_in);
+        assert_eq!(work.auth_state, UiAccountAuthState::SignedIn);
+        assert!(work.available);
+        assert!(work.reauth_required);
+        assert!(work.unavailable_reason.is_none());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -613,7 +613,11 @@ fn stderr_timestamp_suffix(timestamp: Option<u64>) -> String {
 
 fn account_availability(status: &comradex::routing::AccountRoutingStatus) -> String {
     if status.available {
-        return String::new();
+        return if status.reauth_required {
+            "; sign-in needed for renewal (current access still usable)".to_owned()
+        } else {
+            String::new()
+        };
     }
     let reason = match status
         .unavailable_reason
@@ -624,6 +628,7 @@ fn account_availability(status: &comradex::routing::AccountRoutingStatus) -> Str
         "temporary_failure" => "temporarily unavailable",
         "login_in_progress" => "login in progress",
         "needs_login" => "sign-in required",
+        "access_token_rejected" => "access token rejected",
         reason => reason,
     };
     let retry = status.retry_at_unix.and_then(|deadline| {
@@ -908,6 +913,19 @@ fn state_dir(config: &Config) -> PathBuf {
 mod tests {
     use super::*;
     use std::ffi::OsString;
+
+    #[test]
+    fn available_bearer_reports_renewal_login_separately() {
+        let status = comradex::routing::AccountRoutingStatus {
+            available: true,
+            reauth_required: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            account_availability(&status),
+            "; sign-in needed for renewal (current access still usable)"
+        );
+    }
 
     #[test]
     fn managed_login_holds_auth_lock_for_entire_child_action() {

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -138,6 +138,7 @@ impl App {
         for attempt in 0..2 {
             let response = self
                 .send_http(
+                    &owner.alias,
                     &Method::POST,
                     path,
                     headers,
@@ -145,21 +146,25 @@ impl App {
                     bytes_body(bytes.clone()),
                 )
                 .await?;
-            if response.status() == StatusCode::UNAUTHORIZED
-                && attempt == 0
-                && let Some(refreshed) = self
-                    .auth
-                    .force_refresh(&self.config.accounts[&owner.alias], &credentials)
-                    .await?
-            {
-                anyhow::ensure!(
-                    self.context_store
-                        .physical_key(&refreshed.context_identity()?)
-                        == owner.physical_id,
-                    "context owner unavailable"
-                );
-                credentials = refreshed;
-                continue;
+            if response.status() == StatusCode::UNAUTHORIZED {
+                if attempt == 0
+                    && let Some(refreshed) = self
+                        .auth
+                        .force_refresh(&self.config.accounts[&owner.alias], &credentials)
+                        .await?
+                {
+                    anyhow::ensure!(
+                        self.context_store
+                            .physical_key(&refreshed.context_identity()?)
+                            == owner.physical_id,
+                        "context owner unavailable"
+                    );
+                    credentials = refreshed;
+                    continue;
+                }
+                self.auth
+                    .reject_bearer(&self.config.accounts[&owner.alias], &credentials)
+                    .await?;
             }
             return Ok(response);
         }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -734,6 +734,8 @@ impl App {
             &config.proxy.affinity_key,
             Duration::from_secs(config.proxy.affinity_idle_days * 86_400),
         )?);
+        let mut auth = auth::Resolver::new(&config);
+        auth.health = router.auth_health.clone();
         Ok(Arc::new(Self {
             http_slots: Arc::new(Semaphore::new(config.proxy.max_inflight)),
             bridge_turn_slots: Arc::new(Semaphore::new(config.proxy.max_inflight)),
@@ -755,7 +757,7 @@ impl App {
                     .unwrap_or_else(|| ".".into())
                     .join("live-calls.json"),
             ),
-            auth: auth::Resolver::new(&config),
+            auth,
             file_owners,
             context_store: context_store::ContextStore::open(
                 &state_dir.join("context.sqlite3"),
@@ -793,15 +795,13 @@ impl App {
             .fetch_add(results.len() as u64, Ordering::Relaxed);
         for (account_id, result) in results {
             match result {
-                Ok(auth::ProactiveRefresh::Fresh) => {
-                    self.router.proactive_auth_ready(&account_id).await;
-                }
+                Ok(auth::ProactiveRefresh::Fresh) => {}
                 Ok(auth::ProactiveRefresh::Refreshed) => {
                     self.stats.refresh_successes.fetch_add(1, Ordering::Relaxed);
                     self.stats
                         .refresh_last_success_unix
                         .store(now, Ordering::Relaxed);
-                    self.router.proactive_auth_ready(&account_id).await;
+
                     info!(account = account_id, "managed credential refreshed");
                 }
                 Err(error) => {
@@ -810,7 +810,7 @@ impl App {
                         self.stats
                             .refresh_reauth_required
                             .fetch_add(1, Ordering::Relaxed);
-                        self.router.reauth_required(&account_id).await;
+
                         warn!(
                             account = account_id,
                             "managed credential requires device login"
@@ -818,6 +818,17 @@ impl App {
                     } else {
                         warn!(account = account_id, %error, "proactive credential refresh failed");
                     }
+                }
+            }
+        }
+    }
+
+    async fn reject_account_bearer(&self, account: &str, credentials: &Credentials) {
+        match &self.config.accounts[account] {
+            crate::config::AccountConfig::Inbound => self.router.auth_failure(account).await,
+            managed => {
+                if let Err(error) = self.auth.reject_bearer(managed, credentials).await {
+                    warn!(account, %error, "could not record rejected managed bearer");
                 }
             }
         }
@@ -1358,7 +1369,14 @@ impl App {
                 DirectAccountLease::new_for_selection(self.router.clone(), &selected);
             let (body, upload_progress) = progress_body(replay.body(attempt)?);
             let result = await_upstream_headers(
-                self.send_http(&method, &path, &inbound_headers, credentials.clone(), body),
+                self.send_http(
+                    &account,
+                    &method,
+                    &path,
+                    &inbound_headers,
+                    credentials.clone(),
+                    body,
+                ),
                 upload_progress,
                 HTTP_UPSTREAM_UPLOAD_IDLE_TIMEOUT,
                 HTTP_UPSTREAM_HEADERS_TIMEOUT,
@@ -1453,7 +1471,7 @@ impl App {
                             self.config.accounts[&account],
                             crate::config::AccountConfig::CodexHome { .. }
                         ) {
-                            self.router.auth_failure(&account).await;
+                            self.reject_account_bearer(&account, &credentials).await;
                         }
                         request_lease.disarm();
                         return Ok(map_http_response_leased(
@@ -1583,6 +1601,7 @@ impl App {
 
     async fn send_http(
         &self,
+        account: &str,
         method: &Method,
         path: &str,
         inbound: &hyper::HeaderMap,
@@ -1599,6 +1618,8 @@ impl App {
         headers::strip_hop_by_hop(headers);
         headers.remove(CONTENT_LENGTH);
         let _ = inbound;
+        self.auth
+            .ensure_bearer_usable(&self.config.accounts[account], &credentials)?;
         apply_credentials(headers, credentials)?;
         Ok(self.client.request(builder.body(body)?).await?)
     }
@@ -2377,6 +2398,13 @@ impl App {
             normalize_websocket_beta(upstream_req.headers_mut(), path);
             apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
             self.router.begin(account).await;
+            if let Err(error) = self
+                .auth
+                .ensure_bearer_usable(&self.config.accounts[account], &credentials)
+            {
+                self.router.end(account).await;
+                return Err(error);
+            }
             let connect_deadline = tokio::time::Instant::now() + connect_timeout;
             let mut response = match tokio::time::timeout_at(
                 connect_deadline,
@@ -2474,7 +2502,7 @@ impl App {
                     crate::config::AccountConfig::CodexHome { .. }
                 )
             {
-                self.router.auth_failure(account).await;
+                self.reject_account_bearer(account, &credentials).await;
             }
             anyhow::bail!("upstream WebSocket handshake failed with {status}")
         }
@@ -2612,7 +2640,9 @@ impl App {
                                     continue;
                                 }
                             };
-                            if protocol.pending_len() > 0 && route.account_id != account {
+                            let rejected_socket = self.auth.ensure_bearer_usable(
+                                &self.config.accounts[&account], &upstream_credentials).is_err();
+                            if protocol.pending_len() > 0 && (route.account_id != account || rejected_socket) {
                                 send_direct_error(
                                     &mut client,
                                     "continuity_owner_conflict",
@@ -2621,7 +2651,7 @@ impl App {
                                 .await?;
                                 continue;
                             }
-                            if protocol.pending_len() == 0 && route.account_id != account {
+                            if protocol.pending_len() == 0 && (route.account_id != account || rejected_socket) {
                                 let clear_session = route.account_id != account;
                                 let replacement = match self
                                     .connect_direct_upstream_with_selection(
@@ -2677,6 +2707,7 @@ impl App {
                                 }
                             };
                             self.record_context_dispatch(&value, &listener.pool, &account, &upstream_credentials).await?;
+                            self.auth.ensure_bearer_usable(&self.config.accounts[&account], &upstream_credentials)?;
                             upstream.send(client_message.clone()).await?;
                             if analysis.has_nonportable_state {
                                 route.hard_owner = true;
@@ -2811,7 +2842,7 @@ impl App {
                                         self.router.capacity_failure(&account).await;
                                     }
                                     FailureKind::Authentication { .. } => {
-                                        self.router.auth_failure(&account).await;
+                                        self.reject_account_bearer(&account, &upstream_credentials).await;
                                     }
                                     FailureKind::Transient => {
                                         self.router.soft_failure(&account).await;
@@ -3008,6 +3039,12 @@ impl App {
                     .await;
             }
             FailureKind::Capacity => self.router.capacity_failure(account).await,
+            FailureKind::Authentication { .. } => {
+                // Rejection evidence applies even when ownership or replay gates forbid recovery.
+                self.auth
+                    .reject_bearer(&self.config.accounts[account], failed_credentials)
+                    .await?;
+            }
             FailureKind::Transient => self.router.soft_failure(account).await,
             _ => {}
         }
@@ -3023,7 +3060,8 @@ impl App {
             Ok(plan) => plan,
             Err(_) => {
                 if matches!(failure, FailureKind::Authentication { .. }) {
-                    self.router.auth_failure(account).await;
+                    self.reject_account_bearer(account, failed_credentials)
+                        .await;
                 }
                 return Ok(None);
             }
@@ -3075,7 +3113,8 @@ impl App {
         }
         if plan.target == ReplayTarget::AlternateAccount || replacement_account.is_empty() {
             if matches!(failure, FailureKind::Authentication { .. }) {
-                self.router.auth_failure(account).await;
+                self.reject_account_bearer(account, failed_credentials)
+                    .await;
             }
             if turn_hard_owner && plan.mode == ReplayMode::OriginalRequest {
                 return Ok(None);
@@ -3170,6 +3209,10 @@ impl App {
             &replacement.credentials,
         )
         .await?;
+        self.auth.ensure_bearer_usable(
+            &self.config.accounts[&replacement_account],
+            &replacement.credentials,
+        )?;
         if let Err(error) = replacement.socket.send(replay_message.clone()).await {
             warn!(%error, account = replacement_account, "safe direct replay send failed");
             return Ok(None);
@@ -3533,6 +3576,13 @@ impl App {
             normalize_websocket_beta(upstream_req.headers_mut(), &path);
             apply_credentials(upstream_req.headers_mut(), credentials.clone())?;
             self.router.begin(&selection.account_id).await;
+            if let Err(error) = self
+                .auth
+                .ensure_bearer_usable(&self.config.accounts[&selection.account_id], &credentials)
+            {
+                self.router.end(&selection.account_id).await;
+                return Err(error);
+            }
             let mut response = match self.upgrade_client.request(upstream_req).await {
                 Ok(response) => response,
                 Err(error) => {
@@ -3673,15 +3723,18 @@ impl App {
                         }
                     }
                     Ok(None) => {
-                        self.router.auth_failure(&selection.account_id).await;
+                        self.reject_account_bearer(&selection.account_id, &credentials)
+                            .await;
                     }
                     Err(error) => {
                         warn!(account = selection.account_id, %error, "websocket credential refresh failed");
-                        self.router.auth_failure(&selection.account_id).await;
+                        self.reject_account_bearer(&selection.account_id, &credentials)
+                            .await;
                     }
                 }
             } else if !capacity && response.status() == StatusCode::UNAUTHORIZED {
-                self.router.auth_failure(&selection.account_id).await;
+                self.reject_account_bearer(&selection.account_id, &credentials)
+                    .await;
             }
             let retry = is_quota_status(response.status())
                 || is_selected_gateway_failure(response.status());
@@ -3723,7 +3776,8 @@ impl App {
                     crate::config::AccountConfig::CodexHome { .. }
                 )
             {
-                self.router.auth_failure(&selection.account_id).await;
+                self.reject_account_bearer(&selection.account_id, &credentials)
+                    .await;
             }
             return Ok(response);
         }
@@ -7209,6 +7263,187 @@ mod tests {
         assert!(!route.hard_owner);
     }
 
+    fn managed_direct_test_app(
+        dir: &std::path::Path,
+        home: &std::path::Path,
+    ) -> (Arc<App>, ListenerConfig, Arc<Router>) {
+        let (template, listener, _, _) = direct_test_app(dir);
+        let mut config = (*template.config).clone();
+        config.accounts.insert(
+            "a".into(),
+            AccountConfig::CodexHome {
+                path: home.to_owned(),
+            },
+        );
+        let config = Arc::new(config);
+        let router = Arc::new(Router::new(&config, template.router.affinity.clone()));
+        let app = App::new_unvalidated(config, router.clone(), Arc::new(Stats::default())).unwrap();
+        (app, listener, router)
+    }
+
+    #[tokio::test]
+    async fn direct_hard_owner_authentication_error_quarantines_without_owner_migration() {
+        use crate::auth::tests::{jwt, write_managed_auth};
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("managed");
+        let now = chrono::Utc::now().timestamp() as u64;
+        write_managed_auth(&home, &jwt(now + 3600, "rejected"));
+        let (app, listener, router) = managed_direct_test_app(dir.path(), &home);
+        let owner = router.affinity.key("turn-state:owned");
+        assert!(router.bind(owner.clone(), "a").await);
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("x-codex-turn-state", "owned".parse().unwrap());
+        let value = serde_json::json!({"type":"response.create","input":[]});
+        let replay = ReplayBody::from_bytes(
+            Bytes::from(value.to_string()),
+            app.config.proxy.max_request_bytes,
+            app.config.proxy.max_spool_bytes,
+            app.stats.clone(),
+        )
+        .unwrap();
+        let route = app
+            .route_websocket_frame(&listener, &headers, &replay, Some("a"))
+            .await
+            .unwrap();
+        assert!(route.hard_owner && route.non_previous_hard_owner);
+        let credentials = app
+            .auth
+            .resolve(&app.config.accounts["a"], &headers)
+            .await
+            .unwrap();
+        let mut protocol = ProtocolState::new(ProtocolLimits::default()).unwrap();
+        let turn_id = protocol.admit_response_create(&value).unwrap();
+        let mut turns = HashMap::from([(
+            turn_id,
+            DirectTurn {
+                route,
+                request: Message::Text(value.to_string().into()),
+                routing_value: value.clone(),
+                value,
+            },
+        )]);
+        let failure =
+            websocket_protocol::classify_failure(&serde_json::json!({"type":"error", "error": {
+                "type":"authentication_error", "message":"Please sign in again"
+            }}));
+        assert!(matches!(
+            failure.kind,
+            FailureKind::Authentication {
+                requires_reauthentication: true
+            }
+        ));
+        let replayed = app
+            .try_replay_direct_turn(
+                &mut protocol,
+                &mut turns,
+                turn_id,
+                failure.kind,
+                ReplayContext::default(),
+                &listener,
+                "/v1/responses",
+                &headers,
+                "a",
+                &credentials,
+            )
+            .await
+            .unwrap();
+        assert!(replayed.is_none());
+        assert_eq!(turns[&turn_id].route.account_id, "a");
+        assert_eq!(router.affinity.get(&owner).await.unwrap().account_id, "a");
+        assert!(
+            router
+                .select_exact(&app.config.pools["default"], "a")
+                .await
+                .is_none()
+        );
+        assert!(
+            app.auth
+                .ensure_bearer_usable(&app.config.accounts["a"], &credentials)
+                .is_err()
+        );
+        assert_eq!(
+            router
+                .select("default", &app.config.pools["default"], None, None)
+                .await
+                .unwrap()
+                .account_id,
+            "b"
+        );
+    }
+
+    #[tokio::test]
+    async fn managed_transient_forced_refresh_failure_recovers_on_later_sweep() {
+        use crate::auth::tests::{jwt, serve_refresh_response, test_resolver, write_managed_auth};
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("managed");
+        let now = chrono::Utc::now().timestamp() as u64;
+        write_managed_auth(&home, &jwt(now + 3600, "rejected"));
+        let (mut app, _, router) = managed_direct_test_app(dir.path(), &home);
+        let mut resolver = test_resolver(
+            &[&home],
+            serve_refresh_response(
+                "503 Service Unavailable",
+                serde_json::json!({"error":"temporarily_unavailable"}),
+            )
+            .await,
+        );
+        resolver.health = router.auth_health.clone();
+        Arc::get_mut(&mut app).unwrap().auth = resolver;
+        let failed = app
+            .auth
+            .resolve(&app.config.accounts["a"], &hyper::HeaderMap::new())
+            .await
+            .unwrap();
+        assert!(
+            app.auth
+                .force_refresh(&app.config.accounts["a"], &failed)
+                .await
+                .is_err()
+        );
+        let state = router.routing_snapshot().await.account_states["a"].clone();
+        assert!(!state.available);
+        assert!(!state.reauth_required);
+        assert_eq!(
+            state.unavailable_reason.as_deref(),
+            Some("access_token_rejected")
+        );
+        let replacement = jwt(now + 7200, "refreshed");
+        let mut resolver = test_resolver(
+            &[&home],
+            serve_refresh_response(
+                "200 OK",
+                serde_json::json!({"access_token": replacement, "refresh_token": "new-grant"}),
+            )
+            .await,
+        );
+        resolver.health = router.auth_health.clone();
+        Arc::get_mut(&mut app).unwrap().auth = resolver;
+        app.refresh_managed_accounts_at(now).await;
+        assert_eq!(app.stats.refresh_successes.load(Ordering::Relaxed), 1);
+        let state = router.routing_snapshot().await.account_states["a"].clone();
+        assert!(state.available);
+        assert!(!state.reauth_required);
+        assert!(
+            router
+                .select_exact(&app.config.pools["default"], "a")
+                .await
+                .is_some()
+        );
+        assert_eq!(
+            app.auth
+                .resolve(&app.config.accounts["a"], &hyper::HeaderMap::new())
+                .await
+                .unwrap()
+                .authorization,
+            format!("Bearer {replacement}")
+        );
+        assert!(
+            app.auth
+                .ensure_bearer_usable(&app.config.accounts["a"], &failed)
+                .is_err()
+        );
+    }
+
     #[tokio::test]
     async fn direct_hard_owner_quota_marks_account_without_cross_account_replay() {
         let dir = tempfile::tempdir().unwrap();
@@ -8707,6 +8942,181 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
             *seen.lock().unwrap(),
             ["Bearer stale-token", "Bearer fresh-token"]
         );
+        proxy_task.abort();
+        upstream_task.abort();
+    }
+
+    #[tokio::test]
+    async fn managed_preflight_failure_routes_valid_bearer_then_quarantines_real_401() {
+        use crate::auth::tests::{jwt, serve_refresh_response, test_resolver, write_managed_auth};
+        let dir = tempfile::tempdir().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let home = dir.path().join("managed");
+        write_managed_auth(&home, &jwt(now + 120, "valid"));
+        let reject = Arc::new(AtomicBool::new(false));
+        let seen = Arc::new(AtomicU64::new(0));
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        let upstream_task = {
+            let reject = reject.clone();
+            let seen = seen.clone();
+            tokio::spawn(async move {
+                loop {
+                    let (stream, _) = upstream.accept().await.unwrap();
+                    let reject = reject.clone();
+                    let seen = seen.clone();
+                    tokio::spawn(async move {
+                        let service = service_fn(move |_request: Request<Incoming>| {
+                            seen.fetch_add(1, Ordering::Relaxed);
+                            let status = if reject.load(Ordering::Relaxed) {
+                                StatusCode::UNAUTHORIZED
+                            } else {
+                                StatusCode::OK
+                            };
+                            async move {
+                                Ok::<_, Infallible>(
+                                    Response::builder()
+                                        .status(status)
+                                        .body(Full::new(Bytes::from_static(b"{}")))
+                                        .unwrap(),
+                                )
+                            }
+                        });
+                        let _ = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(TokioIo::new(stream), service)
+                            .await;
+                    });
+                }
+            })
+        };
+        let (template, mut listener, _, _) = direct_test_app_with_upstream(
+            dir.path(),
+            format!("http://{upstream_addr}/backend-api/codex"),
+        );
+        let mut config = (*template.config).clone();
+        config.accounts =
+            BTreeMap::from([("a".into(), AccountConfig::CodexHome { path: home.clone() })]);
+        config.pools.get_mut("default").unwrap().members = vec!["a".into()];
+        let config = Arc::new(config);
+        let router = Arc::new(Router::new(&config, template.router.affinity.clone()));
+        let mut app =
+            App::new_unvalidated(config.clone(), router.clone(), Arc::new(Stats::default()))
+                .unwrap();
+        let mut resolver = test_resolver(
+            &[&home],
+            serve_refresh_response(
+                "401 Unauthorized",
+                serde_json::json!({"error": "refresh_token_expired"}),
+            )
+            .await,
+        );
+        resolver.health = router.auth_health.clone();
+        Arc::get_mut(&mut app).unwrap().auth = resolver;
+        let key = router.affinity.key("owned-thread");
+        assert!(router.bind(key.clone(), "a").await);
+        let proxy_tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = proxy_tcp.local_addr().unwrap();
+        listener.address = address;
+        let proxy_task = tokio::spawn(app.clone().serve_tcp("default".into(), listener, proxy_tcp));
+        let client = reqwest::Client::new();
+        let url = format!("http://{address}/0123456789abcdef/v1/models");
+
+        // The OAuth preflight really fails, while the bearer succeeds at the product endpoint.
+        assert_eq!(
+            client.get(&url).send().await.unwrap().status(),
+            StatusCode::OK
+        );
+        app.refresh_managed_accounts_at(now).await;
+        let snapshot = router.routing_snapshot().await;
+        assert!(snapshot.account_states["a"].available);
+        assert!(snapshot.account_states["a"].reauth_required);
+        assert!(!router.accounts_needing_login().await.contains("a"));
+        let selected = router
+            .select_exact(&config.pools["default"], "a")
+            .await
+            .unwrap();
+        assert!(
+            router
+                .validate_selection(&selected, "default", &config.pools["default"])
+                .await
+                .is_ok()
+        );
+        assert!(
+            router
+                .context_account_available(&config.pools["default"], "a")
+                .await
+        );
+
+        reject.store(true, Ordering::Relaxed);
+        assert_eq!(
+            client.get(&url).send().await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert!(!router.routing_snapshot().await.account_states["a"].available);
+        assert!(
+            router
+                .select_exact(&config.pools["default"], "a")
+                .await
+                .is_none()
+        );
+        assert!(
+            router
+                .validate_selection(&selected, "default", &config.pools["default"])
+                .await
+                .is_err()
+        );
+        assert!(
+            !router
+                .context_account_available(&config.pools["default"], "a")
+                .await
+        );
+        assert_eq!(
+            client.get(&url).send().await.unwrap().status(),
+            StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(seen.load(Ordering::Relaxed), 2);
+        assert_eq!(router.affinity.get(&key).await.unwrap().account_id, "a");
+
+        // A replacement login recovers immediately; a stale terminal rejection cannot disable it.
+        let old = crate::auth::Credentials {
+            authorization: format!("Bearer {}", jwt(now + 120, "valid")),
+            account_id: None,
+        };
+        fs::write(
+            home.join("auth.json"),
+            serde_json::to_vec(&serde_json::json!({"tokens": {
+                "access_token": jwt(now + 3600, "replacement"), "refresh_token": "new-grant"
+            }}))
+            .unwrap(),
+        )
+        .unwrap();
+        app.reject_account_bearer("a", &old).await;
+        let snapshot = router.routing_snapshot().await;
+        assert!(snapshot.account_states["a"].available);
+        assert!(!snapshot.account_states["a"].reauth_required);
+        assert!(
+            app.send_http(
+                "a",
+                &Method::GET,
+                "/v1/models",
+                &hyper::HeaderMap::new(),
+                old,
+                empty_body()
+            )
+            .await
+            .is_err(),
+            "an already-resolved rejected bearer must not reach upstream after login"
+        );
+        assert_eq!(seen.load(Ordering::Relaxed), 2);
+        reject.store(false, Ordering::Relaxed);
+        assert_eq!(
+            client.get(&url).send().await.unwrap().status(),
+            StatusCode::OK
+        );
+        assert_eq!(seen.load(Ordering::Relaxed), 3);
         proxy_task.abort();
         upstream_task.abort();
     }

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -13,7 +13,8 @@ use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::{
-    config::{Config, PoolConfig},
+    auth::{ManagedAuthHealth, ManagedAuthStatus},
+    config::{AccountConfig, Config, PoolConfig, normalize_codex_home},
     routing::{AffinityStore, ThreadKey},
 };
 
@@ -85,6 +86,8 @@ pub struct RoutingSnapshot {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountRoutingStatus {
+    #[serde(default)]
+    pub reauth_required: bool,
     pub available: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unavailable_reason: Option<String>,
@@ -110,6 +113,8 @@ pub struct QuotaWindowStatus {
 
 #[derive(Debug, Default)]
 struct AccountRuntime {
+    reauth_required: bool,
+    bearer_unusable: bool,
     usage: Option<u8>,
     inflight: u64,
     last_assigned: u64,
@@ -188,6 +193,8 @@ struct WindowEvidence {
 type QuotaEvidence = HashMap<QuotaWindow, WindowEvidence>;
 
 pub struct Router {
+    pub auth_health: ManagedAuthHealth,
+    managed_homes: HashMap<String, std::path::PathBuf>,
     pub affinity: Arc<AffinityStore>,
     accounts: Mutex<HashMap<String, AccountRuntime>>,
     preferred: Mutex<HashMap<String, String>>,
@@ -197,9 +204,44 @@ pub struct Router {
     switch_at: u8,
 }
 
+impl AccountRuntime {
+    fn auth_unavailable(&self) -> bool {
+        self.needs_login || self.bearer_unusable
+    }
+}
+
 impl Router {
+    async fn account_runtimes(
+        &self,
+    ) -> tokio::sync::MutexGuard<'_, HashMap<String, AccountRuntime>> {
+        let mut accounts = self.accounts.lock().await;
+        let now = Utc::now().timestamp().max(0) as u64;
+        for (name, runtime) in accounts.iter_mut() {
+            let status = match self.managed_homes.get(name) {
+                Some(path) => self.auth_health.status_normalized(path, now),
+                _ => ManagedAuthStatus::default(),
+            };
+            runtime.reauth_required = status.reauth_required;
+            runtime.bearer_unusable = status.bearer_unusable;
+        }
+        accounts
+    }
+
     pub fn new(config: &Config, affinity: Arc<AffinityStore>) -> Self {
         Self {
+            auth_health: ManagedAuthHealth::default(),
+            managed_homes: config
+                .accounts
+                .iter()
+                .filter_map(|(name, account)| {
+                    let AccountConfig::CodexHome { path } = account else {
+                        return None;
+                    };
+                    normalize_codex_home(path)
+                        .ok()
+                        .map(|home| (name.clone(), home))
+                })
+                .collect(),
             affinity,
             accounts: Mutex::new(
                 config
@@ -268,7 +310,7 @@ impl Router {
             Some(binding) => Some(self.affinity.account_epoch(&binding.account_id).await),
             None => None,
         };
-        let mut accounts = self.accounts.lock().await;
+        let mut accounts = self.account_runtimes().await;
         for runtime in accounts.values_mut() {
             if runtime.needs_login
                 && runtime
@@ -285,7 +327,7 @@ impl Router {
                 && pool.members.contains(&binding.account_id)
                 && accounts.get(&binding.account_id).is_some_and(|a| {
                     binding_epoch == Some(binding.account_generation)
-                        && !a.needs_login
+                        && !a.auth_unavailable()
                         && !a.login_in_progress
                         && a.quota_until.is_none_or(|v| v <= now)
                 });
@@ -306,7 +348,7 @@ impl Router {
         let eligible = |id: &str| {
             exclude != Some(id)
                 && accounts.get(id).is_some_and(|a| {
-                    !a.needs_login
+                    !a.auth_unavailable()
                         && !a.login_in_progress
                         && a.quota_until.is_none_or(|v| v <= now)
                         && a.avoid_until.is_none_or(|v| v <= now)
@@ -409,7 +451,7 @@ impl Router {
     pub async fn routing_snapshot(&self) -> RoutingSnapshot {
         let now = Instant::now();
         let wall_now = Utc::now();
-        let mut accounts = self.accounts.lock().await;
+        let mut accounts = self.account_runtimes().await;
         for runtime in accounts.values_mut() {
             reconcile_runtime(runtime, now, wall_now);
         }
@@ -484,7 +526,7 @@ impl Router {
             avoid_blocked: bool,
         }
         let probe = {
-            let mut accounts = self.accounts.lock().await;
+            let mut accounts = self.account_runtimes().await;
             let wall_now = Utc::now();
             for runtime in accounts.values_mut() {
                 reconcile_runtime(runtime, now, wall_now);
@@ -492,7 +534,7 @@ impl Router {
             match accounts.get(&selection.account_id) {
                 Some(runtime) => RuntimeProbe {
                     known: true,
-                    needs_login: runtime.needs_login,
+                    needs_login: runtime.auth_unavailable(),
                     login_in_progress: runtime.login_in_progress,
                     quota_blocked: runtime.quota_until.is_some_and(|until| until > now),
                     avoid_blocked: runtime.avoid_until.is_some_and(|until| until > now),
@@ -569,9 +611,9 @@ impl Router {
                 && pool.members.contains(&preferred_id)
             {
                 let preferred_eligible = {
-                    let accounts = self.accounts.lock().await;
+                    let accounts = self.account_runtimes().await;
                     accounts.get(&preferred_id).is_some_and(|runtime| {
-                        !runtime.needs_login
+                        !runtime.auth_unavailable()
                             && !runtime.login_in_progress
                             && runtime.quota_until.is_none_or(|until| until <= now)
                             && runtime.avoid_until.is_none_or(|until| until <= now)
@@ -583,7 +625,7 @@ impl Router {
                 };
                 if preferred_eligible {
                     let usage_ok = {
-                        let accounts = self.accounts.lock().await;
+                        let accounts = self.account_runtimes().await;
                         accounts
                             .get(&preferred_id)
                             .and_then(|runtime| runtime.usage)
@@ -615,14 +657,14 @@ impl Router {
     ) -> Result<(), SelectionStaleReason> {
         let now = Instant::now();
         let probe = {
-            let mut accounts = self.accounts.lock().await;
+            let mut accounts = self.account_runtimes().await;
             let wall_now = Utc::now();
             for runtime in accounts.values_mut() {
                 reconcile_runtime(runtime, now, wall_now);
             }
             accounts.get(account).map(|runtime| {
                 (
-                    runtime.needs_login,
+                    runtime.auth_unavailable(),
                     runtime.login_in_progress,
                     runtime.quota_until.is_some_and(|until| until > now),
                     runtime.avoid_until.is_some_and(|until| until > now),
@@ -661,11 +703,10 @@ impl Router {
 
     /// Accounts the router currently excludes because their credentials need repair.
     pub async fn accounts_needing_login(&self) -> BTreeSet<String> {
-        self.accounts
-            .lock()
+        self.account_runtimes()
             .await
             .iter()
-            .filter(|(_, runtime)| runtime.needs_login)
+            .filter(|(_, runtime)| runtime.auth_unavailable())
             .map(|(account, _)| account.clone())
             .collect()
     }
@@ -674,11 +715,10 @@ impl Router {
     pub async fn context_account_available(&self, pool: &PoolConfig, account: &str) -> bool {
         pool.members.iter().any(|member| member == account)
             && self
-                .accounts
-                .lock()
+                .account_runtimes()
                 .await
                 .get(account)
-                .is_some_and(|runtime| !runtime.needs_login && !runtime.login_in_progress)
+                .is_some_and(|runtime| !runtime.auth_unavailable() && !runtime.login_in_progress)
     }
 
     pub async fn begin(&self, account: &str) {
@@ -698,13 +738,13 @@ impl Router {
     pub async fn select_exact(&self, pool: &PoolConfig, account: &str) -> Option<Selection> {
         let now = Instant::now();
         let wall_now = Utc::now();
-        let mut accounts = self.accounts.lock().await;
+        let mut accounts = self.account_runtimes().await;
         if let Some(runtime) = accounts.get_mut(account) {
             reconcile_expired_quota(runtime, now, wall_now);
         }
         let eligible = pool.members.iter().any(|v| v == account)
             && accounts.get(account).is_some_and(|a| {
-                !a.needs_login
+                !a.auth_unavailable()
                     && !a.login_in_progress
                     && a.quota_until.is_none_or(|v| v <= now)
                     && a.avoid_until.is_none_or(|v| v <= now)
@@ -890,8 +930,10 @@ fn account_routing_status(
 ) -> AccountRoutingStatus {
     let (unavailable_reason, retry_at) = if runtime.login_in_progress {
         (Some("login_in_progress".to_owned()), None)
-    } else if runtime.needs_login {
+    } else if runtime.needs_login || (runtime.bearer_unusable && runtime.reauth_required) {
         (Some("needs_login".to_owned()), runtime.needs_login_retry_at)
+    } else if runtime.bearer_unusable {
+        (Some("access_token_rejected".to_owned()), None)
     } else if runtime.quota_until.is_some_and(|until| until > now) {
         (Some("quota".to_owned()), runtime.quota_until)
     } else if runtime.avoid_until.is_some_and(|until| until > now) {
@@ -921,6 +963,7 @@ fn account_routing_status(
         })
         .collect();
     AccountRoutingStatus {
+        reauth_required: runtime.reauth_required,
         available: unavailable_reason.is_none(),
         unavailable_reason,
         retry_at_unix,


### PR DESCRIPTION
A permanent OAuth refresh failure no longer disables an unexpired access token that the product endpoint still accepts. Status reports reauthentication separately from routing availability; an actual upstream rejection quarantines the specific bearer, and a replacement login restores eligibility without inheriting stale failures.

The same health state governs inference, context access, background refresh, and direct WebSocket recovery. Rejected generations are checked before dispatch, ownership remains intact, and a later successful refresh can restore a transiently rejected account.
