### PR TITLE
Make existing Codex logins easy to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Restart the Codex app after installation, or let Comradex restart its background
 comradex restart-codex
 ```
 
-That's enough to route the Codex App's existing account through Comradex. To add another account:
+That's enough to route Codex through Comradex. Setup reuses your existing local Codex login when available. To sign in another account:
 
 ```sh
 comradex account add personal_2
@@ -74,7 +74,17 @@ The daemon reads the configuration once at startup. Restart it after adding an a
 
 ### Accounts
 
-The generated configuration contains the special `app` account. It forwards the Codex App's inbound `Authorization` and `ChatGPT-Account-Id` headers and never stores or refreshes them.
+Setup creates an `app` account connected to the existing ChatGPT login in `$CODEX_HOME/auth.json`, or `~/.codex/auth.json` by default. It uses that file directly, without copying tokens, so the menubar can show usage. If no supported file-based login is available (including keychain-only or API-key logins), setup keeps `app` in `inbound` mode: it forwards the requesting client's `Authorization` and `ChatGPT-Account-Id` headers.
+
+For an existing inbound account, choose **Connect existing Codex login…** in the menubar, or run:
+
+```sh
+comradex account connect app
+# For a custom Codex home:
+comradex account connect app --codex-home /absolute/path/to/codex-home
+```
+
+Connecting preserves the account name, pool membership, and preferred account. The menubar reloads Comradex after confirmation; active requests are interrupted. The CLI restarts a running macOS service; restart a manually launched daemon yourself. The menubar discovers the login from the daemon's `CODEX_HOME` or `~/.codex`; use the CLI option for another home. If the login is unavailable, the action reports an error and leaves the configuration unchanged.
 
 Add a managed account in one step:
 
