### PR TITLE
Fix menu status recovery and quota display

### DIFF
--- a/macos/ComradexMenu/README.md
+++ b/macos/ComradexMenu/README.md
@@ -2,13 +2,15 @@
 
 A native macOS 14+ menu-bar companion for viewing Comradex daemon, routing, account, and pool status; choosing a pool's preferred account; and completing account login when authentication is required.
 
-Each account occupies one line. Healthy managed accounts show the main quota and its reset countdown, such as `sq — 68% left · 6d 4h`; the tooltip labels the countdown explicitly. The primary window is preferred; zero-duration windows are omitted. Authentication or availability errors replace stale usage details. Account rows have no type or health icons: the native check exclusively marks the preferred account, while the menu header's check continues to indicate daemon health.
+Each account occupies one line. Healthy managed accounts show the main quota and its reset countdown, such as `sq · 68% left · 6d 4h`; the tooltip labels the countdown explicitly. The primary window is preferred; zero-duration windows are omitted. Quota-exhausted accounts retain `0% left` and the exhausted window’s reset countdown (falling back to the retry deadline); the tooltip explains the rate limit. Other authentication or availability errors replace stale usage details. Account rows have no type or health icons: the native check exclusively marks the preferred account, while the menu header's check continues to indicate daemon health.
 
 The special `app` row explains `Codex App account` in its tooltip because it uses credentials supplied by the Codex desktop app rather than a separately managed account home.
 
 For a single pool, account rows appear without a pool section header. A filled dot marks the last-used account only when it differs from the preferred account; if they are the same, the preferred check is sufficient. Multiple pools retain name-only section headers so repeated account rows remain attributable to their pool.
 
 The app talks directly to the daemon's newline-delimited JSON protocol at `~/.config/comradex/state/control.sock`. It does not invoke the Comradex CLI, read configuration files, expose subprocess output, or handle credentials. Device login polling uses the daemon-issued random session ID and displays only the verification URI, user code, coarse state, and safe error text. Set `COMRADEX_CONTROL_SOCKET` before launching to use another socket path.
+
+Status refreshes automatically every five seconds and when the menu opens. Only one status request runs at a time. While the menu is open, structural updates wait until it closes to avoid moving actions under the pointer. Failed reads preserve the last snapshot and show “Reconnecting · showing last update”; the header tooltip includes the last successful refresh time and failure detail. Recovery clears the connection warning automatically. Account-change errors remain separate and clear on the next successful account change. Connection failures and recovery are recorded in macOS unified logging, with error details private.
 
 ## Build and test
 

