### PR TITLE
Preserve native reasoning across account replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ does not change inference quota state or globally stop inference.
 
 The relay preserves native encrypted arguments and protocol headers. It authenticates and encrypts
 the combined tool result, then restores the native results before the next inference request. Only
-verified context outputs receive portable routing treatment; unrelated encrypted reasoning and
-other account-owned state retain their existing continuity restrictions. HTTP, the HTTP WebSocket
+verified context outputs receive portable routing treatment on this path. Native reasoning items
+with nonempty encrypted content directly in Responses input are also portable, with their full item
+shape preserved. Other account-owned state retains its continuity restrictions. HTTP, the HTTP WebSocket
 bridge, and direct Responses WebSockets support this path. Backend-alias Responses WebSockets use
 frame inspection even when the legacy `/v1` transport is configured as raw.
 
@@ -246,7 +247,16 @@ Existing owners remain usable, and an account in capacity backoff is still selec
 no alternative is eligible. `comradex status --json` exposes the soft deadline as
 `routing.account_states.<account>.capacity_backoff_until_unix`.
 
-A pre-output quota response, account-scoped connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Responses bodies carrying encrypted reasoning, hosted operation state, or durable operation metadata become bound to the first account that actually receives them; a proven pre-dispatch connection failure does not create that binding. Shared DNS and network-reachability failures remain account-neutral and do not rotate credentials. Successful or ambiguous Live Voice creation is never replayed. On HTTP, a managed-account 401 gets one same-account refresh retry, and a 401/403 never crosses accounts. No response is retried after visible output. When no alternate is eligible, the original upstream rejection and its `Retry-After` or reset headers are preserved; primary, secondary, and tertiary reset windows bound quota cooldowns.
+A pre-output quota response, account-scoped connection-establishment failure, or selected gateway failure may use one alternate only for native Responses or idempotent methods, never for hard account-owned continuity. Native encrypted reasoning items can travel unchanged with a self-contained transcript. Compaction, unrelated encrypted tool output, hosted operation state, and durable operation metadata remain bound to the first account that actually receives them; a proven pre-dispatch connection failure does not create that binding. File ownership and previous-response or turn-state anchors remain separately enforced. Shared DNS and network-reachability failures remain account-neutral and do not rotate credentials. Successful or ambiguous Live Voice creation is never replayed. On HTTP, a managed-account 401 gets one same-account refresh retry, and a 401/403 never crosses accounts. No response is retried after visible output. When no alternate is eligible, the original upstream rejection and its `Retry-After` or reset headers are preserved; primary, secondary, and tertiary reset windows bound quota cooldowns.
+
+Native reasoning portability was qualified on the configured Codex backend with `gpt-6-astra`,
+two distinct managed identities, and an unchanged tool continuation on September 7, 2026. Both the
+same-account control and cross-account continuation completed the synthetic task. This observation
+does not establish a contract for every model, account combination, or encrypted payload. The ignored
+`native_reasoning_live` integration test repeats that gate using normal Comradex credential resolution;
+set `COMRADEX_PROBE_MODEL` to the configured client model and explicitly authorize live account use
+before running `mbx test --test native_reasoning_live -- --ignored --nocapture`. It logs only safe
+status metadata and keeps credentials, native items, and synthetic response text in memory.
 
 Quota cooldowns recover automatically on the next selection or status request. When upstream reports several quota windows, only windows explicitly reported at 100% constrain a quota rejection; unrelated longer windows do not keep the account blocked. `comradex status` and `comradex status --json` expose each account's availability, retry deadline, usage, and blocking quota windows. Neither Comradex nor Codex needs to be restarted when a quota window resets.
 

--- a/src/proxy/context_tests.rs
+++ b/src/proxy/context_tests.rs
@@ -620,7 +620,7 @@ async fn signed_context_wrapper_can_rotate_inference_without_moving_notes_owner(
 }
 
 #[tokio::test]