@@ -94,7 +104,7 @@ comradex account prefer --clear
 comradex account remove personal_2
 ```
 
-`account list` shows each account's login state. `account remove` removes it from the configuration and every pool but keeps its credential directory unless `--purge` is passed.
+`account list` shows each account's login state. `account remove` removes it from the configuration and every pool but keeps its credential directory. `--purge` can delete only the isolated home created for that account; it refuses external or linked Codex homes.
 
 `account prefer <name>` immediately makes that account the first choice for new, unbound work in the default pool. Use `--pool <name>` for another pool and `--clear` to restore automatic selection. The daemon applies the change through an authenticated, user-only Unix socket and persists it in `comradex.toml`; it does not restart, interrupt active turns, or move sticky conversations. An unavailable, quota-limited, or over-threshold preferred account is skipped by the normal quota-aware fallback. If the daemon is not running, the preference is saved and takes effect on its next start.
 
@@ -117,7 +127,7 @@ comradex account login personal_2
 
 This executes `codex login --device-auth` with `CODEX_HOME` set to the isolated directory. Absolute account paths are used unchanged; relative paths are resolved against the canonical directory containing `comradex.toml`, just like a relative `proxy.state_dir`.
 
-For each request, the daemon reads the account's `auth.json`, derives a missing account ID from the ID-token claims, and uses Codex's current OAuth refresh contract when the access token is near expiry or receives a 401. A bounded background sweep checks managed accounts once per minute and refreshes only tokens within five minutes of expiry, so rarely selected accounts do not depend on request-time refresh. Refreshes are single-flight per normalized, non-overlapping account home and atomically rotate `auth.json`; permanent refresh rejection marks only that account as requiring device login. The Codex App's own credentials remain unmanaged.
+For each request, the daemon reads the account's `auth.json`, derives a missing account ID from the ID-token claims, and uses Codex's current OAuth refresh contract when the access token is near expiry or receives a 401. A bounded background sweep checks managed accounts once per minute and refreshes only tokens within five minutes of expiry, so rarely selected accounts do not depend on request-time refresh. Refreshes are single-flight per normalized, non-overlapping account home and atomically rotate `auth.json`; permanent refresh rejection marks only that account as requiring device login. This includes an existing Codex login explicitly connected as a `codex_home` account. Credentials forwarded by an `inbound` account remain unmanaged.
 
 On macOS, `comradex account login` temporarily unloads an installed, running Comradex LaunchAgent while the official Codex client writes the selected account home, then restores the service and waits for its listeners. This prevents login and daemon refresh from racing over rotating credentials.
 

--- a/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
@@ -8,6 +8,7 @@ final class ComradexStore: ObservableObject {
     @Published private(set) var login: LoginSnapshot?
     @Published private(set) var isRefreshing = false
     @Published private(set) var updatingPool: String?
+    @Published private(set) var connectingAccount: String?
     @Published private(set) var errorMessage: String?
     @Published private(set) var actionErrorMessage: String?
     @Published private(set) var lastSuccessfulRefresh: Date?
@@ -79,6 +80,32 @@ final class ComradexStore: ObservableObject {
             } catch {
                 apply(login: LoginSnapshot(account: account, sessionID: login?.sessionID, state: .failed, error: error.localizedDescription))
             }
+        }
+    }
+
+    func connectExistingLogin(account: String) async {
+        guard connectingAccount == nil, !isLoginRunning, updatingPool == nil else { return }
+        connectingAccount = account
+        defer { connectingAccount = nil }
+        do {
+            try await client.connectExistingLogin(account: account)
+            // The daemon acknowledges before reloading. Wait until the new account
+            // is visible instead of reporting the old inbound snapshot as success.
+            for _ in 0..<40 {
+                try await Task.sleep(nanoseconds: 250_000_000)
+                if let updated = try? await client.status(),
+                   let connected = updated.accounts.first(where: { $0.name == account }),
+                   !connected.isInbound {
+                    apply(status: updated)
+                    actionErrorMessage = nil
+                    return
+                }
+            }
+            throw ControlSocketError.daemon("Login connection saved, but Comradex has not reconnected yet. Refresh to check its status.")
+        } catch is CancellationError {
+            return
+        } catch {
+            actionErrorMessage = error.localizedDescription
         }
     }
 

--- a/macos/ComradexMenu/Sources/ComradexMenu/ControlSocketClient.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/ControlSocketClient.swift
@@ -5,6 +5,7 @@ enum UIControlCommand: Equatable, Sendable {
     case status
     case setPreferred(pool: String, account: String?)
     case startLogin(account: String)
+    case connectExistingLogin(account: String)
     case loginStatus(sessionID: String)
 
     func encoded() throws -> Data {
@@ -20,6 +21,8 @@ enum UIControlCommand: Equatable, Sendable {
             ]
         case .startLogin(let account):
             object = ["command": "ui_start_login", "account": account]
+        case .connectExistingLogin(let account):
+            object = ["command": "ui_connect_existing_login", "account": account]
         case .loginStatus(let sessionID):
             object = ["command": "ui_login_status", "session_id": sessionID]
         }
@@ -59,6 +62,7 @@ protocol ControlServing: Sendable {
     func status() async throws -> UIStatusSnapshot
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot?
     func startLogin(account: String) async throws -> LoginSnapshot
+    func connectExistingLogin(account: String) async throws
     func loginStatus(sessionID: String) async throws -> LoginSnapshot
 }
 
@@ -93,6 +97,13 @@ final class ControlSocketClient: ControlServing, @unchecked Sendable {
     func startLogin(account: String) async throws -> LoginSnapshot {
         let data = try await request(.startLogin(account: account))
         return try Self.decode(LoginSnapshot.self, from: data, preferredKeys: ["login", "login_status", "payload", "result"])
+    }
+
+    func connectExistingLogin(account: String) async throws {
+        struct Acknowledgement: Decodable { let ok: Bool }
+        let data = try await request(.connectExistingLogin(account: account))
+        let response = try Self.decode(Acknowledgement.self, from: data, preferredKeys: [])
+        guard response.ok else { throw ControlSocketError.malformedResponse }
     }
 
     func loginStatus(sessionID: String) async throws -> LoginSnapshot {

--- a/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
@@ -180,18 +180,31 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             item.title = "\(account.name) · \(detail)"
         }
         item.state = isPreferred ? .on : .off
-        item.isEnabled = pool != nil && store.updatingPool == nil
+        item.isEnabled = pool != nil && store.updatingPool == nil && store.connectingAccount == nil
         if let pool {
             item.representedObject = PreferredAccountAction(pool: pool.name, account: account.name)
         }
         menu.addItem(item)
+
+        if account.isInbound {
+            let connect = actionItem(
+                title: store.connectingAccount == account.name ? "Connecting Codex login…" : "Connect existing Codex login…",
+                icon: "person.crop.circle.badge.checkmark",
+                action: #selector(connectExistingLoginSelected(_:)),
+                enabled: store.connectingAccount == nil && !store.isLoginRunning && store.updatingPool == nil
+            )
+            connect.representedObject = account.name
+            connect.indentationLevel = 1
+            connect.toolTip = "Reuse your local Codex login and show its usage."
+            menu.addItem(connect)
+        }
 
         if account.needsLoginAction {
             let login = actionItem(
                 title: "Re-login \(account.name)…",
                 icon: "person.crop.circle.badge.exclamationmark",
                 action: #selector(reloginSelected(_:)),
-                enabled: !store.isLoginRunning
+                enabled: !store.isLoginRunning && store.connectingAccount == nil
             )
             login.representedObject = account.name
             login.indentationLevel = 1
@@ -258,6 +271,22 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         showLoginWindow()
     }
 
+    @objc private func connectExistingLoginSelected(_ sender: NSMenuItem) {
+        guard let account = sender.representedObject as? String else { return }
+        let alert = NSAlert()
+        alert.messageText = "Connect existing Codex login to \(account)?"
+        alert.informativeText = "Reuse the local Codex login to show usage and route requests with that account. No tokens are copied and your preferred account stays the same. Comradex will reload, interrupting active requests."
+        alert.addButton(withTitle: "Connect Login")
+        alert.addButton(withTitle: "Cancel")
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            await store.connectExistingLogin(account: account)
+            rebuildMenu()
+        }
+    }
+
     private func showLoginWindow() {
         if loginWindowController == nil {
             let window = NSWindow(
@@ -315,7 +344,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         }
         switch account.authState?.lowercased() {
         case "login_in_progress": return "Login in progress"
-        case "inbound": return "Codex App account"
+        case "inbound": return "Requesting client’s login"
         case "signed_in": return "Signed in"
         case "signed_out": return "Sign-in required"
         default: return account.isSignedIn ? "Signed in" : "Sign-in required"
@@ -330,7 +359,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         {
             return accountState(account, expanded: expanded)
         }
-        if account.isInbound { return expanded ? "Codex App account" : "" }
+        if account.isInbound { return "Requesting client’s login" }
         return usageDescription(account, expanded: expanded) ?? "Usage pending"
     }
 

--- a/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
+++ b/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
@@ -40,11 +40,16 @@ final class ComradexMenuTests: XCTestCase {
         let items = controller.renderedMenu.items
         XCTAssertFalse(controller.renderedMenu.autoenablesItems)
         XCTAssertFalse(items.contains { $0.title.contains("default") || $0.title.contains("Active:") })
-        let app = try XCTUnwrap(items.first(where: { $0.title == "app" }))
+        let app = try XCTUnwrap(items.first(where: { $0.title == "app · Requesting client’s login" }))
+        let connect = try XCTUnwrap(items.first(where: { $0.title == "Connect existing Codex login…" }))
+        XCTAssertEqual(connect.representedObject as? String, "app")
+        XCTAssertTrue(connect.isEnabled)
+        XCTAssertNotNil(connect.action)
+        XCTAssertEqual(items.filter { $0.title == "Connect existing Codex login…" }.count, 1)
         XCTAssertEqual(app.state, .on)
         XCTAssertNil(app.image)
         XCTAssertNil(app.subtitle)
-        XCTAssertEqual(app.toolTip, "Preferred · Codex App account")
+        XCTAssertEqual(app.toolTip, "Preferred · Requesting client’s login")
         let sq = try XCTUnwrap(items.first(where: { $0.title.hasPrefix("sq · 81% left · ") }))
         XCTAssertFalse(sq.title.contains("resets in"))
         XCTAssertFalse(sq.title.contains("19%"))
@@ -210,6 +215,37 @@ final class ComradexMenuTests: XCTestCase {
             with: UIControlCommand.setPreferred(pool: "default", account: nil).encoded()
         ) as? [String: Any])
         XCTAssertTrue(automatic["account"] is NSNull)
+    }
+
+    func testConnectCommandIncludesOnlyAccount() throws {
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(
+            with: UIControlCommand.connectExistingLogin(account: "app").encoded()
+        ) as? [String: String])
+        XCTAssertEqual(object, ["command": "ui_connect_existing_login", "account": "app"])
+    }
+
+    @MainActor
+    func testConnectFailureRemainsVisibleWithoutClearingStatus() async {
+        let store = ComradexStore(client: FailingClient())
+        let original = UIStatusSnapshot(daemonRunning: true)
+        store.apply(status: original)
+        await store.connectExistingLogin(account: "app")
+        XCTAssertNotNil(store.actionErrorMessage)
+        XCTAssertNil(store.connectingAccount)
+        XCTAssertEqual(store.snapshot, original)
+        XCTAssertNil(store.errorMessage)
+    }
+
+    @MainActor
+    func testConnectWaitsForManagedAccountAfterReload() async throws {
+        let client = ConnectingClient()
+        let store = ComradexStore(client: client)
+        await store.connectExistingLogin(account: "app")
+        XCTAssertNil(store.actionErrorMessage)
+        XCTAssertNil(store.connectingAccount)
+        XCTAssertEqual(store.snapshot?.accounts.first?.kind, "codex_home")
+        let calls = await client.calls
+        XCTAssertEqual(calls, 3)
     }
 
     func testSocketOverrideAndDefaultPath() {
@@ -446,6 +482,7 @@ final class ComradexMenuTests: XCTestCase {
 private struct StubClient: ControlServing {
     func status() async throws -> UIStatusSnapshot { UIStatusSnapshot() }
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.daemon("unavailable") }
     func startLogin(account: String) async throws -> LoginSnapshot { LoginSnapshot(account: account, state: .running) }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { LoginSnapshot(account: "work", sessionID: sessionID, state: .succeeded) }
 }
@@ -453,6 +490,7 @@ private struct StubClient: ControlServing {
 private struct FailingClient: ControlServing {
     func status() async throws -> UIStatusSnapshot { throw ControlSocketError.daemon("unavailable") }
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { throw ControlSocketError.daemon("unavailable") }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.daemon("unavailable") }
     func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.daemon("unavailable") }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.daemon("unavailable") }
 }
@@ -475,6 +513,7 @@ private actor RecoveringClient: ControlServing {
         if account == "missing" { throw ControlSocketError.daemon("Unknown account") }
         return nil
     }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.daemon("unavailable") }
     func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
 }
@@ -492,6 +531,22 @@ private actor SuspendedClient: ControlServing {
         }
     }
     func complete() { continuation?.resume(returning: UIStatusSnapshot(daemonRunning: true)); continuation = nil }
+    func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.daemon("unavailable") }
+    func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+    func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+}
+
+private actor ConnectingClient: ControlServing {
+    private(set) var calls = 0
+    func connectExistingLogin(account: String) async throws {}
+    func status() async throws -> UIStatusSnapshot {
+        calls += 1
+        if calls == 1 { throw ControlSocketError.emptyResponse }
+        let kind = calls == 2 ? "inbound" : "codex_home"
+        let account = try JSONDecoder().decode(AccountSnapshot.self, from: Data("{\"name\":\"app\",\"kind\":\"\(kind)\"}".utf8))
+        return UIStatusSnapshot(daemonRunning: true, accounts: [account])
+    }
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
     func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -5,7 +5,94 @@
 //! result through `Config::load` before persisting it.
 
 use anyhow::{Context, Result, bail};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 use toml_edit::{DocumentMut, Item, value};
+
+/// Locate the login used by the requesting user's Codex CLI.
+pub fn default_codex_home() -> Result<PathBuf> {
+    default_codex_home_from(std::env::var_os("CODEX_HOME"), std::env::var_os("HOME"))
+}
+
+fn default_codex_home_from(
+    codex_home: Option<OsString>,
+    home: Option<OsString>,
+) -> Result<PathBuf> {
+    let path = match codex_home.filter(|value| !value.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(
+            home.filter(|value| !value.is_empty())
+                .context("HOME is not set")?,
+        )
+        .join(".codex"),
+    };
+    let absolute = std::path::absolute(path).context("resolve Codex home")?;
+    crate::config::normalize_codex_home(&absolute)
+}
+
+/// Discover a supported existing login without refreshing or changing credentials.
+pub fn existing_codex_home() -> Result<PathBuf> {
+    let home = default_codex_home()?;
+    crate::auth::validate_existing_login(&home)?;
+    Ok(home)
+}
+
+/// Link an inbound account to an existing login, keeping its pool membership and preferences.
+/// The caller must validate the result with Config::load to reject duplicate homes.
+pub fn connect_existing_account(text: &str, name: &str, home: &Path) -> Result<String> {
+    validate_name(name)?;
+    let mut doc: DocumentMut = text.parse().context("parse comradex.toml")?;
+    let account = doc
+        .get_mut("accounts")
+        .and_then(Item::as_table_like_mut)
+        .and_then(|accounts| accounts.get_mut(name))
+        .with_context(|| format!("unknown account {name}"))?;
+    if account.get("kind").and_then(Item::as_str) != Some("inbound") {
+        bail!(
+            "account {name} already has its own login; only inbound accounts can connect an existing login"
+        )
+    }
+    let home = crate::config::normalize_codex_home(&std::path::absolute(home)?)?;
+    crate::auth::validate_existing_login(&home)?;
+    let path = home
+        .to_str()
+        .context("Codex home path is not valid UTF-8")?;
+    // Preserve inline comments attached to the original kind value.
+    let decor = account["kind"]
+        .as_value()
+        .map(|value| value.decor().clone());
+    account["kind"] = value("codex_home");
+    if let Some(decor) = decor {
+        *account["kind"]
+            .as_value_mut()
+            .expect("kind is a value")
+            .decor_mut() = decor;
+    }
+    account["path"] = value(path);
+    Ok(doc.to_string())
+}
+
+/// Purging is restricted to the isolated home allocated for this account.
+pub fn validate_purge_home(config_path: &Path, name: &str, home: &Path) -> Result<()> {
+    validate_name(name)?;
+    let config_path = std::path::absolute(config_path)?;
+    let parent = config_path
+        .parent()
+        .context("configuration has no parent directory")?;
+    let expected = parent.join("accounts").join(name);
+    // Do not follow a symlink at the isolated account directory to an external login.
+    if std::fs::symlink_metadata(&expected).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        bail!("cannot purge a linked Codex home; remove the account without --purge")
+    }
+    let accounts = crate::config::normalize_codex_home(&parent.join("accounts"))?;
+    let home = crate::config::normalize_codex_home(&std::path::absolute(home)?)?;
+    if home != accounts.join(name) {
+        bail!("cannot purge an external Codex login; remove the account without --purge")
+    }
+    Ok(())
+}
 
 /// Account names become directory names under the config directory, so keep
 /// them to a safe character set.
@@ -135,6 +222,117 @@ members = ["caller"]
 [accounts.caller]
 kind = "inbound"
 "#;
+
+    fn login_home() -> tempfile::TempDir {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::write(
+            home.path().join("auth.json"),
+            r#"{"tokens":{"access_token":"test-access-token"}}"#,
+        )
+        .unwrap();
+        home
+    }
+
+    #[test]
+    fn discover_home_honors_custom_home_and_empty_fallback() {
+        let directory = tempfile::tempdir().unwrap();
+        let custom = directory.path().join("custom");
+        let user = directory.path().join("user");
+        assert_eq!(
+            default_codex_home_from(
+                Some(custom.clone().into_os_string()),
+                Some(user.clone().into_os_string())
+            )
+            .unwrap(),
+            crate::config::normalize_codex_home(&custom).unwrap()
+        );
+        assert_eq!(
+            default_codex_home_from(Some(OsString::new()), Some(user.clone().into_os_string()))
+                .unwrap(),
+            crate::config::normalize_codex_home(&user.join(".codex")).unwrap()
+        );
+        assert!(default_codex_home_from(None, None).is_err());
+    }
+
+    #[test]
+    fn connect_preserves_preferences_members_comments_and_credentials() {
+        let home = login_home();
+        let auth_before = std::fs::read(home.path().join("auth.json")).unwrap();
+        let original = set_preferred_account(TEMPLATE, "default", Some("caller"))
+            .unwrap()
+            .replace(
+                "kind = \"inbound\"",
+                "kind = \"inbound\" # existing comment",
+            );
+        let updated =
+            connect_existing_account(&original, "caller", &home.path().join(".")).unwrap();
+        let config: crate::config::Config = toml::from_str(&updated).unwrap();
+        assert_eq!(config.pools["default"].preferred.as_deref(), Some("caller"));
+        assert_eq!(config.pools["default"].members, vec!["caller"]);
+        assert!(updated.contains("# my listener"));
+        assert!(updated.contains("# existing comment"));
+        let crate::config::AccountConfig::CodexHome { path } = &config.accounts["caller"] else {
+            panic!("expected linked login")
+        };
+        assert_eq!(path, &std::fs::canonicalize(home.path()).unwrap());
+        assert_eq!(
+            std::fs::read(home.path().join("auth.json")).unwrap(),
+            auth_before
+        );
+        assert!(connect_existing_account(&updated, "caller", home.path()).is_err());
+        assert!(connect_existing_account(TEMPLATE, "missing", home.path()).is_err());
+    }
+
+    #[test]
+    fn connect_rejects_missing_malformed_and_unsupported_logins_without_exposing_contents() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(connect_existing_account(TEMPLATE, "caller", home.path()).is_err());
+        for auth in [
+            "secret-malformed-json",
+            r#"{"OPENAI_API_KEY":"secret-key"}"#,
+            r#"{"tokens":{"access_token":""}}"#,
+        ] {
+            std::fs::write(home.path().join("auth.json"), auth).unwrap();
+            let error = connect_existing_account(TEMPLATE, "caller", home.path()).unwrap_err();
+            assert!(!format!("{error:#}").contains("secret"));
+        }
+    }
+
+    #[test]
+    fn caller_validation_rejects_duplicate_linked_home() {
+        let home = login_home();
+        let added = add_account(TEMPLATE, "other", "default").unwrap();
+        let added = added.replace(
+            "path = \"accounts/other\"",
+            &format!("path = {:?}", home.path().to_str().unwrap()),
+        );
+        let updated = connect_existing_account(&added, "caller", home.path()).unwrap();
+        let config_directory = tempfile::tempdir().unwrap();
+        let config_path = config_directory.path().join("comradex.toml");
+        std::fs::write(&config_path, &updated).unwrap();
+        assert!(crate::config::Config::load(&config_path).is_err());
+    }
+
+    #[test]
+    fn purge_accepts_only_the_accounts_own_isolated_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("comradex.toml");
+        assert!(validate_purge_home(&config, "app", &dir.path().join("accounts/app")).is_ok());
+        for path in [
+            dir.path().join(".codex"),
+            dir.path().join("accounts"),
+            dir.path().join("accounts/other"),
+        ] {
+            assert!(validate_purge_home(&config, "app", &path).is_err());
+        }
+        #[cfg(unix)]
+        {
+            std::fs::create_dir_all(dir.path().join("accounts")).unwrap();
+            let external = tempfile::tempdir().unwrap();
+            std::os::unix::fs::symlink(external.path(), dir.path().join("accounts/app")).unwrap();
+            assert!(validate_purge_home(&config, "app", external.path()).is_err());
+        }
+    }
 
     #[test]
     fn add_appends_account_and_pool_member_preserving_comments() {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -622,6 +622,26 @@ fn inbound_credentials(inbound: &HeaderMap) -> Result<Credentials> {
     })
 }
 
+/// Check a local ChatGPT login without refreshing it or exposing credential contents.
+pub fn validate_existing_login(home: &Path) -> Result<()> {
+    let document = read_auth(&home.join("auth.json")).map_err(|_| {
+        anyhow::anyhow!("No readable Codex login found. Sign in with `codex login` using file credential storage, then try again.")
+    })?;
+    if ![
+        &["tokens", "access_token"][..],
+        &["tokens", "accessToken"][..],
+        &["access_token"][..],
+    ]
+    .iter()
+    .any(|keys| lookup(&document.value, keys).is_some_and(|token| !token.is_empty()))
+    {
+        bail!(
+            "Connect a ChatGPT login from `codex login`; API-key logins do not provide ChatGPT usage."
+        )
+    }
+    Ok(())
+}
+
 fn read_auth(path: &Path) -> Result<AuthDocument> {
     let value: Value = serde_json::from_slice(
         &fs::read(path).with_context(|| format!("read {}", path.display()))?,

--- a/src/control.rs
+++ b/src/control.rs
@@ -23,7 +23,7 @@ use tokio::{
     io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader as AsyncBufReader},
     net::{UnixListener, UnixStream},
     process::Command,
-    sync::{Mutex, Semaphore},
+    sync::{Mutex, Notify, Semaphore},
 };
 use tracing::warn;
 
@@ -62,6 +62,11 @@ enum Request {
     UiStartLogin {
         account: String,
     },
+    UiConnectExistingLogin {
+        account: String,
+        #[serde(default)]
+        codex_home: Option<PathBuf>,
+    },
     UiLoginStatus {
         session_id: String,
     },
@@ -74,6 +79,7 @@ impl Request {
             Self::UiStatus
             | Self::UiSetPreferred { .. }
             | Self::UiStartLogin { .. }
+            | Self::UiConnectExistingLogin { .. }
             | Self::UiLoginStatus { .. } => None,
         }
     }
@@ -489,6 +495,11 @@ impl Drop for SocketGuard {
     }
 }
 
+struct ConfigChanges {
+    edit_lock: Mutex<()>,
+    reload: Arc<Notify>,
+}
+
 pub struct ControlServer {
     listener: UnixListener,
     _guard: SocketGuard,
@@ -497,7 +508,7 @@ pub struct ControlServer {
     router: Arc<Router>,
     stats: Arc<Stats>,
     login_manager: LoginManager,
-    edit_lock: Arc<Mutex<()>>,
+    changes: Arc<ConfigChanges>,
     clients: Arc<Semaphore>,
 }
 
@@ -531,9 +542,16 @@ impl ControlServer {
             router,
             stats,
             login_manager,
-            edit_lock: Arc::new(Mutex::new(())),
+            changes: Arc::new(ConfigChanges {
+                edit_lock: Mutex::new(()),
+                reload: Arc::new(Notify::new()),
+            }),
             clients: Arc::new(Semaphore::new(MAX_CONTROL_CLIENTS)),
         })
+    }
+
+    pub fn reload_requested(&self) -> Arc<Notify> {
+        self.changes.reload.clone()
     }
 
     pub async fn run(self) -> Result<()> {
@@ -544,8 +562,12 @@ impl ControlServer {
             }
         }
         let _login_shutdown = LoginShutdownGuard(self.login_manager.clone());
+        let mut handlers = tokio::task::JoinSet::new();
         loop {
-            let (stream, _) = self.listener.accept().await?;
+            let (stream, _) = tokio::select! {
+                connection = self.listener.accept() => connection?,
+                Some(_) = handlers.join_next(), if !handlers.is_empty() => continue,
+            };
             let Ok(permit) = self.clients.clone().try_acquire_owned() else {
                 continue;
             };
@@ -554,8 +576,8 @@ impl ControlServer {
             let router = self.router.clone();
             let stats = self.stats.clone();
             let login_manager = self.login_manager.clone();
-            let edit_lock = self.edit_lock.clone();
-            tokio::spawn(async move {
+            let changes = self.changes.clone();
+            handlers.spawn(async move {
                 let _permit = permit;
                 if let Err(error) = handle(
                     stream,
@@ -564,7 +586,7 @@ impl ControlServer {
                     router,
                     stats,
                     login_manager,
-                    edit_lock,
+                    changes,
                 )
                 .await
                 {
@@ -603,7 +625,7 @@ async fn handle(
     router: Arc<Router>,
     stats: Arc<Stats>,
     login_manager: LoginManager,
-    edit_lock: Arc<Mutex<()>>,
+    changes: Arc<ConfigChanges>,
 ) -> Result<()> {
     if !peer_is_current_user(&stream)? {
         bail!("control peer is not the daemon user")
@@ -615,6 +637,7 @@ async fn handle(
         .await
         .context("control request timed out")?
         .context("read control request")?;
+    let mut reload_after_response = false;
     let response = if read == 0 || bytes.len() > MAX_MESSAGE_BYTES || !bytes.ends_with(b"\n") {
         Response {
             ok: false,
@@ -626,6 +649,7 @@ async fn handle(
     } else {
         match serde_json::from_slice::<Request>(&bytes) {
             Ok(request) => {
+                reload_after_response = matches!(request, Request::UiConnectExistingLogin { .. });
                 process(
                     request,
                     &config_path,
@@ -633,7 +657,7 @@ async fn handle(
                     &router,
                     &stats,
                     &login_manager,
-                    &edit_lock,
+                    &changes.edit_lock,
                 )
                 .await
             }
@@ -646,17 +670,24 @@ async fn handle(
             },
         }
     };
+    let reload_after_response = reload_after_response && response.ok;
     let mut encoded = serde_json::to_vec(&response)?;
     if encoded.len() > MAX_RESPONSE_BYTES {
         encoded = serde_json::to_vec(&Response::error("control response is too large"))?;
     }
     encoded.push(b'\n');
-    tokio::time::timeout(RESPONSE_TIMEOUT, async {
+    let sent = tokio::time::timeout(RESPONSE_TIMEOUT, async {
         writer.write_all(&encoded).await?;
         writer.shutdown().await
     })
     .await
-    .context("control response timed out")??;
+    .context("control response timed out");
+    // The config is already persisted. Reload even if the client disconnected while
+    // receiving its acknowledgement, but never tear down a successful response early.
+    if reload_after_response {
+        changes.reload.notify_one();
+    }
+    sent??;
     Ok(())
 }
 
@@ -688,6 +719,17 @@ async fn process(
             Request::UiStartLogin { account } => {
                 let home = managed_account_home(config, &account)?.to_owned();
                 Response::login(login_manager.start(account, home).await?)
+            }
+            Request::UiConnectExistingLogin {
+                account,
+                codex_home,
+            } => {
+                let home = match codex_home {
+                    Some(home) => home,
+                    None => accounts::existing_codex_home()?,
+                };
+                connect_existing_login(config_path, edit_lock, &account, &home).await?;
+                Response::routing(router.routing_snapshot().await)
             }
             Request::UiLoginStatus { session_id } => {
                 Response::login(login_manager.status(&session_id)?)
@@ -767,6 +809,18 @@ async fn update_preferred(
     config::write_validated(config_path, &updated)?;
     router.set_preferred(pool, account).await;
     Ok(())
+}
+
+async fn connect_existing_login(
+    config_path: &Path,
+    edit_lock: &Mutex<()>,
+    account: &str,
+    home: &Path,
+) -> Result<()> {
+    let _guard = edit_lock.lock().await;
+    let text = fs::read_to_string(config_path).context("read Comradex configuration")?;
+    let updated = accounts::connect_existing_account(&text, account, home)?;
+    config::write_validated(config_path, &updated)
 }
 
 async fn build_ui_status(
@@ -892,7 +946,9 @@ fn managed_account_home<'a>(config: &'a Config, account: &str) -> Result<&'a Pat
         .with_context(|| format!("unknown account {account}"))?
     {
         crate::config::AccountConfig::Inbound => {
-            bail!("inbound accounts use the Codex App login and cannot be logged in here")
+            bail!(
+                "this account uses the requesting client's login; connect an existing Codex login first"
+            )
         }
         crate::config::AccountConfig::CodexHome { path } => Ok(path),
     }
@@ -1251,6 +1307,106 @@ path = "accounts/work"
         })
         .await
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn connect_existing_login_acknowledges_then_reloads_and_rejects_invalid_login() {
+        let (dir, config, router) = managed_login_fixture();
+        let config_path = dir.path().join("comradex.toml");
+        let state = config.proxy.state_dir.clone().unwrap();
+        let server = ControlServer::bind(
+            &state,
+            config_path.clone(),
+            config.clone(),
+            router,
+            Arc::new(Stats::default()),
+        )
+        .unwrap();
+        let reload = server.reload_requested();
+        let task = tokio::spawn(server.run());
+        let original = fs::read_to_string(&config_path).unwrap();
+        let home = dir.path().join("existing-login");
+        let state_copy = state.clone();
+        let home_copy = home.clone();
+        let rejected = tokio::task::spawn_blocking(move || send_raw(&state_copy, serde_json::json!({
+            "command": "ui_connect_existing_login", "account": "app", "codex_home": home_copy,
+        }))).await.unwrap();
+        assert!(!rejected.ok);
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), original);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), reload.notified())
+                .await
+                .is_err()
+        );
+
+        fs::create_dir_all(&home).unwrap();
+        let auth =
+            r#"{"tokens":{"access_token":"fixture-access","refresh_token":"fixture-refresh"}}"#;
+        fs::write(home.join("auth.json"), auth).unwrap();
+        let state_copy = state.clone();
+        let home_copy = home.clone();
+        let accepted = tokio::task::spawn_blocking(move || send_raw(&state_copy, serde_json::json!({
+            "command": "ui_connect_existing_login", "account": "app", "codex_home": home_copy,
+        }))).await.unwrap();
+        assert!(accepted.ok, "{:?}", accepted.error);
+        tokio::time::timeout(Duration::from_secs(1), reload.notified())
+            .await
+            .unwrap();
+        assert_eq!(fs::read_to_string(home.join("auth.json")).unwrap(), auth);
+        assert!(
+            !serde_json::to_string(&accepted)
+                .unwrap()
+                .contains("fixture-access")
+        );
+        task.abort();
+        let _ = task.await;
+        let updated = Arc::new(Config::load(&config_path).unwrap());
+        assert_eq!(
+            updated.pools["default"].members,
+            config.pools["default"].members
+        );
+        assert_eq!(
+            updated.pools["default"].preferred,
+            config.pools["default"].preferred
+        );
+        assert!(matches!(
+            updated.accounts["app"],
+            config::AccountConfig::CodexHome { .. }
+        ));
+        let affinity = Arc::new(
+            AffinityStore::load(
+                state.join("affinity.json"),
+                &updated.proxy.affinity_key,
+                Duration::from_secs(60),
+            )
+            .unwrap(),
+        );
+        let router = Arc::new(Router::new(&updated, affinity));
+        let server = ControlServer::bind(
+            &state,
+            config_path,
+            updated,
+            router,
+            Arc::new(Stats::default()),
+        )
+        .unwrap();
+        let task = tokio::spawn(server.run());
+        let status = tokio::task::spawn_blocking(move || {
+            send_raw(&state, serde_json::json!({"command":"ui_status"}))
+        })
+        .await
+        .unwrap();
+        let app = status
+            .status
+            .unwrap()
+            .accounts
+            .into_iter()
+            .find(|account| account.name == "app")
+            .unwrap();
+        assert!(app.signed_in);
+        assert_eq!(app.auth_state, UiAccountAuthState::SignedIn);
+        task.abort();
+        let _ = task.await;
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,10 +102,17 @@ enum AccountCommand {
     },
     /// Sign an account in through the official Codex device flow
     Login { name: String },
+    /// Connect an inbound account to your existing Codex login
+    Connect {
+        name: String,
+        /// Existing Codex home [default: CODEX_HOME or ~/.codex]
+        #[arg(long)]
+        codex_home: Option<PathBuf>,
+    },
     /// Remove an account from the configuration and all pools
     Remove {
         name: String,
-        /// Also delete the account's codex_home directory (credentials)
+        /// Also delete an isolated account home (external logins cannot be purged)
         #[arg(long)]
         purge: bool,
     },
@@ -217,6 +224,13 @@ fn load_config(path: &Path) -> Result<Config> {
 }
 
 fn init(path: &Path) -> Result<()> {
+    init_with_codex_home(
+        path,
+        comradex::accounts::default_codex_home().ok().as_deref(),
+    )
+}
+
+fn init_with_codex_home(path: &Path, codex_home: Option<&Path>) -> Result<()> {
     if path.exists() {
         bail!("{} already exists", path.display())
     }
@@ -254,17 +268,36 @@ kind = "inbound"
         URL_SAFE_NO_PAD.encode(secret),
         URL_SAFE_NO_PAD.encode(key)
     );
-    fs::write(path, text)?;
+    let connected = codex_home
+        .and_then(|home| comradex::accounts::connect_existing_account(&text, "app", home).ok());
+    let uses_existing_login = connected.is_some();
+    let text = connected.unwrap_or(text);
+    write_config_validated(path, &text)?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
     }
     println!("created {}", path.display());
+    if uses_existing_login {
+        println!("connected app to your existing Codex login");
+    } else {
+        println!(
+            "no supported login found in the local Codex auth.json; app uses the requesting client's login"
+        );
+        println!(
+            "after signing in with Codex, run `comradex account connect app` to enable usage tracking"
+        );
+    }
     Ok(())
 }
 
 async fn serve(path: &Path) -> Result<()> {
+    while serve_once(path).await? {}
+    Ok(())
+}
+
+async fn serve_once(path: &Path) -> Result<bool> {
     #[cfg(unix)]
     if let Some((soft, hard)) = open_file_limits() {
         info!(soft, hard, "open file limits");
@@ -288,6 +321,7 @@ async fn serve(path: &Path) -> Result<()> {
         router.clone(),
         stats.clone(),
     )?;
+    let reload = control_server.reload_requested();
     let mut control_task = tokio::spawn(control_server.run());
     let app = App::new(config.clone(), router.clone(), stats.clone())?;
     let mut tasks = tokio::task::JoinSet::new();
@@ -340,7 +374,12 @@ async fn serve(path: &Path) -> Result<()> {
             usage_refresh_app.refresh_managed_usage_at(now).await;
         }
     });
+    let mut reload_requested = false;
     let listener_error = tokio::select! {
+        _ = reload.notified() => {
+            reload_requested = true;
+            None
+        },
         signal = shutdown_signal() => {
             signal?;
             None
@@ -380,7 +419,7 @@ async fn serve(path: &Path) -> Result<()> {
     if let Some(error) = listener_error {
         return Err(error);
     }
-    Ok(())
+    Ok(reload_requested)
 }
 
 #[cfg(unix)]
@@ -670,7 +709,7 @@ fn account_status_state(
     status: Option<&comradex::routing::AccountRoutingStatus>,
 ) -> String {
     if matches!(account, comradex::config::AccountConfig::Inbound) {
-        return "Codex App login".to_owned();
+        return "Requesting client's login".to_owned();
     }
     let Some(status) = status else {
         return match account {
@@ -763,7 +802,7 @@ fn human_duration(seconds: u64) -> String {
 /// Short, plain-language state for one account.
 fn account_state(account: &comradex::config::AccountConfig) -> String {
     match account {
-        comradex::config::AccountConfig::Inbound => "Codex App login".to_owned(),
+        comradex::config::AccountConfig::Inbound => "Requesting client's login".to_owned(),
         comradex::config::AccountConfig::CodexHome { path } => {
             if path.join("auth.json").exists() {
                 "signed in".to_owned()
@@ -804,6 +843,22 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
             Ok(())
         }
         AccountCommand::Login { name } => login(config_path, &name),
+        AccountCommand::Connect { name, codex_home } => {
+            load_config(config_path)?;
+            let home = match codex_home {
+                Some(home) => home,
+                None => comradex::accounts::existing_codex_home()?,
+            };
+            let text = fs::read_to_string(config_path)
+                .with_context(|| format!("read {}", config_path.display()))?;
+            let updated = comradex::accounts::connect_existing_account(&text, &name, &home)?;
+            service::while_daemon_stopped(|| write_config_validated(config_path, &updated))?;
+            println!("connected account {name} to the existing Codex login");
+            println!(
+                "if the daemon is running outside the macOS service, restart it to apply the change"
+            );
+            Ok(())
+        }
         AccountCommand::Prefer { name, pool, clear } => {
             debug_assert!(name.is_some() || clear);
             let config = load_config(config_path)?;
@@ -878,6 +933,12 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
         }
         AccountCommand::Remove { name, purge } => {
             let config = load_config(config_path)?;
+            if purge
+                && let Some(comradex::config::AccountConfig::CodexHome { path }) =
+                    config.accounts.get(&name)
+            {
+                comradex::accounts::validate_purge_home(config_path, &name, path)?;
+            }
             let text = fs::read_to_string(config_path)
                 .with_context(|| format!("read {}", config_path.display()))?;
             let (updated, _) = comradex::accounts::remove_account(&text, &name)?;
@@ -899,10 +960,14 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
                         }
                     }
                 } else if path.exists() {
-                    println!(
-                        "credentials kept at {} (pass --purge to delete them)",
-                        path.display()
-                    );
+                    if comradex::accounts::validate_purge_home(config_path, &name, path).is_ok() {
+                        println!(
+                            "credentials kept at {} (pass --purge to delete them)",
+                            path.display()
+                        );
+                    } else {
+                        println!("existing Codex login kept at {}", path.display());
+                    }
                 }
             }
             Ok(())
@@ -991,7 +1056,9 @@ fn login(config_path: &Path, account_name: &str) -> Result<()> {
         .get(account_name)
         .with_context(|| format!("unknown account {account_name}"))?;
     let comradex::config::AccountConfig::CodexHome { path } = account else {
-        bail!("this is the Codex App's own login and cannot be logged in here")
+        bail!(
+            "this uses the requesting client's login; use account connect to link an existing login"
+        )
     };
     service::while_daemon_stopped(|| {
         login_managed_home_with(path, |path| {
@@ -1023,6 +1090,86 @@ fn state_dir(config: &Config) -> PathBuf {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn init_links_existing_login_and_falls_back_when_unavailable() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("custom-home");
+        fs::create_dir_all(&home).unwrap();
+        fs::write(
+            home.join("auth.json"),
+            r#"{"tokens":{"access_token":"test-access-token"}}"#,
+        )
+        .unwrap();
+        let connected = directory.path().join("connected.toml");
+        init_with_codex_home(&connected, Some(&home)).unwrap();
+        let config = load_config(&connected).unwrap();
+        assert!(
+            matches!(&config.accounts["app"], comradex::config::AccountConfig::CodexHome { path } if path == &fs::canonicalize(&home).unwrap())
+        );
+        assert_eq!(config.pools["default"].members, vec!["app"]);
+        assert_eq!(config.pools["default"].preferred, None);
+        for (index, home) in [
+            None,
+            Some(directory.path()),
+            Some(directory.path().join("missing").as_path()),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let fallback = directory.path().join(format!("fallback-{index}.toml"));
+            init_with_codex_home(&fallback, home).unwrap();
+            assert!(matches!(
+                load_config(&fallback).unwrap().accounts["app"],
+                comradex::config::AccountConfig::Inbound
+            ));
+        }
+    }
+
+    #[test]
+    fn account_connect_accepts_custom_codex_home() {
+        let cli = Cli::try_parse_from([
+            "comradex",
+            "account",
+            "connect",
+            "app",
+            "--codex-home",
+            "/tmp/custom-codex",
+        ])
+        .unwrap();
+        assert!(
+            matches!(cli.command, CommandName::Account { command: AccountCommand::Connect { name, codex_home: Some(path) } } if name == "app" && path == Path::new("/tmp/custom-codex"))
+        );
+    }
+
+    #[test]
+    fn remove_purge_rejects_external_login_before_changing_configuration() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = directory.path().join("existing-codex");
+        fs::create_dir_all(&home).unwrap();
+        let auth = r#"{"tokens":{"access_token":"test-access-token"}}"#;
+        fs::write(home.join("auth.json"), auth).unwrap();
+        let config_path = directory.path().join("comradex.toml");
+        init_with_codex_home(&config_path, Some(&home)).unwrap();
+        let original = fs::read_to_string(&config_path).unwrap();
+        let updated = comradex::accounts::add_account(&original, "other", "default").unwrap();
+        write_config_validated(&config_path, &updated).unwrap();
+        let error = account_command(
+            &config_path,
+            AccountCommand::Remove {
+                name: "app".to_owned(),
+                purge: true,
+            },
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("cannot purge an external Codex login")
+        );
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), updated);
+        assert_eq!(fs::read_to_string(home.join("auth.json")).unwrap(), auth);
+    }
     use std::ffi::OsString;
 
     #[test]


### PR DESCRIPTION
Setup now connects the existing file-based Codex login when available, so the menubar can show its usage without another sign-in or manual configuration. Existing inbound accounts can use “Connect existing Codex login…” in the menubar or `comradex account connect`, including a custom Codex home.

Connecting preserves account preferences and confirms the reload that interrupts active requests. Missing or unsupported logins leave the configuration unchanged, inbound labels describe the requesting client's login, and account removal cannot purge shared credential homes.