--- a/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import OSLog
 
 @MainActor
 final class ComradexStore: ObservableObject {
@@ -7,7 +8,10 @@ final class ComradexStore: ObservableObject {
     @Published private(set) var login: LoginSnapshot?
     @Published private(set) var isRefreshing = false
     @Published private(set) var updatingPool: String?
-    @Published var errorMessage: String?
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var actionErrorMessage: String?
+    @Published private(set) var lastSuccessfulRefresh: Date?
+    private let logger = Logger(subsystem: "com.nicosuave.comradex.menu", category: "connection")
 
     var isLoginRunning: Bool { login?.state == .running }
 
@@ -26,17 +30,13 @@ final class ComradexStore: ObservableObject {
         defer { isRefreshing = false }
         do {
             apply(status: try await client.status())
-            errorMessage = nil
+        } catch is CancellationError {
+            return
         } catch {
+            if errorMessage != error.localizedDescription {
+                logger.error("Status refresh failed: \(error.localizedDescription, privacy: .private)")
+            }
             errorMessage = error.localizedDescription
-        }
-    }
-
-    func refreshLoop() async {
-        await refresh()
-        while !Task.isCancelled {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
-            if !Task.isCancelled { await refresh() }
         }
     }
 
@@ -48,11 +48,11 @@ final class ComradexStore: ObservableObject {
             if let updated = try await client.setPreferred(pool: pool, account: account) {
                 apply(status: updated)
             } else {
-                apply(status: try await client.status())
+                await refresh()
             }
-            errorMessage = nil
+            actionErrorMessage = nil
         } catch {
-            errorMessage = error.localizedDescription
+            actionErrorMessage = error.localizedDescription
         }
     }
 
@@ -83,7 +83,10 @@ final class ComradexStore: ObservableObject {
     }
 
     func apply(status: UIStatusSnapshot) {
+        if errorMessage != nil { logger.info("Status connection recovered") }
         snapshot = status
+        lastSuccessfulRefresh = Date()
+        errorMessage = nil
     }
 
     func apply(login value: LoginSnapshot) {

--- a/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
@@ -17,6 +17,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private var statusItem: NSStatusItem?
     private let menu = NSMenu()
     private var refreshTask: Task<Void, Never>?
+    private var pollingTask: Task<Void, Never>?
     private var loginWindowController: NSWindowController?
     private var isMenuOpen = false
     private var hasDeferredMenuUpdate = false
@@ -31,6 +32,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     deinit {
         refreshTask?.cancel()
+        pollingTask?.cancel()
         if let statusItem {
             NSStatusBar.system.removeStatusItem(statusItem)
         }
@@ -44,11 +46,33 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         menu.delegate = self
         statusItem.menu = menu
         rebuildMenu()
+        startPolling()
+    }
+
+    // The controller owns polling so completed requests also update the native menu.
+    func startPolling(intervalNanoseconds: UInt64 = 5_000_000_000) {
+        guard pollingTask == nil else { return }
         refreshStatus()
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do { try await Task.sleep(nanoseconds: intervalNanoseconds) }
+                catch { return }
+                guard !Task.isCancelled else { return }
+                self?.refreshStatus()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+        refreshTask?.cancel()
     }
 
     func menuWillOpen(_ menu: NSMenu) {
+        rebuildMenu()
         isMenuOpen = true
+        refreshStatus()
     }
 
     func menuDidClose(_ menu: NSMenu) {
@@ -67,16 +91,17 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         if #available(macOS 14.4, *) {
             header.subtitle = connectionLabel
         } else {
-            header.title = "Comradex — \(connectionLabel)"
+            header.title = "Comradex · \(connectionLabel)"
         }
         header.image = NSImage(systemSymbolName: connectionIcon, accessibilityDescription: connectionLabel)
+        header.toolTip = [
+            store.lastSuccessfulRefresh.map { "Last updated: \($0.formatted(date: .omitted, time: .standard))" },
+            store.errorMessage,
+        ].compactMap { $0 }.joined(separator: "\n")
         menu.addItem(header)
         menu.addItem(.separator())
 
         if let snapshot = store.snapshot {
-            if store.errorMessage != nil {
-                addInformationalItem("Status may be out of date", icon: "exclamationmark.triangle.fill")
-            }
             addStatus(snapshot)
         } else if let error = store.errorMessage {
             addInformationalItem(
@@ -87,6 +112,10 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             addInformationalItem("Connecting…", icon: "arrow.triangle.2.circlepath")
         }
 
+        if let error = store.actionErrorMessage {
+            addInformationalItem("Account change failed", icon: "exclamationmark.triangle.fill")
+            menu.items.last?.toolTip = error
+        }
         menu.addItem(.separator())
         menu.addItem(actionItem(
             title: store.isRefreshing ? "Refreshing…" : "Refresh",
@@ -115,7 +144,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             }
             for member in pool.members {
                 guard let account = snapshot.accounts.first(where: { $0.name == member }) else {
-                    addInformationalItem("\(member) — Unavailable", icon: "questionmark.circle")
+                    addInformationalItem("\(member) · Unavailable", icon: "questionmark.circle")
                     continue
                 }
                 addAccount(account, pool: pool)
@@ -148,7 +177,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         item.toolTip = [isPreferred ? "Preferred" : nil, accountDetail(account, expanded: true)]
             .compactMap { $0 }.joined(separator: " · ")
         if !detail.isEmpty {
-            item.title = "\(account.name) — \(detail)"
+            item.title = "\(account.name) · \(detail)"
         }
         item.state = isPreferred ? .on : .off
         item.isEnabled = pool != nil && store.updatingPool == nil
@@ -254,7 +283,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         if let error = store.errorMessage, store.snapshot == nil {
             return error.contains("unknown variant") ? "Update required" : "Unavailable"
         }
-        if store.errorMessage != nil { return "Stale" }
+        if store.errorMessage != nil { return "Reconnecting · showing last update" }
         if store.snapshot?.daemonRunning == true { return "Running" }
         return store.isRefreshing ? "Connecting" : "Unavailable"
     }
@@ -270,7 +299,14 @@ final class MenuBarController: NSObject, NSMenuDelegate {
                 if expanded, let retry = retryDescription(account.retryAtUnix) {
                     return "Rate limited · retry in \(retry)"
                 }
-                return "Rate limited"
+                if expanded { return "Rate limited" }
+                // Show the exhausted window, even when a different primary window has quota.
+                let reset = account.usageWindows.values
+                    .filter { ($0.usedPercent ?? 0) >= 100 && $0.limitWindowSeconds != 0 }
+                    .compactMap(\.resetAtUnix)
+                    .filter { $0 > Int64(Date().timeIntervalSince1970) }
+                    .max() ?? account.retryAtUnix
+                return retryDescription(reset).map { "0% left · \($0)" } ?? "0% left"
             case "temporary_failure": return "Temporarily unavailable"
             case "login_in_progress": return "Login in progress"
             case "needs_login": return "Sign-in required"

--- a/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
+++ b/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
@@ -45,7 +45,7 @@ final class ComradexMenuTests: XCTestCase {
         XCTAssertNil(app.image)
         XCTAssertNil(app.subtitle)
         XCTAssertEqual(app.toolTip, "Preferred · Codex App account")
-        let sq = try XCTUnwrap(items.first(where: { $0.title.hasPrefix("sq — 81% left · ") }))
+        let sq = try XCTUnwrap(items.first(where: { $0.title.hasPrefix("sq · 81% left · ") }))
         XCTAssertFalse(sq.title.contains("resets in"))
         XCTAssertFalse(sq.title.contains("19%"))
         XCTAssertNotNil(sq.action)
@@ -53,7 +53,7 @@ final class ComradexMenuTests: XCTestCase {
         XCTAssertTrue(sq.image?.accessibilityDescription?.contains("Last used") == true)
         XCTAssertNil(sq.subtitle)
         XCTAssertTrue(sq.toolTip?.contains("resets in") == true)
-        let bad = try XCTUnwrap(items.first(where: { $0.title == "bad — Sign-in required" }))
+        let bad = try XCTUnwrap(items.first(where: { $0.title == "bad · Sign-in required" }))
         XCTAssertNil(bad.subtitle)
         XCTAssertNil(bad.image)
         XCTAssertEqual(snapshot.accounts.first(where: { $0.name == "sq" })?.usageUpdatedAtUnix, 1788800000)
@@ -73,7 +73,7 @@ final class ComradexMenuTests: XCTestCase {
             (#""usage_windows":{"primary":{"used_percent":32},"secondary":{"used_percent":10,"limit_window_seconds":604800}}"#, "68% left"),
             (#""usage_percent":31"#, "69% left"),
             (#""usage_windows":{}"#, "Usage pending"),
-            (#""available":false,"unavailable_reason":"quota","retry_at_unix":4102444800"#, "Rate limited"),
+            (#""available":false,"unavailable_reason":"quota""#, "0% left"),
             (#""available":false,"unavailable_reason":"temporary_failure""#, "Temporarily unavailable"),
             (#""auth_state":"login_in_progress""#, "Login in progress"),
             (#""auth_state":"signed_out","signed_in":false"#, "Sign-in required"),
@@ -88,7 +88,7 @@ final class ComradexMenuTests: XCTestCase {
             ]))
             let controller = MenuBarController(store: store)
             controller.rebuildMenu()
-            let item = try XCTUnwrap(controller.renderedMenu.items.first { $0.title == "work — \(detail)" })
+            let item = try XCTUnwrap(controller.renderedMenu.items.first { $0.title == "work · \(detail)" })
             XCTAssertNil(item.subtitle)
             XCTAssertEqual(item.state, .on)
             XCTAssertFalse(item.toolTip?.contains("0d") == true)
@@ -110,8 +110,28 @@ final class ComradexMenuTests: XCTestCase {
         let controller = MenuBarController(store: store)
         controller.rebuildMenu()
         XCTAssertTrue(controller.renderedMenu.items.contains {
-            $0.title == "sq — 68% left · 6d 4h"
+            $0.title == "sq · 68% left · 6d 4h"
         })
+    }
+
+    @MainActor
+    func testExhaustedQuotaKeepsPercentageAndResetCountdown() throws {
+        let reset = Int64(Date().timeIntervalSince1970) + 5 * 86_400 + 12 * 3_600 + 120
+        let cases = [
+            "\"usage_windows\":{\"primary\":{\"used_percent\":100,\"reset_at_unix\":\(reset),\"limit_window_seconds\":604800}}",
+            "\"usage_windows\":{\"primary\":{\"used_percent\":30,\"limit_window_seconds\":18000},\"secondary\":{\"used_percent\":100,\"reset_at_unix\":\(reset),\"limit_window_seconds\":604800}}",
+            "\"retry_at_unix\":\(reset)",
+            "\"usage_windows\":{\"primary\":{\"used_percent\":100,\"reset_at_unix\":1}},\"retry_at_unix\":\(reset)",
+        ]
+        for fields in cases {
+            let account = try decodeAccount("{\"name\":\"pm\",\"available\":false,\"unavailable_reason\":\"quota\",\(fields)}")
+            let store = ComradexStore(client: StubClient())
+            store.apply(status: UIStatusSnapshot(accounts: [account]))
+            let controller = MenuBarController(store: store)
+            controller.rebuildMenu()
+            let item = try XCTUnwrap(controller.renderedMenu.items.first { $0.title == "pm · 0% left · 5d 12h" })
+            XCTAssertTrue(item.toolTip?.contains("Rate limited") == true)
+        }
     }
 
     @MainActor
@@ -219,6 +239,96 @@ final class ComradexMenuTests: XCTestCase {
 
         XCTAssertEqual(store.snapshot, status)
         XCTAssertNotNil(store.errorMessage)
+    }
+
+    @MainActor
+    func testPollingRecoversWithoutMenuInteractionAndStops() async throws {
+        let recovered = expectation(description: "automatic retry succeeded")
+        recovered.assertForOverFulfill = false
+        let client = RecoveringClient(failures: 2, onSuccess: { recovered.fulfill() })
+        let store = ComradexStore(client: client)
+        let controller = MenuBarController(store: store)
+        let cached = UIStatusSnapshot(daemonRunning: false)
+        store.apply(status: cached)
+        await store.refresh()
+        XCTAssertNotNil(store.errorMessage)
+        XCTAssertEqual(store.snapshot, cached)
+        controller.rebuildMenu()
+        XCTAssertTrue(controller.renderedMenu.items.first?.toolTip?.contains("unavailable") == true)
+        XCTAssertFalse(controller.renderedMenu.items.contains { $0.title == "Status may be out of date" })
+
+        controller.startPolling(intervalNanoseconds: 10_000_000)
+        controller.startPolling(intervalNanoseconds: 10_000_000)
+        await fulfillment(of: [recovered], timeout: 2)
+        // Allow the response to reach the main actor before inspecting rendered state.
+        for _ in 0..<100 where store.errorMessage != nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTAssertNil(store.errorMessage)
+        XCTAssertEqual(store.snapshot?.daemonRunning, true)
+        XCTAssertNotNil(store.lastSuccessfulRefresh)
+        if #available(macOS 14.4, *) {
+            XCTAssertEqual(controller.renderedMenu.items.first?.subtitle, "Running")
+        }
+        controller.stopPolling()
+        let calls = await client.calls
+        try await Task.sleep(nanoseconds: 40_000_000)
+        let afterStop = await client.calls
+        XCTAssertEqual(afterStop, calls)
+    }
+
+    @MainActor
+    func testOpeningMenuRefreshesAndDefersStructuralUpdateUntilClose() async throws {
+        let refreshed = expectation(description: "opening menu fetched status")
+        refreshed.assertForOverFulfill = false
+        let client = RecoveringClient(failures: 0, onSuccess: { refreshed.fulfill() })
+        let store = ComradexStore(client: client)
+        let controller = MenuBarController(store: store)
+        controller.menuWillOpen(controller.renderedMenu)
+        await fulfillment(of: [refreshed], timeout: 2)
+        for _ in 0..<100 where store.snapshot == nil {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTAssertEqual(store.snapshot?.daemonRunning, true)
+        XCTAssertTrue(controller.renderedMenu.items.contains { $0.title == "Connecting…" })
+        controller.menuDidClose(controller.renderedMenu)
+        if #available(macOS 14.4, *) {
+            XCTAssertEqual(controller.renderedMenu.items.first?.subtitle, "Running")
+        }
+        controller.stopPolling()
+    }
+
+    @MainActor
+    func testAccountActionFailureDoesNotMarkConnectionStaleOrDisappearOnPoll() async {
+        let store = ComradexStore(client: RecoveringClient(failures: 0))
+        await store.refresh()
+        await store.setPreferred(pool: "default", account: "missing")
+        XCTAssertNil(store.errorMessage)
+        XCTAssertNotNil(store.actionErrorMessage)
+        await store.refresh()
+        XCTAssertNil(store.errorMessage)
+        XCTAssertNotNil(store.actionErrorMessage)
+        let controller = MenuBarController(store: store)
+        controller.rebuildMenu()
+        XCTAssertTrue(controller.renderedMenu.items.contains { $0.title == "Account change failed" })
+        await store.setPreferred(pool: "default", account: "work")
+        XCTAssertNil(store.actionErrorMessage)
+    }
+
+    @MainActor
+    func testConcurrentRefreshesShareOneInFlightRequest() async {
+        let entered = expectation(description: "status request entered")
+        let client = SuspendedClient(onStatus: { entered.fulfill() })
+        let store = ComradexStore(client: client)
+        let first = Task { await store.refresh() }
+        await fulfillment(of: [entered], timeout: 2)
+        await store.refresh()
+        let count = await client.calls
+        XCTAssertEqual(count, 1)
+        await client.complete()
+        await first.value
+        XCTAssertFalse(store.isRefreshing)
+        XCTAssertEqual(store.snapshot?.daemonRunning, true)
     }
 
     @MainActor
@@ -345,4 +455,44 @@ private struct FailingClient: ControlServing {
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { throw ControlSocketError.daemon("unavailable") }
     func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.daemon("unavailable") }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.daemon("unavailable") }
+}
+
+private actor RecoveringClient: ControlServing {
+    private(set) var calls = 0
+    let failures: Int
+    let onSuccess: @Sendable () -> Void
+    init(failures: Int = 1, onSuccess: @escaping @Sendable () -> Void = {}) {
+        self.failures = failures
+        self.onSuccess = onSuccess
+    }
+    func status() async throws -> UIStatusSnapshot {
+        calls += 1
+        if calls <= failures { throw ControlSocketError.daemon("unavailable") }
+        onSuccess()
+        return UIStatusSnapshot(daemonRunning: true)
+    }
+    func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? {
+        if account == "missing" { throw ControlSocketError.daemon("Unknown account") }
+        return nil
+    }
+    func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+    func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+}
+
+private actor SuspendedClient: ControlServing {
+    private(set) var calls = 0
+    let onStatus: @Sendable () -> Void
+    private var continuation: CheckedContinuation<UIStatusSnapshot, Never>?
+    init(onStatus: @escaping @Sendable () -> Void) { self.onStatus = onStatus }
+    func status() async throws -> UIStatusSnapshot {
+        calls += 1
+        return await withCheckedContinuation {
+            continuation = $0
+            onStatus()
+        }
+    }
+    func complete() { continuation?.resume(returning: UIStatusSnapshot(daemonRunning: true)); continuation = nil }
+    func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
+    func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+    func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
 }


### PR DESCRIPTION
A failed status request could leave the menu showing an old snapshot indefinitely because automatic refresh was never started. Refresh every five seconds and when the menu opens, recover automatically, and keep account-change errors separate from connection status.

Keep connection status in the Comradex header, remove the duplicate warning row, and expose the last successful refresh and error in its tooltip. Exhausted accounts retain their percentage and reset countdown, with dot separators throughout: `pm · 0% left · 5d 12h`.

All 21 Swift tests pass, including automatic recovery, overlapping refreshes, account-action errors, and exhausted-quota countdowns.