-async fn unrelated_encrypted_reasoning_keeps_signed_context_replay_on_first_account() {
+async fn native_reasoning_and_signed_context_replay_together_unchanged() {
     let upstream = start_upstream(Arc::new(|request| {
         if request.path.contains("/alpha/notes/") {
             return (
@@ -651,7 +651,7 @@ async fn unrelated_encrypted_reasoning_keeps_signed_context_replay_on_first_acco
         response_with_context_wrapper(&wrapper, true),
     )
     .await;
-    assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(status, StatusCode::OK);
 
     let seen = upstream.seen.lock().unwrap();
     let attempted: Vec<_> = seen
@@ -664,14 +664,23 @@ async fn unrelated_encrypted_reasoning_keeps_signed_context_replay_on_first_acco
                     .any(|window| window == b"call_context")
         })
         .collect();
-    assert_eq!(attempted.len(), 1);
+    assert_eq!(attempted.len(), 2);
     assert_eq!(attempted[0].account_id, "workspace-a");
-    assert!(
-        attempted[0]
-            .body
-            .windows(b"unrelated-native-ciphertext".len())
-            .any(|window| window == b"unrelated-native-ciphertext")
-    );
+    assert_eq!(attempted[1].account_id, "workspace-b");
+    for attempt in attempted {
+        assert!(
+            attempt
+                .body
+                .windows(b"unrelated-native-ciphertext".len())
+                .any(|window| window == b"unrelated-native-ciphertext")
+        );
+        assert!(
+            attempt
+                .body
+                .windows(b"cipher-workspace-a".len())
+                .any(|window| window == b"cipher-workspace-a")
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/proxy/context_ws_tests.rs
+++ b/src/proxy/context_ws_tests.rs
@@ -566,3 +566,146 @@ async fn http_bridge_websocket_context_replay_preserves_native_context_ownership
     exercise_trusted_context_replay(ResponsesWebsocketMode::HttpBridge).await;
     exercise_untrusted_ciphertext_is_not_replayed(ResponsesWebsocketMode::HttpBridge).await;
 }
+
+fn native_reasoning_continuation() -> Value {
+    json!({
+        "type":"response.create", "model":"gpt-test", "stream":true,
+        "input":[
+            {"role":"user","content":"Compute 17 plus 25."},
+            {"type":"reasoning","id":"rs_native","summary":[{"type":"summary_text","text":"Use addition."}],"content":[{"type":"reasoning_text","text":"Synthetic reasoning."}],"status":"completed","encrypted_content":"native-reasoning-ciphertext"},
+            {"type":"function_call","name":"add","call_id":"call_add","arguments":"{\"a\":17,\"b\":25}"},
+            {"type":"function_call_output","call_id":"call_add","output":"42"}
+        ]
+    })
+}
+
+async fn send_native_reasoning_request(
+    proxy: &ContextWebSocketProxy,
+    body: Value,
+    websocket: bool,
+) -> bool {
+    if websocket {
+        let mut connection = connect_proxy(proxy.address).await;
+        send_turn(&mut connection, body).await.last().unwrap()["type"] == "response.completed"
+    } else {
+        let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+            .build_http::<Full<Bytes>>();
+        let mut body = body;
+        body.as_object_mut().unwrap().remove("type");
+        let response = client
+            .request(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!(
+                        "http://{}/{SECRET}/backend-api/codex/responses",
+                        proxy.address
+                    ))
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Full::new(Bytes::from(serde_json::to_vec(&body).unwrap())))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let success = response.status().is_success();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        success && String::from_utf8_lossy(&bytes).contains("response.completed")
+    }
+}
+
+async fn exercise_native_reasoning_quota_replay(mode: ResponsesWebsocketMode, websocket: bool) {
+    let upstream = start_context_upstream().await;
+    let dir = tempfile::tempdir().unwrap();
+    let proxy = start_context_proxy(dir.path(), upstream.address, mode).await;
+    let body = native_reasoning_continuation();
+    assert!(send_native_reasoning_request(&proxy, body.clone(), websocket).await);
+    let seen = upstream.seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    assert_eq!(
+        seen[0].authorization,
+        format!("Bearer {}", test_token("workspace-a", "user-a"))
+    );
+    assert_eq!(
+        seen[1].authorization,
+        format!("Bearer {}", test_token("workspace-b", "user-b"))
+    );
+    assert_eq!(seen[0].body["input"], body["input"]);
+    assert_eq!(seen[1].body["input"], body["input"]);
+    assert_eq!(seen[0].body, seen[1].body);
+}
+
+async fn exercise_native_reasoning_ownership_negatives(
+    mode: ResponsesWebsocketMode,
+    websocket: bool,
+) {
+    let mut cases = Vec::new();
+    for extra in [
+        json!({"type":"compaction","encrypted_content":"owned-compaction"}),
+        json!({"type":"encrypted_content","encrypted_content":"owned-tool-output"}),
+        json!({"type":"code_interpreter_call","id":"ci_owned","container_id":"container_owned"}),
+        json!({"type":"item_reference","id":"stored_item"}),
+        json!({"type":"input_file","file_id":"file_owned"}),
+        json!({"type":"reasoning","id":"rs_missing_ciphertext"}),
+        json!({"type":"reasoning","encrypted_content":"native","nested":{"encrypted_content":"owned"}}),
+    ] {
+        let mut body = native_reasoning_continuation();
+        body["input"].as_array_mut().unwrap().push(extra);
+        cases.push(body);
+    }
+    for (key, value) in [
+        ("previous_response_id", json!("resp_unknown")),
+        ("turn_state", json!("turn_unknown")),
+        ("conversation", json!("conversation_owned")),
+        (
+            "internal_chat_message_metadata_passthrough",
+            json!({"operation_id":"op_owned"}),
+        ),
+    ] {
+        let mut body = native_reasoning_continuation();
+        body[key] = value;
+        cases.push(body);
+    }
+    for (index, body) in cases.into_iter().enumerate() {
+        let upstream = start_context_upstream().await;
+        let dir = tempfile::tempdir().unwrap();
+        let proxy = start_context_proxy(dir.path(), upstream.address, mode).await;
+        assert!(
+            proxy
+                .app
+                .file_owners
+                .put(
+                    proxy.app.router.affinity.key("file:file_owned"),
+                    "a".into(),
+                    0
+                )
+                .await
+        );
+        assert!(
+            !send_native_reasoning_request(&proxy, body, websocket).await,
+            "ownership case {index}"
+        );
+        let seen = upstream.seen.lock().unwrap();
+        assert!(
+            seen.iter().all(|request| request.authorization
+                == format!("Bearer {}", test_token("workspace-a", "user-a"))),
+            "ownership case {index} crossed accounts"
+        );
+    }
+}
+
+#[tokio::test]
+async fn http_native_reasoning_quota_replay_preserves_items_and_ownership() {
+    exercise_native_reasoning_quota_replay(ResponsesWebsocketMode::HttpBridge, false).await;
+    exercise_native_reasoning_ownership_negatives(ResponsesWebsocketMode::HttpBridge, false).await;
+}
+
+#[tokio::test]
+async fn http_bridge_native_reasoning_quota_replay_preserves_items_and_ownership() {
+    exercise_native_reasoning_quota_replay(ResponsesWebsocketMode::HttpBridge, true).await;
+    exercise_native_reasoning_ownership_negatives(ResponsesWebsocketMode::HttpBridge, true).await;
+}
+
+#[tokio::test]
+async fn direct_websocket_native_reasoning_quota_replay_preserves_items_and_ownership() {
+    exercise_native_reasoning_quota_replay(ResponsesWebsocketMode::Direct, true).await;
+    exercise_native_reasoning_ownership_negatives(ResponsesWebsocketMode::Direct, true).await;
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -9329,7 +9329,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
             ))
             .header(AUTHORIZATION, "Bearer inbound-ignored")
             .body(Full::new(Bytes::from_static(
-                br#"{"model":"gpt-test","input":[{"type":"reasoning","id":"rs_owner","encrypted_content":"ciphertext"}],"stream":true}"#,
+                br#"{"model":"gpt-test","input":[{"type":"compaction","id":"cmp_owner","encrypted_content":"ciphertext"}],"stream":true}"#,
             )))
             .unwrap();
 

--- a/src/proxy/replay_body.rs
+++ b/src/proxy/replay_body.rs
@@ -44,6 +44,8 @@ enum KeyKind {
     PromptCacheKey,
     FileId,
     Type,
+    Input,
+    EncryptedContent,
     Other,
 }
 
@@ -52,6 +54,12 @@ struct Container {
     expect_key: bool,
     file_id: Option<String>,
     account_scoped_file: bool,
+    input_array: bool,
+    native_input_item: bool,
+    reasoning: bool,
+    type_keys: usize,
+    encrypted_content: bool,
+    encrypted_content_string: bool,
 }
 
 #[derive(Default)]
@@ -78,6 +86,12 @@ struct MetadataScanner {
 }
 
 impl MetadataScanner {
+    fn finish(&mut self) {
+        // An unfinished item has not established that its encrypted payload is native
+        // reasoning; do not relax ownership for a truncated or malformed request.
+        self.nonportable_state |= self.in_string || !self.containers.is_empty();
+    }
+
     fn feed(&mut self, bytes: &[u8]) {
         for &byte in bytes {
             if self.disabled {
@@ -127,6 +141,7 @@ impl MetadataScanner {
                                 | KeyKind::PromptCacheKey
                                 | KeyKind::FileId
                                 | KeyKind::Type
+                                | KeyKind::EncryptedContent
                         )
                     });
                     self.string_is_key = self.capture_value.is_none()
@@ -145,12 +160,19 @@ impl MetadataScanner {
                         continue;
                     }
                     let is_client = self.pending_value == Some(KeyKind::ClientMetadata);
+                    let native_input_item = self.containers.last().is_some_and(|v| v.input_array);
                     self.pending_value = None;
                     self.containers.push(Container {
                         object: true,
                         expect_key: true,
                         file_id: None,
                         account_scoped_file: false,
+                        input_array: false,
+                        native_input_item,
+                        reasoning: false,
+                        type_keys: 0,
+                        encrypted_content: false,
+                        encrypted_content_string: false,
                     });
                     if is_client {
                         self.client_depth = Some(self.containers.len());
@@ -162,28 +184,45 @@ impl MetadataScanner {
                         self.disabled = true;
                         continue;
                     }
+                    let input_array =
+                        self.containers.len() == 1 && self.pending_value == Some(KeyKind::Input);
                     self.pending_value = None;
                     self.containers.push(Container {
                         object: false,
                         expect_key: false,
                         file_id: None,
                         account_scoped_file: false,
+                        input_array,
+                        native_input_item: false,
+                        reasoning: false,
+                        type_keys: 0,
+                        encrypted_content: false,
+                        encrypted_content_string: false,
                     });
                 }
                 b'}' | b']' => {
                     if self.client_depth == Some(self.containers.len()) {
                         self.client_depth = None;
                     }
-                    if let Some(container) = self.containers.pop()
-                        && container.account_scoped_file
-                        && let Some(file_id) = container.file_id
-                        && !self.file_ids.contains(&file_id)
-                    {
-                        if self.file_ids.len() < 32 {
-                            self.file_ids.push(file_id);
-                        } else {
-                            self.file_ids_overflow = true;
-                            self.disabled = true;
+                    if let Some(container) = self.containers.pop() {
+                        // Only a self-contained native reasoning item directly in input may
+                        // carry portable ciphertext. Other encrypted payloads retain ownership.
+                        if container.reasoning || container.encrypted_content {
+                            self.nonportable_state |= !(container.native_input_item
+                                && container.reasoning
+                                && container.type_keys == 1
+                                && container.encrypted_content_string);
+                        }
+                        if container.account_scoped_file
+                            && let Some(file_id) = container.file_id
+                            && !self.file_ids.contains(&file_id)
+                        {
+                            if self.file_ids.len() < 32 {
+                                self.file_ids.push(file_id);
+                            } else {
+                                self.file_ids_overflow = true;
+                                self.disabled = true;
+                            }
                         }
                     }
                     self.pending_value = None;
@@ -214,6 +253,12 @@ impl MetadataScanner {
         // Also inspect an all-turns request without session metadata so it fails closed.
         self.context_envelope |= !self.string_is_key && self.token == b"all_turns";
         if let Some(kind) = self.capture_value {
+            if kind == KeyKind::EncryptedContent
+                && !self.token.is_empty()
+                && let Some(container) = self.containers.last_mut()
+            {
+                container.encrypted_content_string = true;
+            }
             if !self.token_overflow && !self.token.is_empty() {
                 let value = String::from_utf8(self.token.clone()).ok();
                 match kind {
@@ -231,9 +276,10 @@ impl MetadataScanner {
                         {
                             container.account_scoped_file =
                                 matches!(value.as_str(), "input_file" | "input_image");
+                            container.reasoning = value == "reasoning";
                             self.nonportable_state |= matches!(
                                 value.as_str(),
-                                "reasoning"
+                                "compaction"
                                     | "item_reference"
                                     | "code_interpreter_call"
                                     | "computer_call"
@@ -246,7 +292,10 @@ impl MetadataScanner {
                             );
                         }
                     }
-                    KeyKind::ClientMetadata | KeyKind::Other => {}
+                    KeyKind::ClientMetadata
+                    | KeyKind::Other
+                    | KeyKind::Input
+                    | KeyKind::EncryptedContent => {}
                 }
             }
         } else if self.string_is_key {
@@ -255,8 +304,7 @@ impl MetadataScanner {
             if !self.token_overflow
                 && (matches!(
                     self.token.as_slice(),
-                    b"encrypted_content"
-                        | b"operation_id"
+                    b"operation_id"
                         | b"codex_operation_id"
                         | b"internal_chat_message_metadata_passthrough"
                 ) || (at_root
@@ -280,7 +328,19 @@ impl MetadataScanner {
             } else if !self.token_overflow && self.token == b"file_id" {
                 Some(KeyKind::FileId)
             } else if !self.token_overflow && self.token == b"type" {
+                if let Some(container) = self.containers.last_mut() {
+                    container.type_keys += 1;
+                }
                 Some(KeyKind::Type)
+            } else if at_root && !self.token_overflow && self.token == b"input" {
+                Some(KeyKind::Input)
+            } else if !self.token_overflow && self.token == b"encrypted_content" {
+                if let Some(container) = self.containers.last_mut() {
+                    // Duplicate ciphertext properties are ambiguous to downstream parsers.
+                    self.nonportable_state |= container.encrypted_content;
+                    container.encrypted_content = true;
+                }
+                Some(KeyKind::EncryptedContent)
             } else {
                 Some(KeyKind::Other)
             };
@@ -349,6 +409,7 @@ impl ReplayBody {
         }
         let mut metadata = MetadataScanner::default();
         metadata.feed(&bytes);
+        metadata.finish();
         Ok(Self {
             len: bytes.len(),
             storage: Storage::Memory(bytes),
@@ -417,6 +478,7 @@ impl ReplayBody {
                     .await?;
             }
         }
+        metadata.finish();
         let storage = if let Some((file, path)) = temp {
             file.sync_data().await?;
             drop(file);
@@ -607,7 +669,7 @@ mod tests {
         scanner.feed(br#"{"input":[{"type":"reas"#);
         scanner.feed(br#"oning","encrypted_con"#);
         scanner.feed(br#"tent":"ciphertext"}]}"#);
-        assert!(scanner.nonportable_state);
+        assert!(!scanner.nonportable_state);
 
         let mut operation = MetadataScanner::default();
         operation
@@ -628,5 +690,52 @@ mod tests {
             br#"{"input":[{"type":"message","role":"user","content":"hello\nworld"}],"reasoning":{"effort":"high"}}"#,
         );
         assert!(!portable.nonportable_state);
+    }
+
+    #[test]
+    fn native_reasoning_exception_is_item_scoped_and_chunk_independent() {
+        let native = serde_json::json!({"type":"reasoning","id":"rs_native","summary":[{"type":"summary_text","text":"synthetic summary"}],"encrypted_content":"x".repeat(2000)});
+        for body in [
+            serde_json::json!({"input":[native.clone()]}),
+            serde_json::json!({"input":[{"encrypted_content":"opaque","summary":[],"type":"reasoning","id":"rs_last"}]}),
+        ] {
+            let bytes = serde_json::to_vec(&body).unwrap();
+            for size in [1, 7, bytes.len()] {
+                let mut scanner = MetadataScanner::default();
+                for chunk in bytes.chunks(size) {
+                    scanner.feed(chunk);
+                }
+                assert!(!scanner.nonportable_state);
+            }
+        }
+        for body in [
+            serde_json::json!({"input":[{"type":"compaction","encrypted_content":"opaque"}]}),
+            serde_json::json!({"input":[{"type":"reasoning","id":"rs_incomplete"}]}),
+            serde_json::json!({"input":[{"type":"reasoning","encrypted_content":null}]}),
+            serde_json::json!({"input":[{"type":"reasoning","encrypted_content":""}]}),
+            serde_json::json!({"input":[{"type":"function_call_output","output":[native.clone()]}]}),
+            serde_json::json!({"input":[{"type":"reasoning","encrypted_content":"opaque","extra":{"encrypted_content":"owned"}}]}),
+            serde_json::json!({"input":[{"type":"reasoning","encrypted_content":"opaque","operation_id":"op"}]}),
+            serde_json::json!({"input":[[native.clone()]]}),
+            serde_json::json!({"extra":native}),
+        ] {
+            let mut scanner = MetadataScanner::default();
+            for chunk in serde_json::to_vec(&body).unwrap().chunks(3) {
+                scanner.feed(chunk);
+            }
+            assert!(scanner.nonportable_state, "{body}");
+        }
+        for body in [
+            br#"{"input":[{"type":"compaction","type":"reasoning","encrypted_content":"opaque"}]}"#.as_slice(),
+            br#"{"input":[{"type":"reasoning","encrypted_content":"first","encrypted_content":"last"}]}"#,
+        ] {
+            let mut scanner = MetadataScanner::default();
+            scanner.feed(body);
+            assert!(scanner.nonportable_state);
+        }
+        let mut unfinished = MetadataScanner::default();
+        unfinished.feed(br#"{"input":[{"type":"reasoning","encrypted_content":"opaque""#);
+        unfinished.finish();
+        assert!(unfinished.nonportable_state);
     }
 }

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -1412,23 +1412,30 @@ fn has_file_reference(value: &Value) -> bool {
 }
 
 fn frame_contains_nonportable_state(value: &Value) -> bool {
-    contains_nonportable_state(value, true)
+    contains_nonportable_state(value, true, false)
 }
 
-fn contains_nonportable_state(value: &Value, at_root: bool) -> bool {
+fn contains_nonportable_state(value: &Value, at_root: bool, native_input_item: bool) -> bool {
     match value {
         Value::Array(values) => values
             .iter()
-            .any(|value| contains_nonportable_state(value, false)),
+            .any(|value| contains_nonportable_state(value, false, false)),
         Value::Object(object) => {
+            let portable_reasoning = native_input_item
+                && object.get("type").and_then(Value::as_str) == Some("reasoning")
+                && object
+                    .get("encrypted_content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.is_empty());
             if object.keys().any(|key| {
-                matches!(
-                    key.as_str(),
-                    "encrypted_content"
-                        | "operation_id"
-                        | "codex_operation_id"
-                        | "internal_chat_message_metadata_passthrough"
-                ) || (at_root && matches!(key.as_str(), "conversation" | "prompt" | "turn_state"))
+                (key == "encrypted_content" && !portable_reasoning)
+                    || matches!(
+                        key.as_str(),
+                        "operation_id"
+                            | "codex_operation_id"
+                            | "internal_chat_message_metadata_passthrough"
+                    )
+                    || (at_root && matches!(key.as_str(), "conversation" | "prompt" | "turn_state"))
             }) {
                 return true;
             }
@@ -1436,26 +1443,36 @@ fn contains_nonportable_state(value: &Value, at_root: bool) -> bool {
                 .get("type")
                 .and_then(Value::as_str)
                 .is_some_and(|item_type| {
-                    matches!(
-                        item_type,
-                        "reasoning"
-                            | "item_reference"
-                            | "code_interpreter_call"
-                            | "computer_call"
-                            | "computer_call_output"
-                            | "file_search_call"
-                            | "image_generation_call"
-                            | "tool_search_call"
-                            | "tool_search_output"
-                            | "web_search_call"
-                    )
+                    (item_type == "reasoning" && !portable_reasoning)
+                        || matches!(
+                            item_type,
+                            "compaction"
+                                | "item_reference"
+                                | "code_interpreter_call"
+                                | "computer_call"
+                                | "computer_call_output"
+                                | "file_search_call"
+                                | "image_generation_call"
+                                | "tool_search_call"
+                                | "tool_search_output"
+                                | "web_search_call"
+                        )
                 })
             {
                 return true;
             }
-            object
-                .values()
-                .any(|value| contains_nonportable_state(value, false))
+            object.iter().any(|(key, value)| {
+                if at_root
+                    && key == "input"
+                    && let Some(items) = value.as_array()
+                {
+                    items
+                        .iter()
+                        .any(|item| contains_nonportable_state(item, false, true))
+                } else {
+                    contains_nonportable_state(value, false, false)
+                }
+            })
         }
         _ => false,
     }
@@ -2336,7 +2353,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_reasoning_remains_nonportable_after_anchor_removal() {
+    fn native_reasoning_is_portable_without_changing_anchor_policy() {
         let frame = json!({
             "type":"response.create",
             "previous_response_id":"resp_old",
@@ -2346,13 +2363,15 @@ mod tests {
             ]
         });
         let analysis = analyze_response_create(&frame, ProtocolLimits::default()).unwrap();
-        assert!(analysis.has_nonportable_state);
+        assert!(!analysis.has_nonportable_state);
+        assert_eq!(analysis.previous_response_id.as_deref(), Some("resp_old"));
         assert_eq!(analysis.full_resend, FullResendSafety::Eligible);
 
         let fresh =
             fresh_replay_without_previous_response(&frame, ProtocolLimits::default()).unwrap();
         assert!(fresh.get("previous_response_id").is_none());
-        assert!(frame_contains_nonportable_state(&fresh));
+        assert!(!frame_contains_nonportable_state(&fresh));
+        assert_eq!(fresh["input"], frame["input"]);
     }
 
     #[test]

--- a/tests/native_reasoning_live.rs
+++ b/tests/native_reasoning_live.rs
@@ -1,0 +1,264 @@
+//! Opt-in qualification against the configured Codex backend. No credentials, account
+//! identities, response text, or encrypted payloads are logged or written to disk.
+//! Run with COMRADEX_PROBE_MODEL set to a model supported by the configured backend:
+//! mbx test --test native_reasoning_live -- --ignored --nocapture
+use std::{path::PathBuf, time::Duration};
+
+use comradex::{
+    auth::{Credentials, Resolver},
+    config::{AccountConfig, Config},
+};
+use serde_json::{Value, json};
+
+async fn response(
+    client: &reqwest::Client,
+    endpoint: &str,
+    credentials: &Credentials,
+    body: &Value,
+    stage: &str,
+) -> Option<Value> {
+    let mut request = client
+        .post(endpoint)
+        .header("authorization", &credentials.authorization)
+        .header("content-type", "application/json")
+        .header("accept", "text/event-stream")
+        .header("originator", "codex_cli_rs")
+        .body(serde_json::to_vec(body).expect("serialize synthetic request"));
+    if let Some(account_id) = &credentials.account_id {
+        request = request.header("chatgpt-account-id", account_id);
+    }
+    let Ok(response) = request.send().await else {
+        println!("stage={stage} transport_failure=true");
+        return None;
+    };
+    let status = response.status();
+    let Ok(text) = response.text().await else {
+        println!("stage={stage} http={} read_failure=true", status.as_u16());
+        return None;
+    };
+    let mut completed = None;
+    let mut output_items = std::collections::BTreeMap::new();
+    let mut code = "none";
+    if !status.is_success() {
+        let lower = text.to_ascii_lowercase();
+        println!(
+            "stage={stage} unsupported={} mentions_model={} mentions_tool_choice={} mentions_required={} mentions_instructions={} mentions_reasoning={} mentions_encrypted={} html={}",
+            lower.contains("unsupported") || lower.contains("not supported"),
+            lower.contains("model"),
+            lower.contains("tool_choice"),
+            lower.contains("required"),
+            lower.contains("instructions"),
+            lower.contains("reasoning"),
+            lower.contains("encrypted"),
+            lower.contains("<html")
+        );
+    }
+    let values = serde_json::from_str::<Value>(&text).into_iter().chain(
+        text.lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter_map(|data| serde_json::from_str::<Value>(data).ok()),
+    );
+    for event in values {
+        if event["type"] == "response.output_item.done"
+            && let (Some(index), Some(item)) = (event["output_index"].as_u64(), event.get("item"))
+        {
+            output_items.insert(index, item.clone());
+        }
+        let candidate = event
+            .pointer("/error/code")
+            .or_else(|| event.pointer("/response/error/code"))
+            .and_then(Value::as_str);
+        code = match candidate {
+            Some("invalid_encrypted_content") => "invalid_encrypted_content",
+            Some("usage_limit_reached") => "usage_limit_reached",
+            Some("insufficient_quota") => "insufficient_quota",
+            Some("invalid_api_key") => "invalid_api_key",
+            Some("model_not_found") => "model_not_found",
+            Some("invalid_request_error") => "invalid_request_error",
+            Some(_) => "other",
+            None => code,
+        };
+        if event["type"] == "response.completed" {
+            completed = event.get("response").cloned();
+        }
+    }
+    // Codex can leave response.completed.output empty; output_item.done owns the
+    // complete native item in that stream. Preserve each item without rewriting it.
+    if let Some(result) = completed.as_mut()
+        && result["output"].as_array().is_some_and(Vec::is_empty)
+    {
+        result["output"] = Value::Array(output_items.into_values().collect());
+    }
+    println!(
+        "stage={stage} http={} completed={} error_code={code}",
+        status.as_u16(),
+        completed.is_some()
+    );
+    completed
+}
+
+#[tokio::test]
+#[ignore = "uses configured managed accounts and live backend; explicitly authorize before running"]
+async fn native_reasoning_same_and_cross_account_tool_continuation() {
+    let home = PathBuf::from(std::env::var_os("HOME").expect("HOME required"));
+    let path = std::env::var_os("COMRADEX_PROBE_CONFIG")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".config/comradex/comradex.toml"));
+    let config = Config::load(&path)
+        .unwrap_or_else(|_| panic!("configured Comradex config could not be loaded"));
+    assert!(
+        config.proxy.upstream == comradex::config::CANONICAL_UPSTREAM,
+        "live qualification requires the canonical Codex upstream"
+    );
+    let resolver = Resolver::new(&config);
+    let mut credentials: Vec<(String, Credentials)> = Vec::new();
+    for account in config
+        .accounts
+        .values()
+        .filter(|account| matches!(account, AccountConfig::CodexHome { .. }))
+    {
+        if let Ok(credential) = resolver.resolve(account, &hyper::HeaderMap::new()).await
+            && let Ok(identity) = credential.context_identity()
+            && credential.account_id.is_some()
+            && !credentials.iter().any(|(existing, selected)| {
+                existing == &identity || selected.account_id == credential.account_id
+            })
+        {
+            credentials.push((identity, credential));
+            if credentials.len() == 2 {
+                break;
+            }
+        }
+    }
+    assert!(
+        credentials.len() == 2,
+        "two distinct configured managed identities required"
+    );
+    assert!(
+        credentials[0].1.account_id.is_some()
+            && credentials[1].1.account_id.is_some()
+            && credentials[0].1.account_id != credentials[1].1.account_id,
+        "two distinct configured workspace accounts required"
+    );
+    println!(
+        "distinct_configured_identities=true distinct_workspace_accounts=true upstream_canonical=true"
+    );
+    let model = std::env::var("COMRADEX_PROBE_MODEL")
+        .expect("set COMRADEX_PROBE_MODEL to the configured client model");
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(120))
+        .build()
+        .expect("HTTP client");
+    let endpoint = format!("{}/responses", config.proxy.upstream);
+    let prompt = json!({"role":"user", "content":"Four people must cross a bridge at night with one torch. Their crossing times are 1, 2, 5, and 10 minutes. At most two can cross together, a pair takes the slower person's time, and the torch must be carried on every crossing. Work out the minimum total crossing time. Then use the add tool with that minimum as a and 25 as b. Once the tool returns, answer only with the integer it returned."});
+    let mut request = json!({
+        "model": model, "instructions": "Perform the harmless arithmetic task.",
+        "store": false, "stream": true, "reasoning": {"effort":"high"},
+        "include": ["reasoning.encrypted_content"],
+        "input": [prompt],
+        "tools": [{"type":"function", "name":"add", "description":"Add two integers.", "parameters":{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"],"additionalProperties":false},"strict":true}],
+        "tool_choice": "required", "parallel_tool_calls": false
+    });
+    let output = response(
+        &client,
+        &endpoint,
+        &credentials[0].1,
+        &request,
+        "generate_a",
+    )
+    .await
+    .expect("account A generation failed; see safe stage metadata");
+    let items = output["output"]
+        .as_array()
+        .expect("generation output array");
+    println!(
+        "generation_items={} reasoning_items={} encrypted_reasoning_items={} function_calls={}",
+        items.len(),
+        items
+            .iter()
+            .filter(|item| item["type"] == "reasoning")
+            .count(),
+        items
+            .iter()
+            .filter(|item| item["type"] == "reasoning"
+                && item["encrypted_content"]
+                    .as_str()
+                    .is_some_and(|s| !s.is_empty()))
+            .count(),
+        items
+            .iter()
+            .filter(|item| item["type"] == "function_call")
+            .count()
+    );
+    assert!(
+        items.iter().any(|item| item["type"] == "reasoning"
+            && item["encrypted_content"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty())),
+        "generation must contain native encrypted reasoning"
+    );
+    let calls: Vec<_> = items
+        .iter()
+        .filter(|item| item["type"] == "function_call")
+        .collect();
+    assert!(
+        calls.len() == 1 && calls[0]["name"] == "add",
+        "expected one synthetic tool call"
+    );
+    let arguments: Value =
+        serde_json::from_str(calls[0]["arguments"].as_str().expect("tool arguments"))
+            .expect("tool argument JSON");
+    assert!(
+        arguments["a"] == 17 && arguments["b"] == 25,
+        "expected synthetic tool arguments"
+    );
+    let mut input = vec![prompt];
+    input.extend(items.iter().cloned());
+    input.push(json!({"type":"function_call_output","call_id":calls[0]["call_id"],"output":"42"}));
+    request["input"] = Value::Array(input);
+    request["tool_choice"] = json!("auto");
+    let bytes_before = serde_json::to_vec(&request).unwrap();
+    let control = response(
+        &client,
+        &endpoint,
+        &credentials[0].1,
+        &request,
+        "same_account_tool_continuation",
+    )
+    .await;
+    let cross = response(
+        &client,
+        &endpoint,
+        &credentials[1].1,
+        &request,
+        "cross_account_tool_continuation",
+    )
+    .await;
+    assert!(
+        bytes_before == serde_json::to_vec(&request).unwrap(),
+        "continuation request was mutated"
+    );
+    println!("exact_native_items_preserved=true same_request_bytes=true");
+    assert!(
+        control.is_some(),
+        "same-account control failed; qualification inconclusive"
+    );
+    assert!(
+        cross.is_some(),
+        "cross-account qualification failed; native portability is not qualified"
+    );
+    for result in [control.unwrap(), cross.unwrap()] {
+        assert!(
+            result["output"]
+                .as_array()
+                .is_some_and(|items| items.iter().any(|item| item["content"]
+                    .as_array()
+                    .is_some_and(|content| content.iter().any(|part| part["text"]
+                        .as_str()
+                        .is_some_and(|text| text.trim() == "42"))))),
+            "continuation must complete the synthetic tool task"
+        );
+    }
+    println!("native_reasoning_portability_qualified=true tool_continuations_correct=true");
+}


### PR DESCRIPTION
Self-contained requests can replay native reasoning items across accounts without changing or removing encrypted_content. The exception applies only to complete reasoning items directly in input; compaction, private encrypted tool output, files, and existing ownership restrictions keep their current handling.

A live same-account control and cross-account continuation passed against the configured Codex backend with gpt-6-astra, preserving the entire input and completing a tool call. This qualifies the tested account/model/backend combination; HTTP, bridge, and direct WebSocket regression tests cover the routing behavior.
