### PR TITLE
Fix account selection and device login

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ Both authenticated URL forms remain supported. Start a new task after enabling i
 track its history from the first inference request.
 
 The first context operation or qualifying inference dispatch establishes a durable notes owner for
-the root session. After inference switches from account A to B, notes reads and writes still use A's
-credentials, and their results are delivered to inference on B. No notes are copied between accounts.
+the root session. New context sessions consult the pool's current preference, including changes
+made without restarting Comradex. After inference switches from account A to B, notes reads and
+writes still use A's credentials, and their results are delivered to inference on B. No notes are
+copied between accounts.
 Inference quota exhaustion does not prevent accessing notes, but missing credentials, an account
 being logged into, removal from the pool, or a different user signing into the same account alias
 make that owner's context unavailable. Notes writes never fail over to another account.

--- a/macos/ComradexMenu/README.md
+++ b/macos/ComradexMenu/README.md
@@ -4,6 +4,8 @@ A native macOS 14+ menu-bar companion for viewing Comradex daemon, routing, acco
 
 Each account occupies one line. Healthy managed accounts show the main quota and its reset countdown, such as `sq · 68% left · 6d 4h`; the tooltip labels the countdown explicitly. The primary window is preferred; zero-duration windows are omitted. Quota-exhausted accounts retain `0% left` and the exhausted window’s reset countdown (falling back to the retry deadline); the tooltip explains the rate limit. Other authentication or availability errors replace stale usage details. Account rows have no type or health icons: the native check exclusively marks the preferred account, while the menu header's check continues to indicate daemon health.
 
+Click an account that needs sign-in or renewal to open its device login without changing your preferred account. There is no separate re-login row. While this app is handling login, the same row reopens the login window. The window distinguishes requesting a code from waiting for authorization, shows the selectable code, and provides Copy Code and browser controls. Starting another login attempt clears the previous attempt's code.
+
 The special `app` row explains `Codex App account` in its tooltip because it uses credentials supplied by the Codex desktop app rather than a separately managed account home.
 
 For a single pool, account rows appear without a pool section header. A filled dot marks the last-used account only when it differs from the preferred account; if they are the same, the preferred check is sufficient. Multiple pools retain name-only section headers so repeated account rows remain attributable to their pool.

