### PR TITLE
Retry capacity rejections after response acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ status metadata and keeps credentials, native items, and synthetic response text
 
 Quota cooldowns recover automatically on the next selection or status request. When upstream reports several quota windows, only windows explicitly reported at 100% constrain a quota rejection; unrelated longer windows do not keep the account blocked. `comradex status` and `comradex status --json` expose each account's availability, retry deadline, usage, and blocking quota windows. Neither Comradex nor Codex needs to be restarted when a quota window resets.
 
-Requests up to 256 KiB are replayed from memory by default; larger requests use a temporary file, and all bodies have a hard cap. Responses and upgraded streams are forwarded with backpressure and are never retained.
+Requests up to 256 KiB are replayed from memory by default; larger requests use a temporary file, and all bodies have a hard cap. Responses and upgraded streams are forwarded with backpressure. The Responses WebSocket modes may briefly buffer lifecycle metadata as described below; model output is never retained for retry.
 
 ### Responses WebSocket modes
 
@@ -271,6 +271,8 @@ Select behavior with `proxy.responses_websocket_mode`:
 - `direct` keeps upstream WebSocket transport while routing and tracking each `response.create` frame independently. It supports multiplexed, out-of-order turns, reconnects only before visible output, refreshes an expired credential on the same account before considering one alternate, and can remove a stale `previous_response_id` only when the request contains a verified self-contained full resend. If safe internal replay is unavailable, it preserves Codex's canonical `previous_response_not_found` retry classifier while removing account-scoped details.
 
 Direct mode uses the explicit refresh-then-alternate sequence above. Live Voice upgrades are separate from these modes and remain raw, call-bound relays.
+
+Both Responses WebSocket modes can use their one unused replay allowance after an explicit capacity rejection when the upstream emitted only empty `response.created`/`response.in_progress` metadata and the terminal proves zero output tokens. Missing usage, output items or deltas (including reasoning and tools), quota failures, and interrupted streams do not qualify. Eligible metadata is buffered for at most one second, 16 frames, or 64 KiB; any other event releases it immediately. A successful alternate therefore exposes one lifecycle with its original response ID and sequence numbers. When no alternate can be dispatched, the original lifecycle and rejection are preserved. File, turn-state, and nonportable context ownership restrictions still apply. Raw HTTP streaming does not use this accepted-work retry.
 
 HTTP bridge sessions have their own `proxy.max_bridge_sessions` limit (256 by default), separate from `proxy.max_upgrades`, which continues to bound raw/direct upstream upgrades and Live Voice. At bridge capacity, Comradex closes the least-recently-used idle session before admitting a replacement. Sessions with active turns are never evicted. Idle bridge sessions close after `proxy.bridge_idle_seconds` (900 by default), and admission waits up to `proxy.bridge_admission_timeout_millis` (2000 by default) for a closing session before returning a retryable `503 at_capacity` response with `Retry-After: 1`.
 

--- a/src/proxy/accepted_retry.rs
+++ b/src/proxy/accepted_retry.rs
@@ -1,0 +1,229 @@
+//! The only accepted work that may move accounts is an explicit capacity
+//! rejection after empty lifecycle metadata, with affirmative zero-output usage.
+//! Keeping these exact frames private avoids translating response IDs or sequence
+//! numbers across upstream attempts.
+
+use serde_json::Value;
+
+use super::websocket_protocol::{FailureKind, classify_terminal_event};
+
+const MAX_LIFECYCLE_EVENTS: usize = 16;
+const MAX_LIFECYCLE_BYTES: usize = 64 * 1024;
+
+#[derive(Debug)]
+pub(super) struct BufferedEvent {
+    pub payload: String,
+    pub value: Value,
+}
+
+#[derive(Debug)]
+pub(super) struct LifecycleBuffer {
+    enabled: bool,
+    response_id: Option<String>,
+    bytes: usize,
+    events: Vec<BufferedEvent>,
+}
+
+impl LifecycleBuffer {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            response_id: None,
+            bytes: 0,
+            events: Vec::new(),
+        }
+    }
+
+    /// Returns true only when this exact event was retained. Any other event
+    /// must release the buffer before it is delivered, and closes the retry gate.
+    pub fn retain(&mut self, event: &Value, payload: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let kind = event.get("type").and_then(Value::as_str);
+        let response = event.get("response");
+        let id = response
+            .and_then(|response| response.get("id"))
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty());
+        let lifecycle = match kind {
+            Some("response.created") => self.response_id.is_none() && id.is_some(),
+            Some("response.in_progress") => self.response_id.is_some() && id.is_some(),
+            _ => false,
+        };
+        let same_response = self
+            .response_id
+            .as_deref()
+            .is_none_or(|previous| Some(previous) == id);
+        let empty = response.is_some_and(|response| {
+            response
+                .get("output")
+                .is_none_or(|output| output.as_array().is_some_and(Vec::is_empty))
+                && response
+                    .get("usage")
+                    .filter(|usage| !usage.is_null())
+                    .is_none_or(zero_output_usage)
+        });
+        if !lifecycle
+            || !same_response
+            || !empty
+            || self.events.len() >= MAX_LIFECYCLE_EVENTS
+            || payload.len() > MAX_LIFECYCLE_BYTES.saturating_sub(self.bytes)
+        {
+            self.enabled = false;
+            return false;
+        }
+        self.response_id = id.map(str::to_owned);
+        self.bytes += payload.len();
+        self.events.push(BufferedEvent {
+            payload: payload.to_owned(),
+            value: event.clone(),
+        });
+        true
+    }
+
+    pub fn permits_capacity_retry(&self, terminal: &Value) -> bool {
+        self.enabled
+            && !self.events.is_empty()
+            && classify_terminal_event(terminal).kind == FailureKind::Capacity
+            && terminal.get("response").is_some_and(|response| {
+                response.get("id").and_then(Value::as_str) == self.response_id.as_deref()
+                    && response
+                        .get("output")
+                        .and_then(Value::as_array)
+                        .is_some_and(Vec::is_empty)
+                    && response.get("usage").is_some_and(zero_output_usage)
+            })
+    }
+
+    /// Release preserves the original payloads, including sequence numbers and
+    /// unknown fields. Once anything is released, this attempt cannot be hidden.
+    pub fn release(&mut self) -> Vec<BufferedEvent> {
+        self.enabled = false;
+        self.bytes = 0;
+        std::mem::take(&mut self.events)
+    }
+}
+
+fn zero_output_usage(usage: &Value) -> bool {
+    usage.get("output_tokens").and_then(Value::as_u64) == Some(0)
+        && ["output_tokens_details", "completion_tokens_details"]
+            .iter()
+            .all(|key| {
+                usage.get(key).is_none_or(|details| {
+                    details.is_null()
+                        || details.as_object().is_some_and(|details| {
+                            details.values().all(|value| value.as_u64() == Some(0))
+                        })
+                })
+            })
+        && ["completion_tokens", "reasoning_tokens"]
+            .iter()
+            .all(|key| usage.get(key).is_none_or(|value| value.as_u64() == Some(0)))
+        && match (usage.get("input_tokens"), usage.get("total_tokens")) {
+            (Some(input), Some(total)) => {
+                input.as_u64().is_some() && input.as_u64() == total.as_u64()
+            }
+            _ => true,
+        }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn created() -> Value {
+        json!({"type":"response.created","sequence_number":0,
+            "response":{"id":"resp_a","output":[],"usage":null}})
+    }
+
+    fn capacity() -> Value {
+        json!({"type":"response.failed","sequence_number":2,"response":{
+            "id":"resp_a","output":[],"usage":{"output_tokens":0,
+                "output_tokens_details":{"reasoning_tokens":0}},
+            "error":{"code":"server_is_overloaded"}}})
+    }
+
+    #[test]
+    fn requires_affirmative_zero_output_usage_and_matching_response() {
+        let mut buffer = LifecycleBuffer::new(true);
+        let created = created();
+        assert!(buffer.retain(&created, &created.to_string()));
+        assert!(buffer.permits_capacity_retry(&capacity()));
+        for usage in [
+            Value::Null,
+            json!({}),
+            json!({"output_tokens":1}),
+            json!({"output_tokens":"0"}),
+            json!({"output_tokens":0,"output_tokens_details":{"reasoning_tokens":1}}),
+            json!({"output_tokens":0,"output_tokens_details":{"reasoning_tokens":null}}),
+            json!({"output_tokens":0,"completion_tokens":1}),
+            json!({"output_tokens":0,"reasoning_tokens":1}),
+            json!({"output_tokens":0,"reasoning_tokens":"0"}),
+            json!({"output_tokens":0,"completion_tokens_details":{"reasoning_tokens":1}}),
+            json!({"output_tokens":0,"input_tokens":2,"total_tokens":3}),
+        ] {
+            let mut terminal = capacity();
+            terminal["response"]["usage"] = usage;
+            assert!(!buffer.permits_capacity_retry(&terminal), "{terminal}");
+        }
+        let mut terminal = capacity();
+        terminal["response"]["id"] = json!("resp_other");
+        assert!(!buffer.permits_capacity_retry(&terminal));
+        terminal = capacity();
+        terminal["response"]["output"] = json!([{"type":"reasoning"}]);
+        assert!(!buffer.permits_capacity_retry(&terminal));
+    }
+
+    #[test]
+    fn first_other_event_including_empty_output_shell_permanently_closes_gate() {
+        for kind in [
+            "response.output_item.added",
+            "response.output_item.done",
+            "response.output_text.delta",
+            "response.reasoning_text.delta",
+            "response.reasoning_summary_text.delta",
+            "response.function_call_arguments.delta",
+            "response.custom_tool_call_input.delta",
+            "response.content_part.added",
+            "response.audio.delta",
+            "response.metadata",
+            "unknown",
+        ] {
+            let mut buffer = LifecycleBuffer::new(true);
+            let created = created();
+            assert!(buffer.retain(&created, &created.to_string()));
+            let output = json!({"type":kind,"delta":""});
+            assert!(!buffer.retain(&output, &output.to_string()));
+            assert!(!buffer.permits_capacity_retry(&capacity()), "{kind}");
+            assert_eq!(buffer.release()[0].value, created);
+        }
+    }
+
+    #[test]
+    fn preserves_exact_payloads_and_bounds_count_and_bytes() {
+        let mut buffer = LifecycleBuffer::new(true);
+        let created = created();
+        let payload = format!("  {}  ", created);
+        assert!(buffer.retain(&created, &payload));
+        let mut progress = created.clone();
+        progress["type"] = json!("response.in_progress");
+        let progress_payload = format!("  {}  ", progress);
+        for _ in 1..MAX_LIFECYCLE_EVENTS {
+            assert!(buffer.retain(&progress, &progress_payload));
+        }
+        assert!(!buffer.retain(&progress, &progress_payload));
+        assert!(!buffer.permits_capacity_retry(&capacity()));
+        let events = buffer.release();
+        assert_eq!(events[0].payload, payload);
+        assert!(
+            events[1..]
+                .iter()
+                .all(|event| event.payload == progress_payload)
+        );
+        let mut buffer = LifecycleBuffer::new(true);
+        assert!(!buffer.retain(&created, &" ".repeat(MAX_LIFECYCLE_BYTES + 1)));
+        assert!(buffer.release().is_empty());
+    }
+}

