### PR TITLE
Prevent stale quota updates from affecting replacement accounts

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -57,7 +57,32 @@ pub struct Credentials {
     pub account_id: Option<String>,
 }
 
+/// Quota belongs to a workspace/user, not to a rotating bearer or configured alias.
+/// Opaque credentials retain legacy alias-scoped accounting when claims are unavailable.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QuotaOwner(Option<blake3::Hash>);
+
+impl QuotaOwner {
+    pub fn is_known(&self) -> bool {
+        self.0.is_some()
+    }
+}
+
+pub fn managed_quota_owner(home: &Path) -> Result<QuotaOwner> {
+    Ok(read_auth(&home.join("auth.json"))?
+        .credentials
+        .quota_owner())
+}
+
 impl Credentials {
+    pub fn quota_owner(&self) -> QuotaOwner {
+        QuotaOwner(
+            self.context_identity()
+                .ok()
+                .map(|identity| blake3::hash(identity.as_bytes())),
+        )
+    }
+
     /// Context belongs to a user within a workspace, not to a token or a config alias.
     /// These claims identify the credential; upstream still authenticates the bearer itself.
     pub fn context_identity(&self) -> Result<String> {

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -417,6 +417,7 @@ fn materialize_http_bridge_continuation(
 struct CapacityObservation(Arc<AtomicBool>);
 
 struct HttpBridgeCapture {
+    quota_owner: auth::QuotaOwner,
     capacity_observation: CapacityObservation,
     input: Vec<serde_json::Value>,
     response_id: Option<String>,
@@ -947,7 +948,7 @@ impl App {
         let observed_at_unix = i64::try_from(now).unwrap_or(i64::MAX);
         let snapshot = usage::parse_usage_response(&bytes, observed_at_unix)?;
         self.router
-            .observe_usage_snapshot(account_id, snapshot)
+            .observe_usage_snapshot_for_owner(account_id, snapshot, &credentials.quota_owner())
             .await;
         Ok(())
     }
@@ -1660,7 +1661,11 @@ impl App {
                         payload_dispatch_owner.get_or_insert_with(|| account.clone());
                     }
                     self.router
-                        .observe_headers(&account, response.headers())
+                        .observe_headers_for_owner(
+                            &account,
+                            response.headers(),
+                            &credentials.quota_owner(),
+                        )
                         .await;
                     let status = response.status();
                     // Defer soft success affinity for native Responses until
@@ -1805,7 +1810,11 @@ impl App {
                             || status == StatusCode::PAYMENT_REQUIRED
                         {
                             self.router
-                                .quota_failure(&account, response.headers())
+                                .quota_failure_for_owner(
+                                    &account,
+                                    response.headers(),
+                                    &credentials.quota_owner(),
+                                )
                                 .await;
                         } else {
                             self.router.soft_failure(&account).await;
@@ -1887,8 +1896,11 @@ impl App {
         let _ = inbound;
         self.auth
             .ensure_bearer_usable(&self.config.accounts[account], &credentials)?;
+        let quota_owner = credentials.quota_owner();
         apply_credentials(headers, credentials)?;
-        Ok(self.client.request(builder.body(body)?).await?)
+        let mut response = self.client.request(builder.body(body)?).await?;
+        response.extensions_mut().insert(quota_owner);
+        Ok(response)
     }
 
     async fn map_file_create_response(
@@ -2856,7 +2868,13 @@ impl App {
             if capacity {
                 // The body classification takes precedence over quota/gateway status.
             } else if is_quota_status(status) {
-                self.router.quota_failure(account, response.headers()).await;
+                self.router
+                    .quota_failure_for_owner(
+                        account,
+                        response.headers(),
+                        &credentials.quota_owner(),
+                    )
+                    .await;
             } else if is_selected_gateway_failure(status) {
                 self.router.soft_failure(account).await;
             } else if status == StatusCode::UNAUTHORIZED
@@ -3239,7 +3257,7 @@ impl App {
                                 match failure.kind {
                                     FailureKind::Quota => {
                                         self.router
-                                            .quota_failure(&account, &hyper::HeaderMap::new())
+                                            .quota_failure_for_owner(&account, &hyper::HeaderMap::new(), &upstream_credentials.quota_owner())
                                             .await;
                                     }
                                     FailureKind::Capacity => {
@@ -3507,7 +3525,11 @@ impl App {
         match failure {
             FailureKind::Quota => {
                 self.router
-                    .quota_failure(account, &hyper::HeaderMap::new())
+                    .quota_failure_for_owner(
+                        account,
+                        &hyper::HeaderMap::new(),
+                        &failed_credentials.quota_owner(),
+                    )
                     .await;
             }
             FailureKind::Capacity => self.router.capacity_failure(account).await,
@@ -4260,7 +4282,11 @@ impl App {
                 StatusCode::TOO_MANY_REQUESTS | StatusCode::PAYMENT_REQUIRED
             ) {
                 self.router
-                    .quota_failure(&selection.account_id, response.headers())
+                    .quota_failure_for_owner(
+                        &selection.account_id,
+                        response.headers(),
+                        &credentials.quota_owner(),
+                    )
                     .await;
             } else if is_selected_gateway_failure(response.status()) {
                 self.router.soft_failure(&selection.account_id).await;
@@ -4798,6 +4824,11 @@ where
         .unwrap_or_default();
     parts.extensions.insert(capacity_observation.clone());
     let account = selection.account_id.clone();
+    let quota_owner = parts
+        .extensions
+        .get::<auth::QuotaOwner>()
+        .cloned()
+        .unwrap_or_default();
     let response_headers = parts.headers.clone();
     let observer = observe_response_ids.then(|| {
         HttpResponseObserver::new(response_observer_for_content_type(
@@ -4807,6 +4838,7 @@ where
     Response::from_parts(
         parts,
         BodyExt::boxed(LeasedIncoming {
+            quota_owner,
             inner: body.map_err(std::io::Error::other).boxed(),
             capacity_observation,
             router,
@@ -4823,6 +4855,7 @@ where
 }
 
 struct LeasedIncoming {
+    quota_owner: auth::QuotaOwner,
     inner: ProxyBody,
     capacity_observation: CapacityObservation,
     router: Arc<Router>,
@@ -5159,6 +5192,7 @@ impl LeasedIncoming {
         observed: HttpObservedBody,
     ) -> Option<Pin<Box<dyn Future<Output = ()> + Send + Sync>>> {
         let account = self.account.clone()?;
+        let quota_owner = self.quota_owner.clone();
         // Without an observer there is no deferred work; immediate
         // header-time binds (non-native paths) already ran.
         let router = self.router.clone();
@@ -5176,7 +5210,9 @@ impl LeasedIncoming {
                         router.capacity_failure(&account).await;
                     }
                 } else {
-                    router.quota_failure(&account, &headers).await;
+                    router
+                        .quota_failure_for_owner(&account, &headers, &quota_owner)
+                        .await;
                 }
                 return;
             }
@@ -5602,6 +5638,11 @@ async fn pump_http_response_to_websocket(
     retry_policy: HttpBridgeRetryPolicy,
 ) -> std::result::Result<Option<HttpBridgeCapacityRetry>, HttpBridgePumpFailure> {
     let mut capture = HttpBridgeCapture {
+        quota_owner: response
+            .extensions()
+            .get::<auth::QuotaOwner>()
+            .cloned()
+            .unwrap_or_default(),
         capacity_observation: response
             .extensions()
             .get::<CapacityObservation>()
@@ -5674,7 +5715,7 @@ async fn pump_http_response_to_websocket(
                         app.router.capacity_failure(account).await;
                     }
                 } else {
-                    app.router.quota_failure(account, &response_headers).await;
+                    app.router.quota_failure_for_owner(account, &response_headers, &capture.quota_owner).await;
                 }
             }
         }
@@ -5904,7 +5945,9 @@ async fn send_protocol_events(
         if is_quota || classification.kind == FailureKind::Capacity {
             if let Some(account) = account {
                 if is_quota {
-                    app.router.quota_failure(account, response_headers).await;
+                    app.router
+                        .quota_failure_for_owner(account, response_headers, &capture.quota_owner)
+                        .await;
                 } else if !capture.capacity_observation.0.swap(true, Ordering::AcqRel) {
                     app.router.capacity_failure(account).await;
                 }
@@ -6197,6 +6240,7 @@ async fn collect_proxy_body_with_initial(
 #[cfg(test)]
 mod tests {
     include!("capacity_tests.rs");
+    include!("quota_identity_tests.rs");
     use super::*;
     use crate::{
         config::{AccountConfig, ProxyConfig, ResponsesWebsocketMode},

--- a/src/proxy/quota_identity_tests.rs
+++ b/src/proxy/quota_identity_tests.rs
@@ -1,0 +1,370 @@
+// Deterministic scheduling: keep an old response body unpolled until a replacement
+// credential has been resolved. All auth files and tokens are temporary fixtures.
+async fn deferred_quota_after_credential_replacement(replacement_workspace: &str) -> bool {
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("managed");
+    let expiration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 3600;
+    let token = |workspace: &str, marker: &str| {
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "exp": expiration,
+                "marker": marker,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": workspace,
+                    "chatgpt_user_id": "test-user"
+                }
+            }))
+            .unwrap(),
+        );
+        format!("e30.{payload}.sig")
+    };
+    crate::auth::tests::write_managed_auth(&home, &token("old-workspace", "old"));
+    let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_address = upstream.local_addr().unwrap();
+    let (template, _, _, _) = direct_test_app_with_upstream(
+        dir.path(),
+        format!("http://{upstream_address}/backend-api/codex"),
+    );
+    let mut config = (*template.config).clone();
+    config.accounts =
+        BTreeMap::from([("a".into(), AccountConfig::CodexHome { path: home.clone() })]);
+    config.pools.get_mut("default").unwrap().members = vec!["a".into()];
+    let config = Arc::new(config);
+    let router = Arc::new(Router::new(&config, template.router.affinity.clone()));
+    let app =
+        App::new_unvalidated(config.clone(), router.clone(), Arc::new(Stats::default())).unwrap();
+    let pool = &config.pools["default"];
+    let selection = router.select_exact(pool, "a").await.unwrap();
+    let old = app
+        .auth
+        .resolve(&config.accounts["a"], &hyper::HeaderMap::new())
+        .await
+        .unwrap();
+    router
+        .validate_selection(&selection, "default", pool)
+        .await
+        .unwrap();
+
+    // Exercise send_http itself: its response stamp must come from the bearer
+    // actually sent to upstream, then survive mapping into the deferred body.
+    let expected_authorization = old.authorization.clone();
+    let (seen, received) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (stream, _) = upstream.accept().await.unwrap();
+        let seen = Arc::new(Mutex::new(Some(seen)));
+        hyper::server::conn::http1::Builder::new().serve_connection(
+            TokioIo::new(stream), service_fn(move |request: Request<Incoming>| {
+                assert_eq!(request.headers()[AUTHORIZATION], expected_authorization);
+                seen.lock().unwrap().take().unwrap().send(()).unwrap();
+                async move {
+                    Ok::<_, Infallible>(Response::builder()
+                        .header(CONTENT_TYPE, "application/json")
+                        .header("retry-after", "3600")
+                        .body(Full::new(Bytes::from_static(
+                            br#"{"status":"incomplete","error":{"code":"usage_limit_reached"},"incomplete_details":{"reason":"usage_limit_reached"}}"#,
+                        ))).unwrap())
+                }
+            })
+        ).await.unwrap();
+    });
+    let dispatched = app
+        .send_http(
+            "a",
+            &Method::GET,
+            "/v1/responses",
+            &hyper::HeaderMap::new(),
+            old.clone(),
+            empty_body(),
+        )
+        .await
+        .unwrap();
+    received.await.unwrap();
+    assert_eq!(
+        dispatched.extensions().get::<auth::QuotaOwner>(),
+        Some(&old.quota_owner())
+    );
+    let response =
+        map_http_response_leased(dispatched, router.clone(), &selection, true, Vec::new());
+
+    assert!(router.begin_login("a").await);
+    crate::auth::tests::write_managed_auth(&home, &token(replacement_workspace, "new"));
+    router.finish_login("a", true).await;
+    let replacement = app
+        .auth
+        .resolve(&config.accounts["a"], &hyper::HeaderMap::new())
+        .await
+        .unwrap();
+    assert_ne!(old.authorization, replacement.authorization);
+    assert_eq!(
+        old.context_identity().unwrap() == replacement.context_identity().unwrap(),
+        replacement_workspace == "old-workspace",
+    );
+    assert!(router.select_exact(pool, "a").await.is_some());
+    response.into_body().collect().await.unwrap();
+    let available = router.select_exact(pool, "a").await.is_some();
+    server.abort();
+    available
+}
+
+#[tokio::test]
+async fn deferred_quota_survives_same_identity_bearer_replacement() {
+    assert!(
+        !deferred_quota_after_credential_replacement("old-workspace").await,
+        "quota from the same physical account must survive bearer replacement",
+    );
+}
+
+#[tokio::test]
+async fn deferred_quota_does_not_block_replacement_physical_identity() {
+    assert!(
+        deferred_quota_after_credential_replacement("new-workspace").await,
+        "a late quota terminal from the old physical account must not block its replacement",
+    );
+}
+
+struct QuotaIdentityFixture {
+    _dir: tempfile::TempDir,
+    home: PathBuf,
+    app: Arc<App>,
+}
+
+impl QuotaIdentityFixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("managed");
+        let (template, _, _, _) = direct_test_app(dir.path());
+        let mut config = (*template.config).clone();
+        config.accounts =
+            BTreeMap::from([("a".into(), AccountConfig::CodexHome { path: home.clone() })]);
+        config.pools.get_mut("default").unwrap().members = vec!["a".into()];
+        let config = Arc::new(config);
+        let router = Arc::new(Router::new(&config, template.router.affinity.clone()));
+        let app = App::new_unvalidated(config, router, Arc::new(Stats::default())).unwrap();
+        let fixture = Self {
+            _dir: dir,
+            home,
+            app,
+        };
+        fixture.replace("workspace-a", "user-a", "initial");
+        fixture
+    }
+
+    fn replace(&self, workspace: &str, user: &str, marker: &str) {
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "exp": chrono::Utc::now().timestamp() + 3600,
+                "marker": marker,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": workspace,
+                    "chatgpt_user_id": user,
+                }
+            }))
+            .unwrap(),
+        );
+        crate::auth::tests::write_managed_auth(&self.home, &format!("e30.{payload}.sig"));
+    }
+
+    async fn owner(&self) -> auth::QuotaOwner {
+        self.app
+            .auth
+            .resolve(&self.app.config.accounts["a"], &hyper::HeaderMap::new())
+            .await
+            .unwrap()
+            .quota_owner()
+    }
+
+    async fn status(&self) -> crate::routing::AccountRoutingStatus {
+        self.app.router.routing_snapshot().await.account_states["a"].clone()
+    }
+}
+
+fn quota_identity_headers(used: u8, reset: i64) -> hyper::HeaderMap {
+    let mut headers = hyper::HeaderMap::new();
+    headers.insert("retry-after", "3600".parse().unwrap());
+    headers.insert(
+        "x-codex-primary-used-percent",
+        used.to_string().parse().unwrap(),
+    );
+    headers.insert(
+        "x-codex-primary-reset-at",
+        reset.to_string().parse().unwrap(),
+    );
+    headers
+}
+
+fn quota_identity_snapshot(used: u8, reset: i64) -> usage::UsageSnapshot {
+    usage::UsageSnapshot {
+        observed_at_unix: chrono::Utc::now().timestamp(),
+        windows: BTreeMap::from([(
+            "primary".into(),
+            crate::routing::QuotaWindowStatus {
+                used_percent: Some(used),
+                reset_at_unix: Some(reset),
+                limit_window_seconds: Some(18000),
+            },
+        )]),
+    }
+}
+
+fn assert_quota_identity_deadline_eq(actual: Option<i64>, expected: Option<i64>) {
+    match (actual, expected) {
+        // Status reconstructs monotonic deadlines using whole wall-clock seconds.
+        (Some(actual), Some(expected)) => assert!(actual.abs_diff(expected) <= 1),
+        _ => assert_eq!(actual, expected),
+    }
+}
+
+fn assert_quota_identity_status_eq(
+    actual: &crate::routing::AccountRoutingStatus,
+    expected: &crate::routing::AccountRoutingStatus,
+) {
+    let (mut actual, mut expected) = (actual.clone(), expected.clone());
+    assert_quota_identity_deadline_eq(actual.retry_at_unix.take(), expected.retry_at_unix.take());
+    assert_quota_identity_deadline_eq(
+        actual.capacity_backoff_until_unix.take(),
+        expected.capacity_backoff_until_unix.take(),
+    );
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn quota_identity_changes_clear_old_evidence_but_same_identity_refresh_preserves_it() {
+    let fixture = QuotaIdentityFixture::new();
+    let router = &fixture.app.router;
+    let owner = fixture.owner().await;
+    let headers = quota_identity_headers(100, chrono::Utc::now().timestamp() + 3600);
+    router
+        .observe_headers_for_owner("a", &headers, &owner)
+        .await;
+    router.quota_failure_for_owner("a", &headers, &owner).await;
+    router.begin("a").await;
+    for _ in 0..3 {
+        router.capacity_failure("a").await;
+    }
+    let before = fixture.status().await;
+    assert!(!before.available);
+    assert_eq!(before.usage_percent, Some(100));
+    assert!(before.capacity_backoff_until_unix.is_some());
+
+    fixture.replace("workspace-a", "user-a", "refreshed-bearer");
+    assert_eq!(fixture.owner().await, owner);
+    assert_quota_identity_status_eq(&fixture.status().await, &before);
+
+    // A different user within the same workspace is a different quota owner too.
+    // No replacement resolve is needed: selection must notice the external file edit.
+    fixture.replace("workspace-a", "user-b", "replacement-user");
+    assert!(
+        router
+            .select_exact(&fixture.app.config.pools["default"], "a")
+            .await
+            .is_some()
+    );
+    let after = fixture.status().await;
+    assert!(after.available);
+    assert!(after.quota_windows.is_empty());
+    assert!(after.usage_windows.is_empty());
+    assert_eq!(after.usage_percent, None);
+    assert_eq!(after.inflight, before.inflight);
+    assert_quota_identity_deadline_eq(
+        after.capacity_backoff_until_unix,
+        before.capacity_backoff_until_unix,
+    );
+}
+
+#[tokio::test]
+async fn quota_identity_stale_headers_and_snapshots_cannot_clear_replacement_cooldown() {
+    let fixture = QuotaIdentityFixture::new();
+    let router = &fixture.app.router;
+    let old = fixture.owner().await;
+    fixture.replace("workspace-b", "user-b", "replacement");
+    let current = fixture.owner().await;
+    let reset = chrono::Utc::now().timestamp() + 3600;
+    let blocked = quota_identity_headers(100, reset);
+    router
+        .observe_headers_for_owner("a", &blocked, &current)
+        .await;
+    router
+        .quota_failure_for_owner("a", &blocked, &current)
+        .await;
+    let before = fixture.status().await;
+
+    // Both observations would otherwise confirm a recovered, advanced quota window.
+    let recovered = quota_identity_headers(3, reset + 18000);
+    router
+        .observe_headers_for_owner("a", &recovered, &old)
+        .await;
+    assert_quota_identity_status_eq(&fixture.status().await, &before);
+    router
+        .observe_usage_snapshot_for_owner("a", quota_identity_snapshot(3, reset + 18000), &old)
+        .await;
+    assert_quota_identity_status_eq(&fixture.status().await, &before);
+    router
+        .quota_failure_for_owner("a", &quota_identity_headers(100, reset + 36000), &old)
+        .await;
+    assert_quota_identity_status_eq(&fixture.status().await, &before);
+
+    router
+        .observe_usage_snapshot_for_owner("a", quota_identity_snapshot(3, reset + 18000), &current)
+        .await;
+    assert!(fixture.status().await.available);
+    assert_eq!(fixture.status().await.usage_percent, Some(3));
+}
+
+#[tokio::test]
+async fn quota_identity_unreadable_or_unknown_replacement_preserves_evidence_and_rejects_old_updates()
+ {
+    let fixture = QuotaIdentityFixture::new();
+    let router = &fixture.app.router;
+    let old = fixture.owner().await;
+    let reset = chrono::Utc::now().timestamp() + 3600;
+    let blocked = quota_identity_headers(100, reset);
+    router.observe_headers_for_owner("a", &blocked, &old).await;
+    router.quota_failure_for_owner("a", &blocked, &old).await;
+    let before = fixture.status().await;
+
+    for state in ["missing", "malformed", "opaque"] {
+        match state {
+            "missing" => fs::remove_file(fixture.home.join("auth.json")).unwrap(),
+            "malformed" => fs::write(fixture.home.join("auth.json"), "{").unwrap(),
+            "opaque" => crate::auth::tests::write_managed_auth(&fixture.home, "opaque-replacement"),
+            _ => unreachable!(),
+        }
+        router
+            .quota_failure_for_owner("a", &quota_identity_headers(100, reset + 36000), &old)
+            .await;
+        router
+            .observe_headers_for_owner("a", &quota_identity_headers(3, reset + 18000), &old)
+            .await;
+        router
+            .observe_usage_snapshot_for_owner("a", quota_identity_snapshot(3, reset + 18000), &old)
+            .await;
+        assert_quota_identity_status_eq(&fixture.status().await, &before);
+    }
+}
+
+#[tokio::test]
+async fn quota_identity_opaque_bearer_replacement_preserves_legacy_quota() {
+    let fixture = QuotaIdentityFixture::new();
+    crate::auth::tests::write_managed_auth(&fixture.home, "opaque-original");
+    let owner = fixture.owner().await;
+    assert!(!owner.is_known());
+    fixture
+        .app
+        .router
+        .quota_failure_for_owner(
+            "a",
+            &quota_identity_headers(100, chrono::Utc::now().timestamp() + 3600),
+            &owner,
+        )
+        .await;
+    crate::auth::tests::write_managed_auth(&fixture.home, "opaque-refreshed");
+    assert_eq!(fixture.owner().await, owner);
+    assert!(!fixture.status().await.available);
+}

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -13,7 +13,7 @@ use tokio::sync::Mutex;
 use tracing::{error, info};
 
 use crate::{
-    auth::{ManagedAuthHealth, ManagedAuthStatus},
+    auth::{ManagedAuthHealth, ManagedAuthStatus, QuotaOwner, managed_quota_owner},
     config::{AccountConfig, Config, PoolConfig, normalize_codex_home},
     routing::{AffinityStore, ThreadKey},
     usage::UsageSnapshot,
@@ -120,6 +120,7 @@ pub struct QuotaWindowStatus {
 
 #[derive(Debug, Default)]
 struct AccountRuntime {
+    quota_owner: Option<QuotaOwner>,
     reauth_required: bool,
     bearer_unusable: bool,
     usage: Option<u8>,
@@ -226,6 +227,17 @@ impl Router {
         let mut accounts = self.accounts.lock().await;
         let now = Utc::now().timestamp().max(0) as u64;
         for (name, runtime) in accounts.iter_mut() {
+            if runtime
+                .quota_owner
+                .as_ref()
+                .is_some_and(QuotaOwner::is_known)
+                && (runtime.quota_until.is_some()
+                    || runtime.quota_evidence.is_some()
+                    || runtime.usage.is_some()
+                    || !runtime.usage_windows.is_empty())
+            {
+                self.reconcile_quota_owner(name, runtime);
+            }
             let status = match self.managed_homes.get(name) {
                 Some(path) => self.auth_health.status_normalized(path, now),
                 _ => ManagedAuthStatus::default(),
@@ -234,6 +246,55 @@ impl Router {
             runtime.bearer_unusable = status.bearer_unusable;
         }
         accounts
+    }
+
+    fn reconcile_quota_owner(&self, account: &str, runtime: &mut AccountRuntime) {
+        let Some(home) = self.managed_homes.get(account) else {
+            return;
+        };
+        let Ok(current) = managed_quota_owner(home) else {
+            return;
+        };
+        Self::reconcile_quota_owner_snapshot(runtime, &current);
+    }
+
+    fn reconcile_quota_owner_snapshot(runtime: &mut AccountRuntime, current: &QuotaOwner) {
+        if runtime
+            .quota_owner
+            .as_ref()
+            .is_some_and(|old| old.is_known() && current.is_known() && old != current)
+        {
+            runtime.quota_until = None;
+            runtime.quota_reset_at = None;
+            runtime.quota_evidence = None;
+            runtime.usage = None;
+            runtime.usage_updated_at_unix = None;
+            runtime.usage_windows.clear();
+            runtime.quota_owner = None;
+        }
+    }
+
+    /// Check the actual managed file, never register a response's old credentials as current.
+    /// The caller holds the runtime lock through both this check and the ensuing mutation.
+    fn accepts_quota_owner(
+        &self,
+        account: &str,
+        runtime: &mut AccountRuntime,
+        owner: &QuotaOwner,
+    ) -> bool {
+        if let Some(home) = self.managed_homes.get(account) {
+            let Ok(current) = managed_quota_owner(home) else {
+                return false;
+            };
+            if &current != owner {
+                return false;
+            }
+            Self::reconcile_quota_owner_snapshot(runtime, &current);
+        }
+        // Inbound aliases have no authoritative current credential file. Preserve their
+        // existing alias-scoped semantics rather than letting competing callers reset quota.
+        runtime.quota_owner = Some(owner.clone());
+        true
     }
 
     pub fn new(config: &Config, affinity: Arc<AffinityStore>) -> Self {
@@ -784,11 +845,19 @@ impl Router {
             account.inflight = 0;
         }
     }
-    pub async fn quota_failure(&self, account: &str, headers: &hyper::HeaderMap) {
+    pub async fn quota_failure_for_owner(
+        &self,
+        account: &str,
+        headers: &hyper::HeaderMap,
+        owner: &QuotaOwner,
+    ) {
         let now = Utc::now();
         let evidence = blocking_quota_evidence(headers, now);
         let delay = quota_delay_at(headers, now, &evidence);
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
+            if !self.accepts_quota_owner(account, a, owner) {
+                return;
+            }
             a.quota_until = Some(Instant::now() + delay);
             a.quota_reset_at = now.checked_add_signed(
                 chrono::Duration::from_std(delay).unwrap_or(chrono::Duration::MAX),
@@ -873,7 +942,12 @@ impl Router {
             }
         }
     }
-    pub async fn observe_headers(&self, account: &str, headers: &hyper::HeaderMap) {
+    pub async fn observe_headers_for_owner(
+        &self,
+        account: &str,
+        headers: &hyper::HeaderMap,
+        owner: &QuotaOwner,
+    ) {
         let observed_evidence = quota_evidence(headers, Utc::now());
         let candidates = [
             "x-codex-primary-used-percent",
@@ -888,6 +962,12 @@ impl Router {
             .max_by(|left, right| left.total_cmp(right))
             .map(|v| v.clamp(0.0, 100.0) as u8);
         if let Some(a) = self.accounts.lock().await.get_mut(account) {
+            if usage.is_none() && observed_evidence.is_empty() {
+                return;
+            }
+            if !self.accepts_quota_owner(account, a, owner) {
+                return;
+            }
             if let Some(usage) = usage {
                 a.usage = Some(usage);
                 a.usage_updated_at_unix = Some(Utc::now().timestamp());
@@ -919,9 +999,17 @@ impl Router {
     /// Replace the last observed usage view with an authoritative WHAM snapshot. This updates
     /// fresh-work admission scores and status metadata without turning a reported 100% window
     /// into a hard quota cooldown before upstream actually rejects a request.
-    pub async fn observe_usage_snapshot(&self, account: &str, snapshot: UsageSnapshot) {
+    pub async fn observe_usage_snapshot_for_owner(
+        &self,
+        account: &str,
+        snapshot: UsageSnapshot,
+        owner: &QuotaOwner,
+    ) {
         let observed_evidence = usage_snapshot_evidence(&snapshot);
         if let Some(runtime) = self.accounts.lock().await.get_mut(account) {
+            if !self.accepts_quota_owner(account, runtime, owner) {
+                return;
+            }
             runtime.usage = snapshot
                 .windows
                 .values()
@@ -942,6 +1030,27 @@ impl Router {
     }
     pub async fn record_count(&self) -> usize {
         self.accounts.lock().await.len()
+    }
+
+    #[cfg(test)]
+    pub async fn quota_failure(&self, account: &str, headers: &hyper::HeaderMap) {
+        let owner = self
+            .managed_homes
+            .get(account)
+            .and_then(|home| managed_quota_owner(home).ok())
+            .unwrap_or_default();
+        self.quota_failure_for_owner(account, headers, &owner).await;
+    }
+
+    #[cfg(test)]
+    pub async fn observe_headers(&self, account: &str, headers: &hyper::HeaderMap) {
+        let owner = self
+            .managed_homes
+            .get(account)
+            .and_then(|home| managed_quota_owner(home).ok())
+            .unwrap_or_default();
+        self.observe_headers_for_owner(account, headers, &owner)
+            .await;
     }
 }
 


### PR DESCRIPTION
A late quota response could block a different account signed into the same alias, or clear its quota cooldown. Capture the requesting workspace/user identity and check it before applying quota or usage updates across HTTP, WebSocket, and background usage paths.

Same-account token refreshes preserve quota. Credentials without identifiable claims retain existing alias-based behavior. Includes six regression tests covering replacement, refresh, stale updates, and unavailable identity data.