--- a/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/ComradexStore.swift
@@ -18,6 +18,7 @@ final class ComradexStore: ObservableObject {
 
     private let client: any ControlServing
     private var loginTask: Task<Void, Never>?
+    private var statusGeneration: UInt64 = 0
 
     init(client: any ControlServing = ControlSocketClient()) {
         self.client = client
@@ -26,14 +27,22 @@ final class ComradexStore: ObservableObject {
     deinit { loginTask?.cancel() }
 
     func refresh() async {
-        guard !isRefreshing else { return }
+        guard !isRefreshing, updatingPool == nil else { return }
+        let generation = statusGeneration
         isRefreshing = true
         defer { isRefreshing = false }
+        await readStatus(generation: generation)
+    }
+
+    private func readStatus(generation: UInt64) async {
         do {
-            apply(status: try await client.status())
+            let status = try await client.status()
+            guard generation == statusGeneration else { return }
+            apply(status: status)
         } catch is CancellationError {
             return
         } catch {
+            guard generation == statusGeneration else { return }
             if errorMessage != error.localizedDescription {
                 logger.error("Status refresh failed: \(error.localizedDescription, privacy: .private)")
             }
@@ -44,12 +53,15 @@ final class ComradexStore: ObservableObject {
     func setPreferred(pool: String, account: String?) async {
         guard updatingPool == nil else { return }
         updatingPool = pool
+        // A poll already in flight can contain the previous preference. Never let
+        // it overwrite the authoritative read after the user's selection.
+        statusGeneration &+= 1
         defer { updatingPool = nil }
         do {
             if let updated = try await client.setPreferred(pool: pool, account: account) {
                 apply(status: updated)
             } else {
-                await refresh()
+                await readStatus(generation: statusGeneration)
             }
             actionErrorMessage = nil
         } catch {
@@ -60,7 +72,8 @@ final class ComradexStore: ObservableObject {
     func beginLogin(account: String) {
         guard !isLoginRunning else { return }
         loginTask?.cancel()
-        apply(login: LoginSnapshot(account: account, state: .running))
+        // A new attempt must not inherit the previous account's code or session.
+        login = LoginSnapshot(account: account, state: .running)
         loginTask = Task { [weak self] in
             guard let self else { return }
             do {
@@ -117,12 +130,15 @@ final class ComradexStore: ObservableObject {
     }
 
     func apply(login value: LoginSnapshot) {
+        let sameAccount = value.account.isEmpty || value.account == login?.account
+        let sameSession = value.sessionID == nil || login?.sessionID == nil || value.sessionID == login?.sessionID
+        let previous = sameAccount && sameSession ? login : nil
         login = LoginSnapshot(
-            account: value.account.isEmpty ? (login?.account ?? "") : value.account,
-            sessionID: value.sessionID ?? login?.sessionID,
+            account: value.account.isEmpty ? (previous?.account ?? "") : value.account,
+            sessionID: value.sessionID ?? previous?.sessionID,
             state: value.state,
-            verificationURI: value.verificationURI ?? login?.verificationURI,
-            userCode: value.userCode ?? login?.userCode,
+            verificationURI: value.verificationURI ?? previous?.verificationURI,
+            userCode: value.userCode ?? previous?.userCode,
             error: value.error
         )
     }

--- a/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/MenuBarController.swift
@@ -164,24 +164,29 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private func addAccount(_ account: AccountSnapshot, pool: PoolSnapshot?) {
         let isPreferred = pool?.preferred == account.name
         let isLastUsed = pool?.active == account.name
+        let hasRunningLogin = store.isLoginRunning && store.login?.account == account.name
+        let loginAction = account.needsLoginAction || account.isLoginInProgress || hasRunningLogin
         let item = NSMenuItem(
             title: account.name,
-            action: pool == nil ? nil : #selector(preferredAccountSelected(_:)),
+            action: loginAction ? #selector(reloginSelected(_:)) : pool == nil ? nil : #selector(preferredAccountSelected(_:)),
             keyEquivalent: ""
         )
         item.target = self
-        let detail = accountDetail(account)
+        let detail = hasRunningLogin ? "Login in progress…" : accountDetail(account)
         if isLastUsed && !isPreferred {
             item.image = NSImage(systemSymbolName: "circle.fill", accessibilityDescription: "Last used · \(detail)")
         }
-        item.toolTip = [isPreferred ? "Preferred" : nil, accountDetail(account, expanded: true)]
+        item.toolTip = [isPreferred ? "Preferred" : nil, accountDetail(account, expanded: true), loginAction ? "Click to sign in; keeps your preferred account unchanged" : nil]
             .compactMap { $0 }.joined(separator: " · ")
         if !detail.isEmpty {
             item.title = "\(account.name) · \(detail)"
         }
         item.state = isPreferred ? .on : .off
-        item.isEnabled = pool != nil && store.updatingPool == nil && store.connectingAccount == nil
-        if let pool {
+        item.isEnabled = store.updatingPool == nil && store.connectingAccount == nil
+            && (loginAction ? (hasRunningLogin || (!store.isLoginRunning && !account.isLoginInProgress)) : pool != nil)
+        if loginAction {
+            item.representedObject = account.name
+        } else if let pool {
             item.representedObject = PreferredAccountAction(pool: pool.name, account: account.name)
         }
         menu.addItem(item)
@@ -197,18 +202,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             connect.indentationLevel = 1
             connect.toolTip = "Reuse your local Codex login and show its usage."
             menu.addItem(connect)
-        }
-
-        if account.needsLoginAction {
-            let login = actionItem(
-                title: "Re-login \(account.name)…",
-                icon: "person.crop.circle.badge.exclamationmark",
-                action: #selector(reloginSelected(_:)),
-                enabled: !store.isLoginRunning && store.connectingAccount == nil
-            )
-            login.representedObject = account.name
-            login.indentationLevel = 1
-            menu.addItem(login)
         }
     }
 
@@ -268,6 +261,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     @objc private func reloginSelected(_ sender: NSMenuItem) {
         guard let account = sender.representedObject as? String else { return }
         store.beginLogin(account: account)
+        rebuildMenu()
         showLoginWindow()
     }
 
@@ -352,6 +346,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func accountDetail(_ account: AccountSnapshot, expanded: Bool = false) -> String {
+        if account.isLoginInProgress { return "Login in progress" }
         if account.reauthRequired { return "Sign-in needed for renewal" }
         if !account.available
             || account.authState?.lowercased() == "login_in_progress"

--- a/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Models.swift
@@ -71,7 +71,13 @@ struct AccountSnapshot: Codable, Equatable, Identifiable, Sendable {
     }
     var needsLoginAction: Bool {
         guard !isInbound else { return false }
-        return authState?.caseInsensitiveCompare("signed_out") == .orderedSame
+        return reauthRequired
+            || authState?.caseInsensitiveCompare("signed_out") == .orderedSame
+            || unavailableReason?.caseInsensitiveCompare("needs_login") == .orderedSame
+    }
+    var isLoginInProgress: Bool {
+        authState?.caseInsensitiveCompare("login_in_progress") == .orderedSame
+            || unavailableReason?.caseInsensitiveCompare("login_in_progress") == .orderedSame
     }
 
     enum CodingKeys: String, CodingKey {
@@ -181,6 +187,16 @@ struct LoginSnapshot: Codable, Equatable, Sendable {
     let verificationURI: String?
     let userCode: String?
     let error: String?
+
+    var statusLabel: String {
+        switch state {
+        case .idle, .notStarted: return "Idle"
+        case .running:
+            return userCode?.isEmpty == false ? "Waiting for device authorization" : "Requesting a device code"
+        case .succeeded: return "Signed in"
+        case .failed: return "Login failed"
+        }
+    }
 
     init(
         account: String,

--- a/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
+++ b/macos/ComradexMenu/Sources/ComradexMenu/Views.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct LoginWindowView: View {
     @EnvironmentObject private var store: ComradexStore
@@ -15,7 +16,7 @@ struct LoginWindowView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         Text("Login: \(login.account)")
                             .font(.title3.weight(.semibold))
-                        Label(stateLabel(login.state), systemImage: stateIcon(login.state))
+                        Label(login.statusLabel, systemImage: stateIcon(login.state))
                             .foregroundStyle(stateColor(login.state))
                     }
                     Spacer()
@@ -30,7 +31,13 @@ struct LoginWindowView: View {
                         Text(code)
                             .font(.system(.title, design: .monospaced, weight: .semibold))
                             .textSelection(.enabled)
-                        Link("Open OpenAI device login", destination: login.safeVerificationURL)
+                        HStack {
+                            Button("Copy Code") {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(code, forType: .string)
+                            }
+                            Link("Open OpenAI device login", destination: login.safeVerificationURL)
+                        }
                     }
                 } else if login.state == .running {
                     Text("Waiting for a device code…")
@@ -58,15 +65,6 @@ struct LoginWindowView: View {
         }
         .padding(20)
         .frame(width: 420)
-    }
-
-    private func stateLabel(_ state: LoginState) -> String {
-        switch state {
-        case .idle, .notStarted: return "Idle"
-        case .running: return "Waiting for device authorization"
-        case .succeeded: return "Signed in"
-        case .failed: return "Login failed"
-        }
     }
 
     private func stateIcon(_ state: LoginState) -> String {

--- a/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
+++ b/macos/ComradexMenu/Tests/ComradexMenuTests/ComradexMenuTests.swift
@@ -61,6 +61,9 @@ final class ComradexMenuTests: XCTestCase {
         let bad = try XCTUnwrap(items.first(where: { $0.title == "bad · Sign-in required" }))
         XCTAssertNil(bad.subtitle)
         XCTAssertNil(bad.image)
+        XCTAssertEqual(bad.action.map(NSStringFromSelector), "reloginSelected:")
+        XCTAssertEqual(bad.representedObject as? String, "bad")
+        XCTAssertFalse(items.contains { $0.title.hasPrefix("Re-login ") })
         XCTAssertEqual(snapshot.accounts.first(where: { $0.name == "sq" })?.usageUpdatedAtUnix, 1788800000)
         XCTAssertEqual(snapshot.accounts.first(where: { $0.name == "sq" })?.usageWindows["secondary"]?.resetAtUnix, 4103049600)
         XCTAssertEqual(items.first(where: { $0.title == "Refresh" })?.keyEquivalent, "r")
@@ -188,6 +191,89 @@ final class ComradexMenuTests: XCTestCase {
         XCTAssertFalse(inbound.needsLoginAction)
         XCTAssertFalse(inProgress.needsLoginAction)
         XCTAssertFalse(unknown.needsLoginAction)
+    }
+
+    @MainActor
+    func testAccountRowHandlesRenewalAndSignedOutWithoutChangingPreference() throws {
+        let cases = [
+            #""reauth_required":true,"signed_in":true,"auth_state":"signed_in""#,
+            #""auth_state":"signed_out","signed_in":false"#,
+            #""auth_state":"signed_in","available":false,"unavailable_reason":"needs_login""#,
+        ]
+        for fields in cases {
+            let account = try decodeAccount("{\"name\":\"sq\",\"kind\":\"codex_home\",\(fields)}")
+            let pm = try decodeAccount(#"{"name":"pm","kind":"codex_home","auth_state":"signed_in"}"#)
+            let store = ComradexStore(client: StubClient())
+            store.apply(status: UIStatusSnapshot(accounts: [account, pm], pools: [
+                PoolSnapshot(name: "default", members: ["sq", "pm"], preferred: "pm", active: "pm")
+            ]))
+            let controller = MenuBarController(store: store)
+            controller.rebuildMenu()
+            let rows = controller.renderedMenu.items
+            let sq = try XCTUnwrap(rows.first { $0.title.hasPrefix("sq · ") })
+            XCTAssertEqual(sq.action.map(NSStringFromSelector), "reloginSelected:")
+            XCTAssertEqual(sq.representedObject as? String, "sq")
+            XCTAssertTrue(sq.isEnabled)
+            XCTAssertEqual(sq.state, .off)
+            XCTAssertTrue(sq.toolTip?.contains("keeps your preferred account unchanged") == true)
+            XCTAssertFalse(rows.contains { $0.title.hasPrefix("Re-login ") })
+            let preferred = try XCTUnwrap(rows.first { $0.title.hasPrefix("pm · ") })
+            XCTAssertEqual(preferred.action.map(NSStringFromSelector), "preferredAccountSelected:")
+            XCTAssertEqual(preferred.state, .on)
+        }
+    }
+
+    @MainActor
+    func testRunningLoginRowReopensSameSessionAndDisablesOtherLoginRows() throws {
+        let accounts = try ["sq", "pm"].map { name in
+            try decodeAccount("{\"name\":\"\(name)\",\"kind\":\"codex_home\",\"auth_state\":\"signed_out\"}")
+        }
+        let store = ComradexStore(client: StubClient())
+        store.apply(status: UIStatusSnapshot(accounts: accounts))
+        store.apply(login: LoginSnapshot(account: "sq", sessionID: "session", state: .running))
+        let controller = MenuBarController(store: store)
+        controller.rebuildMenu()
+        let sq = try XCTUnwrap(controller.renderedMenu.items.first { $0.title == "sq · Login in progress…" })
+        XCTAssertTrue(sq.isEnabled)
+        XCTAssertEqual(sq.action.map(NSStringFromSelector), "reloginSelected:")
+        let pm = try XCTUnwrap(controller.renderedMenu.items.first { $0.title.hasPrefix("pm · ") })
+        XCTAssertFalse(pm.isEnabled)
+    }
+
+    @MainActor
+    func testLoginInAnotherClientCannotChangePreferenceOrStartDuplicateLogin() throws {
+        let account = try decodeAccount(#"{"name":"sq","kind":"codex_home","reauth_required":true,"auth_state":"login_in_progress"}"#)
+        let store = ComradexStore(client: StubClient())
+        store.apply(status: UIStatusSnapshot(accounts: [account], pools: [
+            PoolSnapshot(name: "default", members: ["sq"], preferred: nil, active: nil)
+        ]))
+        let controller = MenuBarController(store: store)
+        controller.rebuildMenu()
+        let sq = try XCTUnwrap(controller.renderedMenu.items.first { $0.title == "sq · Login in progress" })
+        XCTAssertFalse(sq.isEnabled)
+        XCTAssertEqual(sq.state, .off)
+        XCTAssertFalse(controller.renderedMenu.items.contains { $0.title.hasPrefix("Re-login ") })
+    }
+
+    func testDeviceLoginLabelOnlyRequestsAuthorizationOnceCodeExists() {
+        XCTAssertEqual(LoginSnapshot(account: "sq", state: .running).statusLabel, "Requesting a device code")
+        XCTAssertEqual(LoginSnapshot(account: "sq", state: .running, userCode: "").statusLabel, "Requesting a device code")
+        XCTAssertEqual(LoginSnapshot(account: "sq", state: .running, userCode: "ABCD-EFGH").statusLabel, "Waiting for device authorization")
+    }
+
+    @MainActor
+    func testLoginUpdatesKeepCodeOnlyWithinSameAccountAndSession() {
+        let store = ComradexStore(client: StubClient())
+        store.apply(login: LoginSnapshot(account: "sq", sessionID: "one", state: .running, userCode: "ABCD-EFGH"))
+        store.apply(login: LoginSnapshot(account: "", sessionID: "one", state: .running))
+        XCTAssertEqual(store.login?.userCode, "ABCD-EFGH")
+        store.apply(login: LoginSnapshot(account: "sq", sessionID: "two", state: .running))
+        XCTAssertNil(store.login?.userCode)
+        store.apply(login: LoginSnapshot(account: "sq", sessionID: "two", state: .failed, userCode: "WXYZ-ABCD"))
+        store.beginLogin(account: "pm")
+        XCTAssertEqual(store.login?.account, "pm")
+        XCTAssertNil(store.login?.sessionID)
+        XCTAssertNil(store.login?.userCode)
     }
 
     func testLoginDecodesOnlyAllowlistedDeviceFlowFields() throws {
@@ -365,6 +451,34 @@ final class ComradexMenuTests: XCTestCase {
         await first.value
         XCTAssertFalse(store.isRefreshing)
         XCTAssertEqual(store.snapshot?.daemonRunning, true)
+    }
+
+    @MainActor
+    func testPollStartedBeforeSelectionCannotRestoreOldPreferenceOrError() async throws {
+        for staleFailure in [false, true] {
+            let entered = expectation(description: "old poll entered")
+            let client = PreferenceRaceClient(staleFailure: staleFailure, onStatus: { entered.fulfill() })
+            let store = ComradexStore(client: client)
+            let poll = Task { await store.refresh() }
+            await fulfillment(of: [entered], timeout: 2)
+            await store.setPreferred(pool: "default", account: "pm")
+            XCTAssertEqual(store.snapshot?.pools.first?.preferred, "pm")
+            await client.completeOldPoll()
+            await poll.value
+            XCTAssertEqual(store.snapshot?.pools.first?.preferred, "pm")
+            XCTAssertNil(store.errorMessage)
+            XCTAssertNil(store.actionErrorMessage)
+            XCTAssertFalse(store.isRefreshing)
+        }
+    }
+
+    @MainActor
+    func testSuccessfulSelectionWithFailedStatusReadReportsConnectionFailure() async {
+        let store = ComradexStore(client: SelectionWithoutStatusClient())
+        await store.setPreferred(pool: "default", account: "pm")
+        XCTAssertNil(store.actionErrorMessage)
+        XCTAssertNotNil(store.errorMessage)
+        XCTAssertNil(store.updatingPool)
     }
 
     @MainActor
@@ -548,6 +662,54 @@ private actor ConnectingClient: ControlServing {
         return UIStatusSnapshot(daemonRunning: true, accounts: [account])
     }
     func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
+    func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+    func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+}
+
+private actor PreferenceRaceClient: ControlServing {
+    let staleFailure: Bool
+    let onStatus: @Sendable () -> Void
+    private var calls = 0
+    private var preference = "sq"
+    private var continuation: CheckedContinuation<UIStatusSnapshot, Error>?
+
+    init(staleFailure: Bool, onStatus: @escaping @Sendable () -> Void) {
+        self.staleFailure = staleFailure
+        self.onStatus = onStatus
+    }
+    func status() async throws -> UIStatusSnapshot {
+        calls += 1
+        if calls == 1 {
+            return try await withCheckedThrowingContinuation {
+                continuation = $0
+                onStatus()
+            }
+        }
+        return snapshot(preferred: preference)
+    }
+    func completeOldPoll() {
+        if staleFailure { continuation?.resume(throwing: ControlSocketError.daemon("old failure")) }
+        else { continuation?.resume(returning: snapshot(preferred: "sq")) }
+        continuation = nil
+    }
+    private func snapshot(preferred: String) -> UIStatusSnapshot {
+        UIStatusSnapshot(daemonRunning: true, pools: [
+            PoolSnapshot(name: "default", members: ["sq", "pm"], preferred: preferred, active: nil)
+        ])
+    }
+    func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? {
+        preference = account ?? ""
+        return nil
+    }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.emptyResponse }
+    func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+    func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
+}
+
+private struct SelectionWithoutStatusClient: ControlServing {
+    func status() async throws -> UIStatusSnapshot { throw ControlSocketError.daemon("status unavailable") }
+    func setPreferred(pool: String, account: String?) async throws -> UIStatusSnapshot? { nil }
+    func connectExistingLogin(account: String) async throws { throw ControlSocketError.emptyResponse }
     func startLogin(account: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
     func loginStatus(sessionID: String) async throws -> LoginSnapshot { throw ControlSocketError.emptyResponse }
 }

--- a/src/control.rs
+++ b/src/control.rs
@@ -188,7 +188,30 @@ impl BoundedLoginOutput {
     }
 
     fn allowed_fields(&self) -> (Option<String>, Option<String>) {
-        let text = String::from_utf8_lossy(&self.bytes);
+        // Codex emits SGR colors even to piped stdout. Normalize the accumulated
+        // bytes so an escape split across reads is handled on the next poll too.
+        let mut plain = Vec::with_capacity(self.bytes.len());
+        let mut remaining = self.bytes.as_slice();
+        while let Some((&byte, rest)) = remaining.split_first() {
+            if let Some(parameters) = remaining.strip_prefix(b"\x1b[") {
+                let length = parameters
+                    .iter()
+                    .take_while(|byte| byte.is_ascii_digit() || **byte == b';')
+                    .count();
+                if parameters.get(length) == Some(&b'm') {
+                    remaining = &parameters[length + 1..];
+                    continue;
+                }
+            }
+            plain.push(byte);
+            remaining = rest;
+        }
+        let text = String::from_utf8_lossy(&plain);
+        // A live read may end halfway through a code (or its trailing reset).
+        // Codex terminates prompt lines with newlines; expose only complete tokens.
+        let text = text
+            .rfind(char::is_whitespace)
+            .map_or("", |end| &text[..end]);
         let verification_uri = text.split_whitespace().find_map(|token| {
             let token = token.trim_matches(|character: char| {
                 matches!(
@@ -1414,7 +1437,7 @@ path = "accounts/work"
         let (_dir, config, router) = managed_login_fixture();
         let started = Arc::new(Notify::new());
         let finish = Arc::new(Notify::new());
-        let mut output = b"visit https://evil.example/device secret=never-return\nvisit https://auth.openai.com/codex/device\ncode ABCD-EFGH\n".to_vec();
+        let mut output = b"visit https://evil.example/device secret=never-return\nvisit \x1b[94mhttps://auth.openai.com/codex/device\x1b[0m\ncode \x1b[94mABCD-EFGH\x1b[0m\n".to_vec();
         output.extend(std::iter::repeat_n(b'x', MAX_LOGIN_OUTPUT_BYTES * 2));
         let manager = LoginManager::new(
             Arc::new(FakeLoginRunner {
@@ -1585,6 +1608,42 @@ path = "accounts/work"
         ));
         let (_dir, config, _) = managed_login_fixture();
         assert!(managed_account_home(&config, "app").is_err());
+    }
+
+    #[test]
+    fn bounded_login_output_reads_codex_colored_device_prompt_across_chunks() {
+        // Codex prints these ANSI colors even when stdout is a pipe.
+        let prompt = b"\nWelcome to Codex [v\x1b[90m0.153.4\x1b[0m]\n\
+            \x1b[90mOpenAI's command-line coding agent\x1b[0m\n\
+            \nFollow these steps to sign in with ChatGPT using device code authorization:\n\
+            \n1. Open this link in your browser and sign in to your account\n\
+               \x1b[94mhttps://auth.openai.com/codex/device\x1b[0m\n\
+            \n2. Enter this one-time code \x1b[90m(expires in 15 minutes)\x1b[0m\n\
+               \x1b[94mABCD-EFGH\x1b[0m\n";
+        for split in 0..=prompt.len() {
+            let mut output = BoundedLoginOutput::default();
+            output.append(&prompt[..split]);
+            if split < prompt.len() {
+                assert_eq!(output.allowed_fields().1, None, "split at {split}");
+            }
+            output.append(&prompt[split..]);
+            let (uri, code) = output.allowed_fields();
+            assert_eq!(uri.as_deref(), Some("https://auth.openai.com/codex/device"));
+            assert_eq!(code.as_deref(), Some("ABCD-EFGH"));
+        }
+    }
+
+    #[test]
+    fn bounded_login_output_keeps_colored_url_allowlist_exact() {
+        for url in [
+            "https://evil.example/codex/device",
+            "https://auth.openai.com/codex/device/other",
+            "https://auth.openai.com/codex/device?secret=never-return",
+        ] {
+            let mut output = BoundedLoginOutput::default();
+            output.append(format!("\x1b[1;94m{url}\x1b[0m\n").as_bytes());
+            assert_eq!(output.allowed_fields(), (None, None));
+        }
     }
 
     #[test]

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -268,8 +268,10 @@ impl App {
         let scope = &listener.pool;
         if self.context_store.lookup(scope, session).await?.is_none() {
             let pool = self.pool(listener)?;
+            // Preferences can change without reloading the startup configuration.
+            let preferred = self.router.preferred_account(scope).await;
             let mut selected = None;
-            for account in pool.preferred.iter().chain(pool.members.iter()) {
+            for account in preferred.iter().chain(pool.members.iter()) {
                 if self.router.context_account_available(pool, account).await {
                     selected = Some(account);
                     break;

--- a/src/proxy/context_tests.rs
+++ b/src/proxy/context_tests.rs
@@ -156,6 +156,14 @@ fn write_auth(home: &Path, workspace: &str, user: &str) {
 }
 
 fn context_test_app(dir: &Path, upstream: std::net::SocketAddr) -> ContextTestApp {
+    context_test_app_with_preference(dir, upstream, None)
+}
+
+fn context_test_app_with_preference(
+    dir: &Path,
+    upstream: std::net::SocketAddr,
+    preferred: Option<&str>,
+) -> ContextTestApp {
     let account_a = dir.join("a");
     let account_b = dir.join("b");
     write_auth(&account_a, "workspace-a", "user-a");
@@ -177,7 +185,7 @@ fn context_test_app(dir: &Path, upstream: std::net::SocketAddr) -> ContextTestAp
             "default".into(),
             PoolConfig {
                 members: vec!["a".into(), "b".into()],
-                preferred: None,
+                preferred: preferred.map(str::to_owned),
             },
         )]),
         accounts: BTreeMap::from([
@@ -721,6 +729,55 @@ async fn notes_owner_quota_failure_never_calls_an_alternate_account() {
     let seen = upstream.seen.lock().unwrap();
     assert_eq!(seen.len(), 1);
     assert_eq!(seen[0].account_id, "workspace-a");
+}
+
+#[tokio::test]
+async fn first_context_read_uses_current_preference_and_preserves_its_owner() {
+    for (startup, current, expected) in [
+        (Some("a"), Some("b"), "workspace-b"),
+        (Some("b"), None, "workspace-a"),
+    ] {
+        let upstream = start_upstream(Arc::new(|request| {
+            (
+                StatusCode::OK,
+                json!({"encrypted_output": format!("cipher-{}", request.account_id)}),
+            )
+        }))
+        .await;
+        let dir = tempfile::tempdir().unwrap();
+        let test = context_test_app_with_preference(dir.path(), upstream.address, startup);
+        test.app
+            .router
+            .set_preferred("default", current.map(str::to_owned))
+            .await;
+
+        for read in 0..2 {
+            if read == 1 {
+                // Once notes have an owner, later preference changes must not move them.
+                let other = if current == Some("b") { "a" } else { "b" };
+                test.app
+                    .router
+                    .set_preferred("default", Some(other.to_owned()))
+                    .await;
+            }
+            let (status, _) = post(
+                &test.app,
+                &test.listener,
+                "/alpha/notes/v2/read_file",
+                hyper::HeaderMap::new(),
+                Bytes::from_static(
+                    br#"{"context":{"session_id":"123e4567-e89b-12d3-a456-426614174000","current_agent_name":"/root"}}"#,
+                ),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+        }
+        let seen = upstream.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        for request in seen.iter() {
+            assert_eq!(request.account_id, expected);
+        }
+    }
 }
 
 #[tokio::test]

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -518,6 +518,10 @@ impl Router {
         }
     }
 
+    pub async fn preferred_account(&self, pool: &str) -> Option<String> {
+        self.preferred.lock().await.get(pool).cloned()
+    }
+
     pub async fn routing_snapshot(&self) -> RoutingSnapshot {
         let now = Instant::now();
         let wall_now = Utc::now();


### PR DESCRIPTION
New context sessions honor the current account preference, and late menu refreshes cannot restore an older selection. Existing context ownership is preserved.

Device login now parses colored CLI output and displays the code with a copy button. Accounts needing sign-in use their existing menu row without changing the preferred account, and new login attempts clear old session details.