--- a/src/proxy/accepted_retry_tests.rs
+++ b/src/proxy/accepted_retry_tests.rs
@@ -1,0 +1,801 @@
+use super::*;
+use crate::config::{AccountConfig, ProxyConfig};
+use bytes::Bytes;
+use serde_json::{Value, json};
+use std::{collections::BTreeMap, fs, sync::Mutex};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+#[derive(Clone)]
+struct Script {
+    status: StatusCode,
+    events: Vec<Value>,
+    close: bool,
+    resume_after_created: Option<Arc<Notify>>,
+}
+
+impl Script {
+    fn events(events: Vec<Value>) -> Self {
+        Self {
+            status: StatusCode::OK,
+            events,
+            close: false,
+            resume_after_created: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Dispatch {
+    authorization: String,
+    body: Value,
+}
+
+struct Fixture {
+    address: std::net::SocketAddr,
+    seen: Arc<Mutex<Vec<Dispatch>>>,
+    router: Arc<Router>,
+    file_owners: Arc<AffinityStore>,
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+    _dir: tempfile::TempDir,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+fn take_script(
+    seen: &Mutex<Vec<Dispatch>>,
+    scripts: &[Script],
+    authorization: &str,
+    body: Value,
+) -> Script {
+    let mut seen = seen.lock().unwrap();
+    let index = seen.len();
+    seen.push(Dispatch {
+        authorization: authorization.to_owned(),
+        body,
+    });
+    // An unexpected third dispatch completes promptly so the assertion, rather than a hang,
+    // identifies a retry-budget regression.
+    scripts
+        .get(index)
+        .cloned()
+        .unwrap_or_else(|| success("resp_unexpected"))
+}
+
+impl Fixture {
+    async fn start(mode: ResponsesWebsocketMode, scripts: Vec<Script>) -> Self {
+        Self::start_with_members(mode, scripts, &["a", "b", "c"]).await
+    }
+
+    async fn start_with_members(
+        mode: ResponsesWebsocketMode,
+        scripts: Vec<Script>,
+        members: &[&str],
+    ) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_address = upstream.local_addr().unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let upstream_seen = seen.clone();
+        let scripts = Arc::new(scripts);
+        let server = tokio::spawn(async move {
+            loop {
+                let (stream, _) = upstream.accept().await.unwrap();
+                let seen = upstream_seen.clone();
+                let scripts = scripts.clone();
+                tokio::spawn(async move {
+                    let service = service_fn(move |mut req: Request<Incoming>| {
+                        let seen = seen.clone();
+                        let scripts = scripts.clone();
+                        async move {
+                            let authorization =
+                                req.headers()[AUTHORIZATION].to_str().unwrap().to_owned();
+                            if req.headers().contains_key(SEC_WEBSOCKET_KEY) {
+                                let refusal = {
+                                    let dispatches = seen.lock().unwrap();
+                                    scripts
+                                        .get(dispatches.len())
+                                        .filter(|script| script.status != StatusCode::OK)
+                                        .cloned()
+                                };
+                                if let Some(script) = refusal {
+                                    take_script(&seen, &scripts, &authorization, Value::Null);
+                                    return Ok::<_, Infallible>(
+                                        Response::builder()
+                                            .status(script.status)
+                                            .header(CONTENT_TYPE, "application/json")
+                                            .body(bytes_body(Bytes::from_static(
+                                                br#"{"error":{"code":"server_is_overloaded"}}"#,
+                                            )))
+                                            .unwrap(),
+                                    );
+                                }
+                                let accept =
+                                    tokio_tungstenite::tungstenite::handshake::derive_accept_key(
+                                        req.headers()[SEC_WEBSOCKET_KEY].as_bytes(),
+                                    );
+                                let upgrade = hyper::upgrade::on(&mut req);
+                                tokio::spawn(async move {
+                                    let Ok(upgraded) = upgrade.await else { return };
+                                    let mut ws = WebSocketStream::from_raw_socket(
+                                        TokioIo::new(upgraded),
+                                        Role::Server,
+                                        None,
+                                    )
+                                    .await;
+                                    while let Some(Ok(Message::Text(text))) = ws.next().await {
+                                        let body = serde_json::from_str(&text).unwrap();
+                                        let script =
+                                            take_script(&seen, &scripts, &authorization, body);
+                                        for (index, event) in script.events.into_iter().enumerate()
+                                        {
+                                            if index == 1
+                                                && let Some(gate) = &script.resume_after_created
+                                            {
+                                                gate.notified().await;
+                                            }
+                                            if ws
+                                                .send(Message::Text(event.to_string().into()))
+                                                .await
+                                                .is_err()
+                                            {
+                                                return;
+                                            }
+                                        }
+                                        if script.close {
+                                            let _ = ws.close(None).await;
+                                            return;
+                                        }
+                                    }
+                                });
+                                return Ok::<_, Infallible>(
+                                    Response::builder()
+                                        .status(StatusCode::SWITCHING_PROTOCOLS)
+                                        .header(CONNECTION, "Upgrade")
+                                        .header(UPGRADE, "websocket")
+                                        .header(SEC_WEBSOCKET_ACCEPT, accept)
+                                        .body(bytes_body(Bytes::new()))
+                                        .unwrap(),
+                                );
+                            }
+                            let bytes = req.into_body().collect().await.unwrap().to_bytes();
+                            let body = serde_json::from_slice(&bytes).unwrap();
+                            let script = take_script(&seen, &scripts, &authorization, body);
+                            let body = if script.status == StatusCode::OK {
+                                let gate = script.resume_after_created;
+                                let stream = futures_util::stream::unfold(
+                                    (script.events.into_iter().enumerate(), gate),
+                                    |(mut events, gate)| async move {
+                                        let (index, event) = events.next()?;
+                                        if index == 1
+                                            && let Some(gate) = &gate
+                                        {
+                                            gate.notified().await;
+                                        }
+                                        Some((
+                                            Ok::<_, std::io::Error>(Frame::data(Bytes::from(
+                                                format!("data: {event}\n\n"),
+                                            ))),
+                                            (events, gate),
+                                        ))
+                                    },
+                                );
+                                BodyExt::boxed(http_body_util::StreamBody::new(stream))
+                            } else {
+                                bytes_body(Bytes::from(json!({"error":{"code":"server_is_overloaded","message":"Capacity exhausted"}}).to_string()))
+                            };
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(script.status)
+                                    .header(
+                                        CONTENT_TYPE,
+                                        if script.status == StatusCode::OK {
+                                            "text/event-stream"
+                                        } else {
+                                            "application/json"
+                                        },
+                                    )
+                                    .body(body)
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .with_upgrades()
+                        .await;
+                });
+            }
+        });
+        let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = tcp.local_addr().unwrap();
+        let listener = ListenerConfig {
+            address,
+            pool: "default".into(),
+        };
+        let accounts = members
+            .iter()
+            .copied()
+            .map(|name| {
+                let path = dir.path().join(name);
+                fs::create_dir_all(&path).unwrap();
+                fs::write(
+                    path.join("auth.json"),
+                    json!({"tokens":{"access_token":format!("token-{name}")}}).to_string(),
+                )
+                .unwrap();
+                (name.to_owned(), AccountConfig::CodexHome { path })
+            })
+            .collect();
+        let config = Arc::new(Config {
+            proxy: ProxyConfig {
+                upstream: format!("http://{upstream_address}/backend-api/codex"),
+                responses_websocket_mode: mode,
+                installation_secret: "0123456789abcdef".into(),
+                affinity_key: "0123456789abcdef0123456789abcdef".into(),
+                state_dir: Some(dir.path().join("state")),
+                ..ProxyConfig::default()
+            },
+            listeners: BTreeMap::from([("default".into(), listener.clone())]),
+            pools: BTreeMap::from([(
+                "default".into(),
+                PoolConfig {
+                    members: members.iter().map(|name| (*name).to_owned()).collect(),
+                    preferred: Some("a".into()),
+                },
+            )]),
+            accounts,
+        });
+        let affinity = Arc::new(
+            AffinityStore::load(
+                dir.path().join("affinity.json"),
+                &config.proxy.affinity_key,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Arc::new(Router::new(&config, affinity));
+        let app = App::new_unvalidated(config, router.clone(), Arc::new(Stats::default())).unwrap();
+        let file_owners = app.file_owners.clone();
+        let proxy = tokio::spawn(async move {
+            app.serve_tcp("default".into(), listener, tcp)
+                .await
+                .unwrap();
+        });
+        Self {
+            address,
+            seen,
+            router,
+            file_owners,
+            tasks: vec![server, proxy],
+            _dir: dir,
+        }
+    }
+
+    async fn connect(&self) -> WebSocketStream<TcpStream> {
+        self.connect_with_headers(&[]).await
+    }
+
+    async fn connect_with_headers(&self, headers: &[(&str, &str)]) -> WebSocketStream<TcpStream> {
+        let stream = TcpStream::connect(self.address).await.unwrap();
+        let mut request = format!("ws://{}/0123456789abcdef/v1/responses", self.address)
+            .into_client_request()
+            .unwrap();
+        request
+            .headers_mut()
+            .insert(AUTHORIZATION, "Bearer caller-token".parse().unwrap());
+        for (name, value) in headers {
+            request.headers_mut().insert(
+                hyper::header::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                value.parse().unwrap(),
+            );
+        }
+        tokio_tungstenite::client_async(request, stream)
+            .await
+            .unwrap()
+            .0
+    }
+}
+
+fn created(id: &str) -> Value {
+    json!({"type":"response.created","sequence_number":0,"response":{"id":id,"status":"in_progress","output":[],"usage":null}})
+}
+
+fn capacity(id: &str) -> Script {
+    Script::events(vec![
+        created(id),
+        json!({"type":"response.in_progress","sequence_number":1,"response":{"id":id,"status":"in_progress","output":[],"usage":null}}),
+        json!({"type":"response.failed","sequence_number":2,"response":{
+            "id":id,"status":"failed","output":[],
+            "usage":{"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0}},
+            "error":{"code":"server_is_overloaded","message":"Capacity exhausted"}
+        }}),
+    ])
+}
+
+fn success(id: &str) -> Script {
+    Script::events(vec![
+        created(id),
+        json!({"type":"response.output_item.done","sequence_number":1,"response_id":id,"output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}}),
+        json!({"type":"response.completed","sequence_number":2,"response":{
+            "id":id,"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}],
+            "usage":{"output_tokens":1,"output_tokens_details":{"reasoning_tokens":0}}
+        }}),
+    ])
+}
+
+async fn send_create(ws: &mut WebSocketStream<TcpStream>, previous: Option<&str>) {
+    let mut request = json!({"type":"response.create","model":"gpt-5","input":[{"role":"user","content":"hello"}]});
+    if let Some(id) = previous {
+        request["previous_response_id"] = json!(id);
+        request["input"][0]["content"] = json!("followup");
+    }
+    ws.send(Message::Text(request.to_string().into()))
+        .await
+        .unwrap();
+}
+
+async fn collect_turn(ws: &mut WebSocketStream<TcpStream>) -> Vec<Value> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut events = Vec::new();
+        while let Some(Ok(message)) = ws.next().await {
+            match message {
+                Message::Text(text) => {
+                    let event: Value = serde_json::from_str(&text).unwrap();
+                    let terminal = matches!(
+                        event["type"].as_str(),
+                        Some(
+                            "response.completed"
+                                | "response.failed"
+                                | "response.incomplete"
+                                | "error"
+                        )
+                    );
+                    events.push(event);
+                    if terminal {
+                        break;
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+        events
+    })
+    .await
+    .expect("proxy did not settle the scripted turn")
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_is_invisible_and_continuation_uses_replacement() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        for terminal_type in ["response.failed", "response.incomplete", "error"] {
+            let mut rejection = capacity("resp_a");
+            rejection.events[2]["type"] = json!(terminal_type);
+            if terminal_type == "response.incomplete" {
+                rejection.events[2]["response"]["status"] = json!("incomplete");
+            }
+            let fixture = Fixture::start(
+                mode,
+                vec![rejection, success("resp_b"), success("resp_next")],
+            )
+            .await;
+            let mut ws = fixture.connect().await;
+            send_create(&mut ws, None).await;
+            let events = collect_turn(&mut ws).await;
+            assert_eq!(events, success("resp_b").events, "mode {mode:?}");
+            send_create(&mut ws, Some("resp_b")).await;
+            assert_eq!(collect_turn(&mut ws).await, success("resp_next").events);
+            assert!(
+                fixture
+                    .router
+                    .affinity
+                    .get(&fixture.router.affinity.key("previous-response:resp_a"))
+                    .await
+                    .is_none()
+            );
+            assert_eq!(
+                fixture
+                    .router
+                    .affinity
+                    .get(&fixture.router.affinity.key("previous-response:resp_b"))
+                    .await
+                    .map(|binding| binding.account_id),
+                Some("b".into())
+            );
+            let seen = fixture.seen.lock().unwrap();
+            assert_eq!(seen.len(), 3, "{seen:?}");
+            assert_eq!(seen[0].authorization, "Bearer token-a");
+            assert_eq!(seen[1].authorization, "Bearer token-b");
+            assert_eq!(seen[2].authorization, "Bearer token-b");
+            if mode == ResponsesWebsocketMode::Direct {
+                assert_eq!(seen[2].body["previous_response_id"], "resp_b");
+            } else {
+                assert!(seen[2].body.get("previous_response_id").is_none());
+                let input = seen[2].body["input"].as_array().unwrap();
+                assert!(
+                    input.iter().any(|item| item["role"] == "assistant"),
+                    "{input:?}"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_never_replays_raw_http_streams() {
+    let rejection = capacity("resp_a");
+    let fixture = Fixture::start(
+        ResponsesWebsocketMode::HttpBridge,
+        vec![rejection.clone(), success("resp_unexpected")],
+    )
+    .await;
+    let response = reqwest::Client::new()
+        .post(format!(
+            "http://{}/0123456789abcdef/v1/responses",
+            fixture.address
+        ))
+        .bearer_auth("caller-token")
+        .header(CONTENT_TYPE.as_str(), "application/json")
+        .body(json!({"model":"gpt-5","stream":true,"input":"hello"}).to_string())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.text().await.unwrap();
+    assert_eq!(
+        body,
+        rejection
+            .events
+            .iter()
+            .map(|event| format!("data: {event}\n\n"))
+            .collect::<String>()
+    );
+    let seen = fixture.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].authorization, "Bearer token-a");
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_requires_explicit_zero_output_and_capacity() {
+    let base = capacity("resp_a");
+    let mut cases = Vec::new();
+    for event in [
+        json!({"type":"response.output_text.delta","response_id":"resp_a","delta":"hello"}),
+        json!({"type":"response.output_item.added","response_id":"resp_a","output_index":0,"item":{"type":"reasoning","id":"rs_1","summary":[]}}),
+        json!({"type":"response.output_item.added","response_id":"resp_a","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"tool","arguments":""}}),
+    ] {
+        let mut script = base.clone();
+        script.events.insert(2, event);
+        cases.push(script);
+    }
+    let mut positive_output = base.clone();
+    positive_output.events[2]["response"]["usage"]["output_tokens"] = json!(1);
+    cases.push(positive_output);
+    let mut positive_reasoning = base.clone();
+    positive_reasoning.events[2]["response"]["usage"]["output_tokens_details"]["reasoning_tokens"] =
+        json!(1);
+    cases.push(positive_reasoning);
+    let mut missing_usage = base.clone();
+    missing_usage.events[2]["response"]
+        .as_object_mut()
+        .unwrap()
+        .remove("usage");
+    cases.push(missing_usage);
+    let mut quota = base.clone();
+    quota.events[2]["response"]["error"]["code"] = json!("insufficient_quota");
+    cases.push(quota);
+    for usage in [
+        json!({"input_tokens":2,"total_tokens":3,"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0}}),
+        json!({"output_tokens":0,"reasoning_tokens":1,"output_tokens_details":{"reasoning_tokens":0}}),
+        json!({"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"completion_tokens_details":{"reasoning_tokens":1}}),
+        json!({"output_tokens":"0","output_tokens_details":{"reasoning_tokens":0}}),
+    ] {
+        let mut script = base.clone();
+        script.events[2]["response"]["usage"] = usage;
+        cases.push(script);
+    }
+    let mut terminal_output = base.clone();
+    terminal_output.events[2]["response"]["output"] =
+        json!([{"type":"reasoning","id":"rs_terminal","summary":[]}]);
+    cases.push(terminal_output);
+    let mut unknown = base.clone();
+    unknown.events.insert(
+        2,
+        json!({"type":"response.future_event","response_id":"resp_a"}),
+    );
+    cases.push(unknown);
+    let mut duplicate_created = base.clone();
+    duplicate_created.events.insert(1, created("resp_a"));
+    cases.push(duplicate_created);
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        for (index, script) in cases.iter().enumerate() {
+            let fixture =
+                Fixture::start(mode, vec![script.clone(), success("resp_unexpected")]).await;
+            let mut ws = fixture.connect().await;
+            send_create(&mut ws, None).await;
+            let events = collect_turn(&mut ws).await;
+            let mut expected = script.events.clone();
+            if mode == ResponsesWebsocketMode::HttpBridge
+                && expected.last().unwrap()["response"]["error"]["code"] == "insufficient_quota"
+            {
+                let terminal = expected.last_mut().unwrap();
+                terminal["status"] = json!(429);
+                terminal["headers"] = json!({});
+            }
+            assert_eq!(events, expected, "mode {mode:?}, case {index}");
+            let seen = fixture.seen.lock().unwrap();
+            assert_eq!(seen.len(), 1, "mode {mode:?}, case {index}: {seen:?}");
+            assert_eq!(seen[0].authorization, "Bearer token-a");
+        }
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_does_not_guess_after_close_or_eof() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        let fixture = Fixture::start(
+            mode,
+            vec![
+                Script {
+                    status: StatusCode::OK,
+                    events: vec![created("resp_a")],
+                    close: true,
+                    resume_after_created: None,
+                },
+                success("resp_unexpected"),
+            ],
+        )
+        .await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        let events = collect_turn(&mut ws).await;
+        assert!(
+            events
+                .iter()
+                .all(|event| event["response"]["id"] != "resp_unexpected")
+        );
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "mode {mode:?}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_has_one_shared_replacement_budget() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        let fixture = Fixture::start(
+            mode,
+            vec![
+                capacity("resp_a"),
+                capacity("resp_b"),
+                success("resp_unexpected"),
+            ],
+        )
+        .await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        let events = collect_turn(&mut ws).await;
+        assert_eq!(events, capacity("resp_b").events, "mode {mode:?}");
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "mode {mode:?}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+        assert_eq!(seen[1].authorization, "Bearer token-b");
+    }
+    let fixture = Fixture::start(
+        ResponsesWebsocketMode::HttpBridge,
+        vec![
+            Script {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                events: vec![],
+                close: false,
+                resume_after_created: None,
+            },
+            capacity("resp_b"),
+            success("resp_unexpected"),
+        ],
+    )
+    .await;
+    let mut ws = fixture.connect().await;
+    send_create(&mut ws, None).await;
+    assert_eq!(collect_turn(&mut ws).await, capacity("resp_b").events);
+    let seen = fixture.seen.lock().unwrap();
+    assert_eq!(seen.len(), 2, "{seen:?}");
+    assert_eq!(seen[0].authorization, "Bearer token-a");
+    assert_eq!(seen[1].authorization, "Bearer token-b");
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_without_alternate_preserves_original_turn() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        let fixture = Fixture::start_with_members(mode, vec![capacity("resp_a")], &["a"]).await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        assert_eq!(
+            collect_turn(&mut ws).await,
+            capacity("resp_a").events,
+            "{mode:?}"
+        );
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "{mode:?}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_replacement_refusal_preserves_original_turn() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        let fixture = Fixture::start(
+            mode,
+            vec![
+                capacity("resp_a"),
+                Script {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    events: vec![],
+                    close: false,
+                    resume_after_created: None,
+                },
+                success("resp_unexpected"),
+            ],
+        )
+        .await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        assert_eq!(
+            collect_turn(&mut ws).await,
+            capacity("resp_a").events,
+            "{mode:?}"
+        );
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "{mode:?}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+        assert_eq!(seen[1].authorization, "Bearer token-b");
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_direct_precreated_failover_consumes_allowance() {
+    for code in ["usage_limit_reached", "server_is_overloaded"] {
+        let fixture = Fixture::start(ResponsesWebsocketMode::Direct, vec![
+            Script::events(vec![json!({"type":"error","error":{"type":"server_error","code":code,"message":code}})]),
+            capacity("resp_b"), success("resp_unexpected"),
+        ]).await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        assert_eq!(
+            collect_turn(&mut ws).await,
+            capacity("resp_b").events,
+            "{code}"
+        );
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "{code}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+        assert_eq!(seen[1].authorization, "Bearer token-b");
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_flushes_lifecycle_before_waiting_indefinitely() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        let resume = Arc::new(Notify::new());
+        let mut script = capacity("resp_a");
+        script.resume_after_created = Some(resume.clone());
+        let fixture = Fixture::start(mode, vec![script, success("resp_unexpected")]).await;
+        let mut ws = fixture.connect().await;
+        send_create(&mut ws, None).await;
+        // The upstream cannot send its terminal until the client sees created. This
+        // demonstrates a bounded flush without relying on a narrowly timed sleep.
+        let first = tokio::time::timeout(Duration::from_secs(5), ws.next())
+            .await
+            .expect("buffered created never became visible")
+            .unwrap()
+            .unwrap();
+        let Message::Text(text) = first else {
+            panic!("expected created, got {first:?}")
+        };
+        assert_eq!(
+            serde_json::from_str::<Value>(&text).unwrap(),
+            created("resp_a")
+        );
+        resume.notify_one();
+        assert_eq!(
+            collect_turn(&mut ws).await,
+            capacity("resp_a").events[1..],
+            "{mode:?}"
+        );
+        let seen = fixture.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "{mode:?}: {seen:?}");
+        assert_eq!(seen[0].authorization, "Bearer token-a");
+    }
+}
+
+#[tokio::test]
+async fn accepted_capacity_retry_preserves_file_hard_and_nonportable_owners() {
+    for mode in [
+        ResponsesWebsocketMode::Direct,
+        ResponsesWebsocketMode::HttpBridge,
+    ] {
+        for (case, input) in [
+            (
+                "file",
+                json!([{"role":"user","content":[{"type":"input_file","file_id":"file_owned"}]}]),
+            ),
+            ("hard", json!([{"role":"user","content":"hello"}])),
+            (
+                "nonportable",
+                json!([{"type":"compaction","id":"cmp_owned","encrypted_content":"native-ciphertext"}]),
+            ),
+        ] {
+            let fixture =
+                Fixture::start(mode, vec![capacity("resp_a"), success("resp_unexpected")]).await;
+            if case == "file" {
+                assert!(
+                    fixture
+                        .file_owners
+                        .put(
+                            fixture.router.affinity.key("file:file_owned"),
+                            "a".into(),
+                            0
+                        )
+                        .await
+                );
+            }
+            if case == "hard" {
+                assert!(
+                    fixture
+                        .router
+                        .bind(fixture.router.affinity.key("turn-state:owned-turn"), "a")
+                        .await
+                );
+            }
+            let headers = if case == "hard" {
+                vec![("x-codex-turn-state", "owned-turn")]
+            } else {
+                vec![]
+            };
+            let mut ws = fixture.connect_with_headers(&headers).await;
+            ws.send(Message::Text(
+                json!({"type":"response.create","model":"gpt-5","input":input})
+                    .to_string()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+            assert_eq!(
+                collect_turn(&mut ws).await,
+                capacity("resp_a").events,
+                "{mode:?}, {case}"
+            );
+            let seen = fixture.seen.lock().unwrap();
+            assert_eq!(seen.len(), 1, "{mode:?}, {case}: {seen:?}");
+            assert_eq!(seen[0].authorization, "Bearer token-a");
+        }
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -7753,6 +7753,8 @@ mod tests {
                 request: Message::Text(value.to_string().into()),
                 routing_value: value.clone(),
                 value,
+                lifecycle: LifecycleBuffer::new(true),
+                lifecycle_deadline: None,
             },
         )]);
         let failure =

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,3 +1,6 @@
+mod accepted_retry;
+#[cfg(test)]
+mod accepted_retry_tests;
 mod context;
 mod context_codec;
 mod context_store;
@@ -66,6 +69,7 @@ use crate::{
     state::Stats,
     transport::{codex_http_connector, codex_websocket_connector},
 };
+use accepted_retry::{BufferedEvent, LifecycleBuffer};
 use replay_body::{ProxyBody, ReplayBody, bytes_body, empty_body, incoming_body, json_body};
 use sse::{ProtocolEvent, SseDecoder, responses_json_events};
 use websocket_protocol::{
@@ -89,6 +93,10 @@ pub(super) const RESPONSES_MISSING_CREATED_TIMEOUT: Duration = Duration::from_se
 pub(super) const RESPONSES_UPSTREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 const RESPONSES_DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const HTTP_BRIDGE_MAX_MATERIALIZED_ITEMS: usize = 4_096;
+// Do not make clients wait for their own created watchdog while the upstream
+// spends a long time before its first output. A delayed rejection simply loses
+// eligibility for transparent retry once this metadata has been released.
+const LIFECYCLE_FLUSH_DELAY: Duration = Duration::from_secs(1);
 
 fn is_direct_hard_continuity(kind: metadata::AffinityKind) -> bool {
     matches!(
@@ -155,6 +163,8 @@ struct DirectTurn {
     request: Message,
     value: serde_json::Value,
     routing_value: serde_json::Value,
+    lifecycle: LifecycleBuffer,
+    lifecycle_deadline: Option<tokio::time::Instant>,
 }
 
 struct DirectUpstream {
@@ -171,6 +181,14 @@ enum ServingLane {
 struct HttpReplayContext {
     previous_response_id: Option<String>,
     lane: ServingLane,
+    bridge_dispatch: Option<Arc<StdMutex<BridgeDispatchState>>>,
+}
+
+#[derive(Default)]
+struct BridgeDispatchState {
+    attempts: usize,
+    cross_account_safe: bool,
+    excluded_account: Option<String>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -398,6 +416,21 @@ struct HttpBridgeCapture {
     response_created: bool,
     progress_events: u64,
     delivery_failed: bool,
+    lifecycle: LifecycleBuffer,
+    capacity_retry: Option<HttpBridgeCapacityRetry>,
+    lifecycle_deadline: Option<tokio::time::Instant>,
+}
+
+#[derive(Debug)]
+struct HttpBridgeCapacityRetry {
+    account: String,
+    events: Vec<BufferedEvent>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct HttpBridgeRetryPolicy {
+    allowed: bool,
+    accepted_work: bool,
 }
 
 #[derive(Debug)]
@@ -406,6 +439,7 @@ struct HttpBridgePumpFailure {
     delivered_event: bool,
     liveness: Option<HttpBridgeLivenessFailure>,
     delivery_failed: bool,
+    accepted_work: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1067,6 +1101,7 @@ impl App {
             HttpReplayContext {
                 previous_response_id: None,
                 lane,
+                bridge_dispatch: None,
             },
         )
         .await
@@ -1084,6 +1119,7 @@ impl App {
         let HttpReplayContext {
             previous_response_id: routing_previous_response_id,
             lane,
+            bridge_dispatch,
         } = context;
         if path.starts_with("/alpha/history/") || path.starts_with("/alpha/notes/") {
             return self
@@ -1185,6 +1221,7 @@ impl App {
             .collect();
         let mut bound_account: Option<String> = None;
         let mut hard_owner = false;
+        let mut non_previous_hard_owner = false;
         let mut known_file_owners = 0usize;
         let mut missing_hard_owner = false;
         let soft_routing_key = affinity_keys
@@ -1228,6 +1265,7 @@ impl App {
                 ));
             }
             hard_owner = true;
+            non_previous_hard_owner |= *kind != metadata::AffinityKind::PreviousResponse;
             if *kind == metadata::AffinityKind::File {
                 known_file_owners += 1;
             }
@@ -1247,6 +1285,19 @@ impl App {
                 "request carries hard continuity state with no known account owner",
             ));
         }
+        let excluded_account = bridge_dispatch.as_ref().and_then(|dispatch| {
+            dispatch
+                .lock()
+                .expect("bridge dispatch")
+                .excluded_account
+                .clone()
+        });
+        if bound_account
+            .as_ref()
+            .is_some_and(|account| Some(account) == excluded_account.as_ref())
+        {
+            anyhow::bail!("accepted retry cannot leave its continuity owner")
+        }
         let first = if let Some(account) = &bound_account {
             match self.router.select_exact(pool, account).await {
                 Some(selection) => selection,
@@ -1260,14 +1311,36 @@ impl App {
             }
         } else {
             self.router
-                .select(&listener.pool, pool, soft_routing_key, None)
+                .select(
+                    &listener.pool,
+                    pool,
+                    soft_routing_key,
+                    excluded_account.as_deref(),
+                )
                 .await
                 .context("no eligible account")?
         };
+        if excluded_account.as_deref() == Some(first.account_id.as_str()) {
+            anyhow::bail!("no alternate account for accepted capacity retry")
+        }
         let mut selected = first;
         let nonportable_payload = replay.has_nonportable_state();
         let mut payload_dispatch_owner: Option<String> = None;
-        for attempt in 0..2 {
+        let first_attempt = if let Some(dispatch) = &bridge_dispatch {
+            let mut dispatch = dispatch.lock().expect("bridge dispatch");
+            dispatch.cross_account_safe &=
+                !non_previous_hard_owner && !nonportable_payload && file_ids.is_empty();
+            dispatch.attempts
+        } else {
+            0
+        };
+        if first_attempt >= 2 {
+            anyhow::bail!("Responses bridge replay budget exhausted")
+        }
+        for attempt in first_attempt..2 {
+            if let Some(dispatch) = &bridge_dispatch {
+                dispatch.lock().expect("bridge dispatch").attempts = attempt + 1;
+            }
             let account = selected.account_id.clone();
             // Dispatch-boundary fence (fix1): `select` above ran before this await. Credential
             // resolution holds a file lock + HomeAuthLock + OAuth I/O for up to 15s, during
@@ -2035,6 +2108,12 @@ impl App {
                         .and_then(serde_json::Value::as_array)
                         .cloned()
                         .unwrap_or_default();
+                    let mut retry_frame = frame.clone();
+                    retry_frame["type"] = serde_json::Value::String("response.create".into());
+                    if let Some(anchor) = &routing_previous_response_id {
+                        retry_frame["previous_response_id"] =
+                            serde_json::Value::String(anchor.clone());
+                    }
                     let body = match serde_json::to_vec(&frame) {
                         Ok(body) => bytes::Bytes::from(body),
                         Err(error) => {
@@ -2058,126 +2137,19 @@ impl App {
                     active_turn = self
                         .spawn_tracked_task(async move {
                             let _turn_guard = turn_guard;
-                            let dispatch_deadline =
-                                tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT;
-                            let replay = match ReplayBody::from_bytes(
+                            app.run_http_bridge_turn(
+                                headers,
+                                &listener,
+                                path,
                                 body,
-                                app.config.proxy.max_request_bytes,
-                                app.config.proxy.max_spool_bytes,
-                                app.stats.clone(),
-                            ) {
-                                Ok(replay) => replay,
-                                Err(error) => {
-                                    send_ws_error(
-                                        &outbound,
-                                        "invalid_request_error",
-                                        &error.to_string(),
-                                    )
-                                    .await;
-                                    return;
-                                }
-                            };
-                            match tokio::time::timeout_at(
-                                dispatch_deadline,
-                                app.handle_http_replay_with_routing_anchor(
-                                    headers,
-                                    Method::POST,
-                                    &listener,
-                                    path,
-                                    replay,
-                                    HttpReplayContext {
-                                        previous_response_id: routing_previous_response_id,
-                                        lane: ServingLane::Bridge,
-                                    },
-                                ),
+                                routing_previous_response_id,
+                                request_input,
+                                retry_frame,
+                                &outbound,
+                                &continuation,
+                                &fatal,
                             )
-                            .await
-                            {
-                                Ok(Ok(response)) => {
-                                    let close_for_inbound_auth = response.status()
-                                        == StatusCode::UNAUTHORIZED
-                                        && response
-                                            .extensions()
-                                            .get::<SelectedAccount>()
-                                            .is_some_and(|selected| {
-                                                matches!(
-                                                    app.config.accounts.get(&selected.account),
-                                                    Some(crate::config::AccountConfig::Inbound)
-                                                )
-                                            });
-                                    let pump_result = pump_http_response_to_websocket(
-                                        response,
-                                        &outbound,
-                                        &app,
-                                        request_input,
-                                        &continuation,
-                                        dispatch_deadline,
-                                        RESPONSES_UPSTREAM_IDLE_TIMEOUT,
-                                    )
-                                    .await;
-                                    if close_for_inbound_auth {
-                                        let _ = outbound
-                                            .send(Message::Close(Some(
-                                                tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                                                    code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Policy,
-                                                    reason: "inbound credentials rejected; reconnect required".into(),
-                                                },
-                                            )))
-                                            .await;
-                                        let _ = fatal.send(
-                                            "inbound credentials rejected; downstream reconnect required"
-                                                .into(),
-                                        );
-                                        return;
-                                    }
-                                    if let Err(failure) = pump_result {
-                                        if let Some(liveness) = failure.liveness {
-                                            send_ws_nonretryable_liveness_error(
-                                                &outbound,
-                                                liveness,
-                                            )
-                                            .await;
-                                            return;
-                                        }
-                                        if failure.delivery_failed {
-                                            let _ = fatal.send(failure.error.to_string());
-                                            return;
-                                        }
-                                        if failure.delivered_event {
-                                            let _ = outbound
-                                                .send(Message::Close(Some(
-                                                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
-                                                        code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error,
-                                                        reason: "upstream stream incomplete".into(),
-                                                    },
-                                                )))
-                                                .await;
-                                            let _ = fatal.send(format!(
-                                                "upstream stream ended after visible output: {}",
-                                                failure.error
-                                            ));
-                                        } else {
-                                            send_ws_error(
-                                                &outbound,
-                                                "websocket_protocol_error",
-                                                &failure.error.to_string(),
-                                            )
-                                            .await;
-                                        }
-                                    }
-                                }
-                                Ok(Err(error)) => {
-                                    send_ws_error(&outbound, "proxy_error", &error.to_string())
-                                        .await;
-                                }
-                                Err(_) => {
-                                    send_ws_nonretryable_liveness_error(
-                                        &outbound,
-                                        HttpBridgeLivenessFailure::MissingResponseCreated,
-                                    )
-                                    .await;
-                                }
-                            }
+                            .await;
                         })
                         .await;
                     if active_turn.is_none() {
@@ -2206,6 +2178,203 @@ impl App {
         match read_error {
             Some(error) => anyhow::bail!("Responses WebSocket bridge failed: {error}"),
             None => Ok(()),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_http_bridge_turn(
+        self: &Arc<Self>,
+        mut headers: hyper::HeaderMap,
+        listener: &ListenerConfig,
+        path: String,
+        body: bytes::Bytes,
+        mut routing_previous_response_id: Option<String>,
+        request_input: Vec<serde_json::Value>,
+        retry_frame: serde_json::Value,
+        outbound: &BridgeSender,
+        continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+        fatal: &mpsc::UnboundedSender<String>,
+    ) {
+        // Context validation can read storage or refresh credentials. Keep it
+        // inside the cancellable turn and its original dispatch deadline.
+        let mut dispatch_deadline = tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT;
+        let retry_view = match tokio::time::timeout_at(
+            dispatch_deadline,
+            self.context_routing_view(&retry_frame, listener, &headers),
+        )
+        .await
+        {
+            Ok(Ok(view)) => view,
+            Ok(Err(_)) => {
+                send_ws_error(outbound, "context_result_invalid", "invalid context result").await;
+                return;
+            }
+            Err(_) => {
+                send_ws_nonretryable_liveness_error(
+                    outbound,
+                    HttpBridgeLivenessFailure::MissingResponseCreated,
+                )
+                .await;
+                return;
+            }
+        };
+        let bridge_replayable = analyze_response_create(&retry_view, ProtocolLimits::default())
+            .is_ok_and(|analysis| {
+                !analysis.has_file_references
+                    && !analysis.has_nonportable_state
+                    && (analysis.previous_response_id.is_none()
+                        || analysis.full_resend == websocket_protocol::FullResendSafety::Eligible)
+            });
+        let dispatch = Arc::new(StdMutex::new(BridgeDispatchState {
+            cross_account_safe: bridge_replayable,
+            ..BridgeDispatchState::default()
+        }));
+        let mut fallback: Option<HttpBridgeCapacityRetry> = None;
+        let mut accepted_retry = false;
+        loop {
+            let replay = match ReplayBody::from_bytes(
+                body.clone(),
+                self.config.proxy.max_request_bytes,
+                self.config.proxy.max_spool_bytes,
+                self.stats.clone(),
+            ) {
+                Ok(replay) => replay,
+                Err(error) => {
+                    if let Some(fallback) = fallback {
+                        send_bridge_capacity_fallback(outbound, fallback).await;
+                    } else {
+                        send_ws_error(outbound, "invalid_request_error", &error.to_string()).await;
+                    }
+                    return;
+                }
+            };
+            let response = match tokio::time::timeout_at(
+                dispatch_deadline,
+                self.handle_http_replay_with_routing_anchor(
+                    headers.clone(),
+                    Method::POST,
+                    listener,
+                    path.clone(),
+                    replay,
+                    HttpReplayContext {
+                        previous_response_id: routing_previous_response_id.clone(),
+                        lane: ServingLane::Bridge,
+                        bridge_dispatch: Some(dispatch.clone()),
+                    },
+                ),
+            )
+            .await
+            {
+                Ok(Ok(response)) => response,
+                failure => {
+                    if let Some(fallback) = fallback {
+                        send_bridge_capacity_fallback(outbound, fallback).await;
+                    } else if let Ok(Err(error)) = failure {
+                        send_ws_error(outbound, "proxy_error", &error.to_string()).await;
+                    } else {
+                        send_ws_nonretryable_liveness_error(
+                            outbound,
+                            HttpBridgeLivenessFailure::MissingResponseCreated,
+                        )
+                        .await;
+                    }
+                    return;
+                }
+            };
+            if let Some(original) = fallback.take()
+                && (!response.status().is_success()
+                    || response
+                        .extensions()
+                        .get::<SelectedAccount>()
+                        .is_none_or(|selected| selected.account == original.account))
+            {
+                // No replacement stream was established. Preserve the original
+                // accepted rejection, including its original ID and sequence.
+                send_bridge_capacity_fallback(outbound, original).await;
+                return;
+            }
+            let close_for_inbound_auth = response.status() == StatusCode::UNAUTHORIZED
+                && response
+                    .extensions()
+                    .get::<SelectedAccount>()
+                    .is_some_and(|selected| {
+                        matches!(
+                            self.config.accounts.get(&selected.account),
+                            Some(crate::config::AccountConfig::Inbound)
+                        )
+                    });
+            let retry_policy = {
+                let dispatch = dispatch.lock().expect("bridge dispatch");
+                HttpBridgeRetryPolicy {
+                    allowed: !accepted_retry
+                        && dispatch.attempts < 2
+                        && dispatch.cross_account_safe,
+                    accepted_work: accepted_retry,
+                }
+            };
+            let pump_result = pump_http_response_to_websocket(
+                response,
+                outbound,
+                self,
+                request_input.clone(),
+                continuation,
+                dispatch_deadline,
+                RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                retry_policy,
+            )
+            .await;
+            if close_for_inbound_auth {
+                let _ = outbound.send(Message::Close(Some(
+                    tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                        code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Policy,
+                        reason: "inbound credentials rejected; reconnect required".into(),
+                    },
+                ))).await;
+                let _ = fatal
+                    .send("inbound credentials rejected; downstream reconnect required".into());
+                return;
+            }
+            match pump_result {
+                Ok(Some(retry)) => {
+                    dispatch.lock().expect("bridge dispatch").excluded_account =
+                        Some(retry.account.clone());
+                    fallback = Some(retry);
+                    accepted_retry = true;
+                    // The bridge already materialized this response anchor, and
+                    // the gate proved that no independent hard owner remains.
+                    routing_previous_response_id = None;
+                    strip_direct_session_headers(&mut headers);
+                    dispatch_deadline =
+                        tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT;
+                }
+                Ok(None) => return,
+                Err(failure) => {
+                    if let Some(liveness) = failure.liveness {
+                        send_ws_nonretryable_liveness_error(outbound, liveness).await;
+                    } else if failure.delivery_failed {
+                        let _ = fatal.send(failure.error.to_string());
+                    } else if failure.delivered_event || failure.accepted_work {
+                        let _ = outbound.send(Message::Close(Some(
+                            tokio_tungstenite::tungstenite::protocol::CloseFrame {
+                                code: tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error,
+                                reason: "upstream stream incomplete".into(),
+                            },
+                        ))).await;
+                        let _ = fatal.send(format!(
+                            "upstream stream ended after acceptance: {}",
+                            failure.error
+                        ));
+                    } else {
+                        send_ws_error(
+                            outbound,
+                            "websocket_protocol_error",
+                            &failure.error.to_string(),
+                        )
+                        .await;
+                    }
+                    return;
+                }
+            }
         }
     }
 
@@ -2532,13 +2701,29 @@ impl App {
         let mut queued_creates = VecDeque::<Message>::new();
         loop {
             let earliest_idle_deadline = earliest_turn_deadline(&upstream_idle_deadlines);
+            let lifecycle_deadline = turns
+                .values()
+                .filter_map(|turn| turn.lifecycle_deadline)
+                .min();
             let queued_message = if awaiting_response_created.is_none() {
-                queued_creates.pop_front()
+                queued_creates.front().cloned()
             } else {
                 None
             };
+            let from_queue = queued_message.is_some();
             tokio::select! {
                 biased;
+                _ = wait_for_optional_deadline(lifecycle_deadline) => {
+                    let now = tokio::time::Instant::now();
+                    let ready: Vec<_> = turns.iter().filter_map(|(id, turn)| {
+                        turn.lifecycle_deadline.filter(|deadline| *deadline <= now).map(|_| *id)
+                    }).collect();
+                    for id in ready {
+                        self.flush_direct_lifecycle(
+                            &mut protocol, &mut turns, &mut client, &account, Some(id), true,
+                        ).await?;
+                    }
+                }
                 _ = wait_for_optional_deadline(missing_created_deadline) => {
                     let close_downstream = self
                         .recover_or_settle_direct_end(
@@ -2588,6 +2773,9 @@ impl App {
                     }
                 } => {
                     let Some(client_message) = client_message else { break };
+                    if from_queue {
+                        queued_creates.pop_front();
+                    }
                     let client_message = client_message.context("read downstream Responses frame")?;
                     if let Message::Text(text) = &client_message {
                         let parsed = serde_json::from_str::<serde_json::Value>(text.as_str()).ok();
@@ -2694,6 +2882,11 @@ impl App {
                                     continue;
                                 }
                             };
+                            // Once turns overlap they cannot move accounts together. Release
+                            // earlier metadata before admitting the next turn, preserving wire order.
+                            self.flush_direct_lifecycle(
+                                &mut protocol, &mut turns, &mut client, &account, None, true,
+                            ).await?;
                             let turn_id = match protocol.admit_response_create(&routing_value) {
                                 Ok(turn_id) => turn_id,
                                 Err(error) => {
@@ -2717,11 +2910,18 @@ impl App {
                             missing_created_deadline = Some(
                                 tokio::time::Instant::now() + RESPONSES_MISSING_CREATED_TIMEOUT,
                             );
+                            let buffer_lifecycle = !analysis.has_file_references
+                                && !analysis.has_nonportable_state
+                                && !route.non_previous_hard_owner
+                                && (analysis.previous_response_id.is_none()
+                                    || analysis.full_resend == websocket_protocol::FullResendSafety::Eligible);
                             turns.insert(turn_id, DirectTurn {
                                 route,
                                 request: client_message,
                                 value,
                                 routing_value,
+                                lifecycle: LifecycleBuffer::new(buffer_lifecycle),
+                                lifecycle_deadline: None,
                             });
                             continue;
                         }
@@ -2777,6 +2977,11 @@ impl App {
                                 _ => None,
                             };
                             let Some(event) = parsed else {
+                                if matches!(message, Message::Text(_) | Message::Binary(_)) {
+                                    self.flush_direct_lifecycle(
+                                        &mut protocol, &mut turns, &mut client, &account, None, true,
+                                    ).await?;
+                                }
                                 client.send(message).await?;
                                 continue;
                             };
@@ -2800,13 +3005,17 @@ impl App {
                             );
                             if failure.kind != FailureKind::None && failure_turns.len() == 1 {
                                 let turn_id = failure_turns[0];
+                                let mut replay_context = ReplayContext::from_failure(&failure);
+                                replay_context.accepted_capacity_rejection = turns
+                                    .get(&turn_id)
+                                    .is_some_and(|turn| turn.lifecycle.permits_capacity_retry(&event));
                                 if let Some((replacement, replacement_account)) = self
                                     .try_replay_direct_turn(
                                         &mut protocol,
                                         &mut turns,
                                         turn_id,
                                         failure.kind,
-                                        ReplayContext::from_failure(&failure),
+                                        replay_context,
                                         &listener,
                                         &path,
                                         &headers,
@@ -2824,6 +3033,7 @@ impl App {
                                     lease.replace(account.clone()).await;
                                     upstream = replacement.socket;
                                     upstream_credentials = replacement.credentials;
+                                    awaiting_response_created = Some(turn_id);
                                     missing_created_deadline = Some(
                                         tokio::time::Instant::now()
                                             + RESPONSES_MISSING_CREATED_TIMEOUT,
@@ -2853,6 +3063,44 @@ impl App {
                             let association = protocol
                                 .observe_upstream_event(&event, anchor_hint.as_deref())
                                 .map_err(|error| anyhow::anyhow!("associate upstream event: {error:?}"))?;
+                            if association.event_type.as_deref() == Some("response.created") {
+                                for turn_id in &association.turn_ids {
+                                    if awaiting_response_created == Some(*turn_id) {
+                                        awaiting_response_created = None;
+                                        missing_created_deadline = None;
+                                        upstream_idle_deadlines.insert(
+                                            *turn_id,
+                                            tokio::time::Instant::now() + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                                        );
+                                    }
+                                }
+                            }
+                            refresh_turn_deadlines(
+                                &mut upstream_idle_deadlines,
+                                &association.turn_ids,
+                                RESPONSES_UPSTREAM_IDLE_TIMEOUT,
+                            );
+                            if association.turn_ids.len() == 1
+                                && let Message::Text(payload) = &message
+                                && turns.get_mut(&association.turn_ids[0]).is_some_and(|turn| {
+                                    if turn.lifecycle.retain(&event, payload.as_str()) {
+                                        turn.lifecycle_deadline.get_or_insert(
+                                            tokio::time::Instant::now() + LIFECYCLE_FLUSH_DELAY,
+                                        );
+                                        true
+                                    } else { false }
+                                })
+                            {
+                                continue;
+                            }
+                            self.flush_direct_lifecycle(
+                                &mut protocol, &mut turns, &mut client, &account,
+                                match association.turn_ids.as_slice() {
+                                    [id] => Some(*id),
+                                    _ => None,
+                                },
+                                terminal_permits_affinity(&failure),
+                            ).await?;
                             if association.failure.kind == FailureKind::PreviousResponseNotFound
                                 && !association.turn_ids.is_empty()
                             {
@@ -2891,15 +3139,6 @@ impl App {
                             }
                             if association.event_type.as_deref() == Some("response.created") {
                                 for turn_id in &association.turn_ids {
-                                    if awaiting_response_created == Some(*turn_id) {
-                                        awaiting_response_created = None;
-                                        missing_created_deadline = None;
-                                        upstream_idle_deadlines.insert(
-                                            *turn_id,
-                                            tokio::time::Instant::now()
-                                                + RESPONSES_UPSTREAM_IDLE_TIMEOUT,
-                                        );
-                                    }
                                     if let Some(turn) = turns.get(turn_id) {
                                         for key in &turn.route.soft_keys {
                                             self.router.bind(key.clone(), &account).await;
@@ -2921,11 +3160,6 @@ impl App {
                                     }
                                 }
                             }
-                            refresh_turn_deadlines(
-                                &mut upstream_idle_deadlines,
-                                &association.turn_ids,
-                                RESPONSES_UPSTREAM_IDLE_TIMEOUT,
-                            );
                             client.send(message).await?;
                             for turn_id in &association.turn_ids {
                                 protocol
@@ -3011,6 +3245,50 @@ impl App {
                                 break;
                             }
                         },
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Release only after the attempt can no longer be hidden. Capacity terminals
+    /// and interrupted streams release metadata without granting success affinity.
+    async fn flush_direct_lifecycle(
+        &self,
+        protocol: &mut ProtocolState,
+        turns: &mut HashMap<TurnId, DirectTurn>,
+        client: &mut UpgradedWebSocket,
+        account: &str,
+        only: Option<TurnId>,
+        bind_affinity: bool,
+    ) -> Result<()> {
+        let ids: Vec<_> = protocol.pending().map(|turn| turn.id()).collect();
+        for id in ids {
+            if only.is_some_and(|only| only != id) {
+                continue;
+            }
+            let Some(turn) = turns.get_mut(&id) else {
+                continue;
+            };
+            let events = turn.lifecycle.release();
+            turn.lifecycle_deadline = None;
+            let keys = turn.route.soft_keys.clone();
+            for event in events {
+                client.send(Message::Text(event.payload.into())).await?;
+                protocol
+                    .mark_downstream_delivered(id, &event.value)
+                    .map_err(|error| anyhow::anyhow!("mark buffered direct event: {error:?}"))?;
+                if bind_affinity {
+                    if let Some(response_id) = websocket_protocol::response_id(&event.value) {
+                        let key = self
+                            .router
+                            .affinity
+                            .key(&format!("previous-response:{response_id}"));
+                        self.router.bind(key, account).await;
+                    }
+                    for key in &keys {
+                        self.router.bind(key.clone(), account).await;
                     }
                 }
             }
@@ -3196,28 +3474,58 @@ impl App {
                 Message::Text(serde_json::to_string(&replay_value)?.into())
             }
         };
-        let committed = protocol
-            .prepare_replay_plan(turn_id, failure, context)
-            .map_err(|error| anyhow::anyhow!("commit direct replay plan: {error:?}"))?;
-        if committed != plan {
-            anyhow::bail!("direct replay plan changed before commit")
+        // Accepted retry keeps the old attempt intact until the new request is
+        // sent. A reconnect/send failure must still expose its original terminal.
+        if !context.accepted_capacity_rejection {
+            let committed = protocol
+                .prepare_replay_plan(turn_id, failure, context)
+                .map_err(|error| anyhow::anyhow!("commit direct replay plan: {error:?}"))?;
+            if committed != plan {
+                anyhow::bail!("direct replay plan changed before commit")
+            }
         }
-        self.record_context_dispatch(
-            &replay_value,
-            &listener.pool,
-            &replacement_account,
-            &replacement.credentials,
-        )
-        .await?;
-        self.auth.ensure_bearer_usable(
+        if let Err(error) = self
+            .record_context_dispatch(
+                &replay_value,
+                &listener.pool,
+                &replacement_account,
+                &replacement.credentials,
+            )
+            .await
+        {
+            if context.accepted_capacity_rejection {
+                warn!(%error, account = replacement_account, "accepted replay context dispatch refused");
+                return Ok(None);
+            }
+            return Err(error);
+        }
+        if let Err(error) = self.auth.ensure_bearer_usable(
             &self.config.accounts[&replacement_account],
             &replacement.credentials,
-        )?;
+        ) {
+            if context.accepted_capacity_rejection {
+                warn!(%error, account = replacement_account, "accepted replay bearer rejected before dispatch");
+                return Ok(None);
+            }
+            return Err(error);
+        }
         if let Err(error) = replacement.socket.send(replay_message.clone()).await {
             warn!(%error, account = replacement_account, "safe direct replay send failed");
             return Ok(None);
         }
+        if context.accepted_capacity_rejection {
+            let committed = protocol
+                .prepare_replay_plan(turn_id, failure, context)
+                .map_err(|error| anyhow::anyhow!("commit accepted direct replay: {error:?}"))?;
+            if committed != plan {
+                anyhow::bail!("direct replay plan changed before commit")
+            }
+        }
         if let Some(turn) = turns.get_mut(&turn_id) {
+            // Every replay consumes the allowance for hiding lifecycle metadata,
+            // even when the first failure happened before upstream acceptance.
+            turn.lifecycle = LifecycleBuffer::new(false);
+            turn.lifecycle_deadline = None;
             turn.request = replay_message;
             turn.value = replay_value;
             turn.route.account_id = replacement_account.clone();
@@ -3225,6 +3533,17 @@ impl App {
                 turn.route.account_generation = generation;
             }
             if mode == ReplayMode::FreshRequestWithoutPreviousResponse {
+                if let Some(previous) = turn
+                    .routing_value
+                    .get("previous_response_id")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    let old_key = self
+                        .router
+                        .affinity
+                        .key(&format!("previous-response:{previous}"));
+                    turn.route.soft_keys.retain(|key| key != &old_key);
+                }
                 turn.routing_value
                     .as_object_mut()
                     .expect("validated response.create")
@@ -3256,6 +3575,8 @@ impl App {
         lease: &mut DirectAccountLease,
         end: UpstreamEnd,
     ) -> Result<bool> {
+        self.flush_direct_lifecycle(protocol, turns, client, account, None, false)
+            .await?;
         let watchdog = matches!(
             end,
             UpstreamEnd::MissingResponseCreatedTimeout | UpstreamEnd::UpstreamIdleTimeout
@@ -4847,6 +5168,14 @@ async fn send_ws_error(outbound: &BridgeSender, kind: &str, message: &str) {
     let _ = outbound.send(Message::Text(payload.into())).await;
 }
 
+async fn send_bridge_capacity_fallback(outbound: &BridgeSender, fallback: HttpBridgeCapacityRetry) {
+    for event in fallback.events {
+        if !outbound.send(Message::Text(event.payload.into())).await {
+            return;
+        }
+    }
+}
+
 async fn send_ws_nonretryable_liveness_error(
     outbound: &BridgeSender,
     failure: HttpBridgeLivenessFailure,
@@ -5067,6 +5396,7 @@ fn enrich_bridge_quota_payload(
     serde_json::to_string(&rewritten).unwrap_or_else(|_| payload.to_owned())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn pump_http_response_to_websocket(
     response: Response<ProxyBody>,
     outbound: &BridgeSender,
@@ -5075,7 +5405,8 @@ async fn pump_http_response_to_websocket(
     continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
     response_created_deadline: tokio::time::Instant,
     upstream_idle_timeout: Duration,
-) -> std::result::Result<(), HttpBridgePumpFailure> {
+    retry_policy: HttpBridgeRetryPolicy,
+) -> std::result::Result<Option<HttpBridgeCapacityRetry>, HttpBridgePumpFailure> {
     let mut capture = HttpBridgeCapture {
         capacity_observation: response
             .extensions()
@@ -5089,9 +5420,12 @@ async fn pump_http_response_to_websocket(
         response_created: false,
         progress_events: 0,
         delivery_failed: false,
+        lifecycle: LifecycleBuffer::new(retry_policy.allowed),
+        capacity_retry: None,
+        lifecycle_deadline: None,
     };
     let mut liveness = None;
-    let result: Result<()> = async {
+    let mut result: Result<()> = async {
     let status = response.status();
     let response_headers = response.headers().clone();
     let content_type = response
@@ -5217,14 +5551,22 @@ async fn pump_http_response_to_websocket(
             .response_created
             .then(|| tokio::time::Instant::now() + upstream_idle_timeout);
         loop {
-            let next_frame = if capture.response_created {
-                tokio::time::timeout_at(
-                    upstream_idle_deadline.expect("created response has idle deadline"),
-                    body.frame(),
-                )
-                .await
-            } else {
-                tokio::time::timeout_at(response_created_deadline, body.frame()).await
+            let next_frame = tokio::select! {
+                _ = wait_for_optional_deadline(capture.lifecycle_deadline) => {
+                    flush_bridge_lifecycle(outbound, app, selected_account.as_deref(),
+                        &mut capture, continuation, &response_headers, true).await?;
+                    continue;
+                }
+                frame = async {
+                    if capture.response_created {
+                        tokio::time::timeout_at(
+                            upstream_idle_deadline.expect("created response has idle deadline"),
+                            body.frame(),
+                        ).await
+                    } else {
+                        tokio::time::timeout_at(response_created_deadline, body.frame()).await
+                    }
+                } => frame,
             };
             let frame = match next_frame {
                 Ok(Some(frame)) => frame,
@@ -5326,12 +5668,27 @@ async fn pump_http_response_to_websocket(
     Ok(())
     }
     .await;
-    result.map_err(|error| HttpBridgePumpFailure {
-        error,
-        delivered_event: capture.delivered_event,
-        liveness,
-        delivery_failed: capture.delivery_failed,
-    })
+    if result.is_err() {
+        // Buffered acceptance is still accepted work. Release it before the
+        // caller chooses the nonretryable interrupted-stream settlement.
+        for buffered in capture.lifecycle.release() {
+            if !outbound.send(Message::Text(buffered.payload.into())).await {
+                capture.delivery_failed = true;
+                result = Err(anyhow::anyhow!("downstream WebSocket writer stopped"));
+                break;
+            }
+            capture.delivered_event = true;
+        }
+    }
+    result
+        .map(|()| capture.capacity_retry.take())
+        .map_err(|error| HttpBridgePumpFailure {
+            error,
+            delivered_event: capture.delivered_event,
+            liveness,
+            delivery_failed: capture.delivery_failed,
+            accepted_work: retry_policy.accepted_work || capture.response_created,
+        })
 }
 
 async fn send_protocol_events(
@@ -5358,53 +5715,128 @@ async fn send_protocol_events(
                     app.router.capacity_failure(account).await;
                 }
             }
-            // Never bind previous-response affinity nor cache a continuation
-            // for quota terminals; the account is cooling down.
-            let previous_response_id = capture.response_id.clone();
-            capture.observe(&event.value);
-            capture.response_id = previous_response_id;
-            let payload = if is_quota {
-                enrich_bridge_quota_payload(&event.payload, &event.value, response_headers)
-            } else {
-                event.payload.clone()
-            };
-            if !outbound.send(Message::Text(payload.into())).await {
-                capture.delivery_failed = true;
-                anyhow::bail!("downstream WebSocket writer stopped before event delivery")
-            }
-            capture.delivered_event = true;
-            if event.terminal.is_some() {
+            if let Some(account) = account
+                && capture.lifecycle.permits_capacity_retry(&event.value)
+            {
+                let mut events = capture.lifecycle.release();
+                events.push(BufferedEvent {
+                    payload: event.payload,
+                    value: event.value,
+                });
+                capture.capacity_retry = Some(HttpBridgeCapacityRetry {
+                    account: account.to_owned(),
+                    events,
+                });
                 return Ok(true);
             }
+        }
+        // Watchdogs and output capture observe upstream progress immediately;
+        // downstream acceptance can be delayed until this attempt commits.
+        capture.observe(&event.value);
+        if capture.lifecycle.retain(&event.value, &event.payload) {
+            capture
+                .lifecycle_deadline
+                .get_or_insert(tokio::time::Instant::now() + LIFECYCLE_FLUSH_DELAY);
             continue;
         }
-        capture.observe(&event.value);
-        if let Some(account) = account
-            && terminal_permits_affinity(&classification)
-        {
-            bind_response_id_from_event(app, &event.payload, account).await;
-        }
+        let permits_affinity = terminal_permits_affinity(&classification);
+        flush_bridge_lifecycle(
+            outbound,
+            app,
+            account,
+            capture,
+            continuation,
+            response_headers,
+            permits_affinity,
+        )
+        .await?;
         let terminal = event.terminal.is_some();
-        if event.terminal == Some(sse::TerminalStatus::Completed)
-            && terminal_permits_affinity(&classification)
-            && let Some(response_id) = capture.response_id.clone()
-        {
-            *continuation.lock().expect("bridge continuation") = Some(HttpBridgeContinuation {
-                response_id,
-                input: capture.input.clone(),
-                output: capture.output.clone(),
-            });
-        }
-        if !outbound.send(Message::Text(event.payload.into())).await {
-            capture.delivery_failed = true;
-            anyhow::bail!("downstream WebSocket writer stopped before event delivery")
-        }
-        capture.delivered_event = true;
+        deliver_bridge_event(
+            event,
+            outbound,
+            app,
+            account,
+            capture,
+            continuation,
+            response_headers,
+            permits_affinity,
+        )
+        .await?;
         if terminal {
             return Ok(true);
         }
     }
     Ok(false)
+}
+
+async fn flush_bridge_lifecycle(
+    outbound: &BridgeSender,
+    app: &Arc<App>,
+    account: Option<&str>,
+    capture: &mut HttpBridgeCapture,
+    continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+    response_headers: &hyper::HeaderMap,
+    permits_affinity: bool,
+) -> Result<()> {
+    capture.lifecycle_deadline = None;
+    for buffered in capture.lifecycle.release() {
+        let mut event = ProtocolEvent::from_value(buffered.value)?;
+        event.payload = buffered.payload;
+        deliver_bridge_event(
+            event,
+            outbound,
+            app,
+            account,
+            capture,
+            continuation,
+            response_headers,
+            permits_affinity,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn deliver_bridge_event(
+    event: ProtocolEvent,
+    outbound: &BridgeSender,
+    app: &Arc<App>,
+    account: Option<&str>,
+    capture: &mut HttpBridgeCapture,
+    continuation: &Arc<StdMutex<Option<HttpBridgeContinuation>>>,
+    response_headers: &hyper::HeaderMap,
+    permits_affinity: bool,
+) -> Result<()> {
+    let classification = classify_terminal_event(&event.value);
+    let payload = if classification.kind == FailureKind::Quota {
+        enrich_bridge_quota_payload(&event.payload, &event.value, response_headers)
+    } else {
+        event.payload.clone()
+    };
+    // Publish continuation before queueing its terminal: the downstream can
+    // immediately send a dependent create and cancel this turn task.
+    if event.terminal == Some(sse::TerminalStatus::Completed)
+        && permits_affinity
+        && let Some(response_id) = capture.response_id.clone()
+    {
+        *continuation.lock().expect("bridge continuation") = Some(HttpBridgeContinuation {
+            response_id,
+            input: capture.input.clone(),
+            output: capture.output.clone(),
+        });
+    }
+    if !outbound.send(Message::Text(payload.into())).await {
+        capture.delivery_failed = true;
+        anyhow::bail!("downstream WebSocket writer stopped before event delivery")
+    }
+    capture.delivered_event = true;
+    if let Some(account) = account
+        && permits_affinity
+    {
+        bind_response_id_from_event(app, &event.payload, account).await;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6648,6 +7080,7 @@ mod tests {
             &continuation,
             tokio::time::Instant::now() + created_after,
             idle_for,
+            HttpBridgeRetryPolicy::default(),
         )
         .await
         .unwrap_err();
@@ -7484,6 +7917,8 @@ mod tests {
                 request: Message::Text(value.to_string().into()),
                 routing_value: value.clone(),
                 value,
+                lifecycle: LifecycleBuffer::new(true),
+                lifecycle_deadline: None,
             },
         )]);
         let replayed = app

--- a/src/proxy/websocket_protocol.rs
+++ b/src/proxy/websocket_protocol.rs
@@ -165,6 +165,7 @@ pub struct PendingTurn {
     downstream_visible: bool,
     last_visible_sequence: Option<SequenceNumber>,
     replay_count: u8,
+    accepted_capacity_replayed: bool,
     auth_refresh_replay_count: u8,
     auth_failover_replay_count: u8,
     analysis: CreateAnalysis,
@@ -313,12 +314,16 @@ pub struct ReplayContext {
     /// True when the failure event being classified carries a response ID.
     /// An assigned ID is treated as accepted work, even for quota or capacity failures.
     pub current_event_has_response_id: bool,
+    /// Set only by the bounded lifecycle buffer after inspecting an explicit
+    /// capacity terminal with affirmative zero output and zero output usage.
+    pub accepted_capacity_rejection: bool,
 }
 
 impl ReplayContext {
     pub fn from_failure(failure: &FailureClassification) -> Self {
         Self {
             current_event_has_response_id: failure.response_id.is_some(),
+            accepted_capacity_rejection: false,
         }
     }
 }
@@ -414,6 +419,7 @@ impl ProtocolState {
             downstream_visible: false,
             last_visible_sequence: None,
             replay_count: 0,
+            accepted_capacity_replayed: false,
             auth_refresh_replay_count: 0,
             auth_failover_replay_count: 0,
             analysis,
@@ -538,22 +544,31 @@ impl ProtocolState {
         if self.pending.len() != 1 {
             return Err(ReplayRefusal::MultiplePendingTurns);
         }
+        // An accepted-capacity retry is the last automatic attempt, including
+        // authentication and pre-created transport recovery on its replacement.
+        if turn.accepted_capacity_replayed {
+            return Err(ReplayRefusal::AlreadyReplayed);
+        }
+        let accepted_capacity = context.accepted_capacity_rejection
+            && failure == FailureKind::Capacity
+            && turn.response_created
+            && turn.response_id.is_some();
         if turn.last_visible_sequence.is_some() {
             return Err(ReplayRefusal::FiniteSequenceVisible);
         }
         if turn.downstream_visible {
             return Err(ReplayRefusal::DownstreamVisible);
         }
-        if turn.response_created {
+        if turn.response_created && !accepted_capacity {
             return Err(ReplayRefusal::ResponseCreated);
         }
-        if turn.response_event_count > 0 {
+        if turn.response_event_count > 0 && !accepted_capacity {
             return Err(ReplayRefusal::PriorResponseEvent);
         }
         if turn.analysis.has_file_references {
             return Err(ReplayRefusal::FileBacked);
         }
-        if context.current_event_has_response_id {
+        if context.current_event_has_response_id && !accepted_capacity {
             return Err(ReplayRefusal::ResponseIdAssigned);
         }
 
@@ -591,7 +606,11 @@ impl ProtocolState {
             if turn.replay_count >= self.limits.max_replays_per_turn {
                 return Err(ReplayRefusal::AlreadyReplayed);
             }
-            ReplayTarget::Unspecified
+            if accepted_capacity {
+                ReplayTarget::AlternateAccount
+            } else {
+                ReplayTarget::Unspecified
+            }
         };
 
         let mode = if turn.previous_response_id.is_none() {
@@ -633,12 +652,15 @@ impl ProtocolState {
             ReplayTarget::SameAccountAfterRefresh => {
                 turn.auth_refresh_replay_count = turn.auth_refresh_replay_count.saturating_add(1);
             }
-            ReplayTarget::AlternateAccount => {
+            ReplayTarget::AlternateAccount
+                if matches!(failure, FailureKind::Authentication { .. }) =>
+            {
                 turn.auth_failover_replay_count = turn.auth_failover_replay_count.saturating_add(1);
             }
-            ReplayTarget::Unspecified => {}
+            ReplayTarget::AlternateAccount | ReplayTarget::Unspecified => {}
         }
         turn.replay_count = turn.replay_count.saturating_add(1);
+        turn.accepted_capacity_replayed |= context.accepted_capacity_rejection;
         turn.response_id = None;
         turn.response_created = false;
         turn.response_event_count = 0;
@@ -1883,6 +1905,7 @@ mod tests {
                 auth,
                 ReplayContext {
                     current_event_has_response_id: true,
+                    ..ReplayContext::default()
                 },
             ),
             Err(ReplayRefusal::ResponseIdAssigned)
@@ -2210,6 +2233,83 @@ mod tests {
             protocol.replay_decision(turn, FailureKind::Capacity, ReplayContext::default()),
             ReplayDecision::Refused(_)
         ));
+    }
+
+    #[test]
+    fn accepted_capacity_uses_the_existing_budget_and_is_the_last_replay() {
+        let mut protocol = state();
+        let turn = protocol
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        protocol
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_a"}}),
+                None,
+            )
+            .unwrap();
+        let context = ReplayContext {
+            current_event_has_response_id: true,
+            accepted_capacity_rejection: true,
+        };
+        for failure in [
+            FailureKind::Quota,
+            FailureKind::Transient,
+            FailureKind::Authentication {
+                requires_reauthentication: false,
+            },
+        ] {
+            assert!(protocol.replay_plan(turn, failure, context).is_err());
+        }
+        let plan = protocol
+            .prepare_replay_plan(turn, FailureKind::Capacity, context)
+            .unwrap();
+        assert_eq!(plan.target, ReplayTarget::AlternateAccount);
+        assert_eq!(protocol.turn(turn).unwrap().replay_count(), 1);
+        assert_eq!(protocol.turn(turn).unwrap().auth_failover_replay_count(), 0);
+        protocol
+            .reset_auth_sequence_after_account_switch(turn)
+            .unwrap();
+        for failure in [
+            FailureKind::Capacity,
+            FailureKind::Quota,
+            FailureKind::Transient,
+            FailureKind::Authentication {
+                requires_reauthentication: false,
+            },
+        ] {
+            assert_eq!(
+                protocol.replay_plan(turn, failure, ReplayContext::default()),
+                Err(ReplayRefusal::AlreadyReplayed)
+            );
+        }
+    }
+
+    #[test]
+    fn earlier_precreated_replay_cannot_grant_another_accepted_retry() {
+        let mut protocol = state();
+        let turn = protocol
+            .admit_response_create(&create(json!("hello")))
+            .unwrap();
+        protocol
+            .prepare_replay_plan(turn, FailureKind::Quota, ReplayContext::default())
+            .unwrap();
+        protocol
+            .observe_upstream_event(
+                &json!({"type":"response.created","response":{"id":"resp_b"}}),
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            protocol.replay_plan(
+                turn,
+                FailureKind::Capacity,
+                ReplayContext {
+                    current_event_has_response_id: true,
+                    accepted_capacity_rejection: true,
+                }
+            ),
+            Err(ReplayRefusal::AlreadyReplayed)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Direct Responses WebSockets and the HTTP bridge can retry one explicit capacity rejection after response.created when upstream reports no output and zero output tokens. Initial lifecycle events are buffered for at most one second, 16 events, or 64 KiB; a successful retry exposes only the replacement response's original IDs and sequence numbers.

Output events, missing or contradictory usage, quota failures, ambiguous disconnects, and account-owned state prevent this retry. It shares the existing turn's retry budget, preserves the original rejection when replacement cannot start, and leaves ordinary HTTP streaming unchanged.
