### PR TITLE
Preserve Comradex service startup during login

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,17 +185,20 @@ An installed Comradex binary can manage its own LaunchAgent:
 comradex service install
 comradex service start
 comradex service status
+comradex service logs
 comradex service restart
 comradex service uninstall
 ```
 
-`service start` is idempotent: it loads an installed but unloaded LaunchAgent, revives a stopped job, and leaves an already-running daemon uninterrupted after verifying its listeners. `service restart` validates the edited configuration before stopping anything, then restarts the LaunchAgent and waits for every listener to answer a health probe. A broken edit fails validation and leaves the running daemon untouched. Both commands use the configuration path recorded in the installed plist regardless of `--config`.
+`service start` is idempotent: it loads an installed but unloaded LaunchAgent, revives a stopped job, and leaves an already-running or starting job uninterrupted while waiting for its listeners. `service restart` validates the edited configuration before stopping anything, then restarts the LaunchAgent and waits for every listener to answer a health probe. A broken edit fails validation and leaves the running daemon untouched. Both commands use the configuration path recorded in the installed plist regardless of `--config`.
 
-The installer records the exact executable and configuration paths, validates the generated plist, starts the daemon at login, and writes logs beneath Comradex's state directory. Early-login platform certificate loading is retried for up to 7.75 seconds so a temporarily unavailable macOS trust store does not strand the LaunchAgent. Installation waits for launchd to report a running PID and verifies every configured listener with a Comradex-specific HTTP probe. A failed replacement restores the previous Comradex plist and loaded job when possible.
+The installer records the exact executable and configuration paths, validates the generated plist, starts the daemon at login, and writes logs beneath Comradex's state directory. Repeating `service install` with the same service definition starts or waits for the existing job without replacing it. WebSocket TLS uses bundled Mozilla roots, avoiding macOS trust-store enumeration during startup. Installation waits for launchd to report a running PID and verifies every configured listener with a Comradex-specific HTTP probe. If the readiness wait expires while the job is still starting, it remains loaded so macOS can finish launching it; the timeout does not kill and replace it. A failed replacement restores the previous Comradex plist and loaded job when possible.
 
 The service manages only `com.nicosuave.comradex`; it does not inspect, stop, or remove OpenCodex or any other relay. Stop OpenCodex first if it owns the same listener port. Codex configuration installation and service installation are separate reversible operations.
 
-`service status` reports whether launchd currently has a running Comradex process. When an installed service is down, it shows the last bounded stderr line and the exact start command; launchctl permission and communication failures are reported as errors instead of being mistaken for an unloaded job. On SIGTERM, Comradex stops the listeners, aborts and joins tracked HTTP/WebSocket connection tasks, clears in-flight counters, and only then writes final affinity, file-owner, and statistics snapshots. Active requests are terminated rather than gracefully completed during shutdown.
+`service status` distinguishes a ready daemon, a running process whose listeners are not ready, a starting job, a stopped job, and an unloaded service. It includes the last exit result when available and directs you to `service logs`, which shows up to 40 lines from the final 64 KiB of each stdout and stderr log, their paths, and human-readable modification times. These logs are historical: an old stderr line is not evidence of the current startup failure. Launchctl permission and communication failures are reported as errors instead of being mistaken for an unloaded job.
+
+On SIGTERM, Comradex stops the listeners, aborts and joins tracked HTTP/WebSocket connection tasks, clears in-flight counters, and only then writes final affinity, file-owner, and statistics snapshots. Active requests are terminated rather than gracefully completed during shutdown.
 
 ## How routing works
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,8 @@ enum ServiceCommand {
     Start,
     Uninstall,
     Status,
+    /// Show recent service stdout and stderr with log paths and modification times
+    Logs,
     /// Restart the daemon so it reloads comradex.toml (needed after config
     /// edits such as adding an account)
     Restart,
@@ -298,6 +300,12 @@ async fn serve(path: &Path) -> Result<()> {
 }
 
 async fn serve_once(path: &Path) -> Result<bool> {
+    let startup = std::time::Instant::now();
+    info!(
+        pid = std::process::id(),
+        version = env!("CARGO_PKG_VERSION"),
+        "daemon startup: loading configuration and routing state"
+    );
     #[cfg(unix)]
     if let Some((soft, hard)) = open_file_limits() {
         info!(soft, hard, "open file limits");
@@ -313,6 +321,10 @@ async fn serve_once(path: &Path) -> Result<bool> {
         Duration::from_secs(config.proxy.affinity_idle_days * 86_400),
     )?);
     let router = Arc::new(Router::new(&config, affinity));
+    info!(
+        elapsed_ms = startup.elapsed().as_millis(),
+        "daemon startup: routing state loaded; opening control socket"
+    );
     let stats = Arc::new(Stats::default());
     let control_server = control::ControlServer::bind(
         &state,
@@ -323,7 +335,15 @@ async fn serve_once(path: &Path) -> Result<bool> {
     )?;
     let reload = control_server.reload_requested();
     let mut control_task = tokio::spawn(control_server.run());
+    info!(
+        elapsed_ms = startup.elapsed().as_millis(),
+        "daemon startup: control socket bound; initializing transports and stores"
+    );
     let app = App::new(config.clone(), router.clone(), stats.clone())?;
+    info!(
+        elapsed_ms = startup.elapsed().as_millis(),
+        "daemon startup: initialization complete; starting listeners"
+    );
     let mut tasks = tokio::task::JoinSet::new();
     for (name, listener) in config.listeners.clone() {
         tasks.spawn(app.clone().run_listener(name, listener));
@@ -466,21 +486,10 @@ fn service_command(config_path: &Path, command: ServiceCommand) -> Result<()> {
             None => println!("service is not installed"),
         },
         ServiceCommand::Status => {
-            if service::status()? {
-                println!("service is running");
-            } else if service::installed()? {
-                println!("service is installed but not running");
-                if let Some(stderr) = service::last_stderr_line()? {
-                    println!(
-                        "last stderr line{}: {}",
-                        stderr_timestamp_suffix(stderr.log_modified_at_unix),
-                        stderr.line
-                    );
-                }
-                println!("run `comradex service start`");
-            } else {
-                println!("service is not installed (run `comradex service install`)");
-            }
+            println!("{}", service::status_description()?);
+        }
+        ServiceCommand::Logs => {
+            println!("{}", service::logs()?);
         }
         ServiceCommand::Restart => {
             service::restart()?;
@@ -1337,6 +1346,17 @@ mod tests {
             cli.command,
             CommandName::Service {
                 command: ServiceCommand::Start
+            }
+        ));
+    }
+
+    #[test]
+    fn service_logs_is_a_first_class_command() {
+        let cli = Cli::try_parse_from(["comradex", "service", "logs"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Service {
+                command: ServiceCommand::Logs
             }
         ));
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -52,6 +52,32 @@ pub fn install(config_path: &Path, state_dir: &Path) -> Result<PathBuf> {
     let stdout = state_dir.join("service.stdout.log");
     let stderr = state_dir.join("service.stderr.log");
     let working_directory = config_path.parent().unwrap_or(Path::new("/"));
+    let previous = match fs::read(&plist_path) {
+        Ok(bytes) => Some(bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error).with_context(|| format!("read {}", plist_path.display())),
+    };
+    // Retain the readiness identity when comparing an existing installation.
+    // Reinstalling the same service must not kill a launch still in progress.
+    let service_nonce = previous
+        .as_deref()
+        .and_then(|bytes| std::str::from_utf8(bytes).ok())
+        .and_then(|plist| plist_string_after(plist, "<key>COMRADEX_SERVICE_NONCE</key><string>"))
+        .unwrap_or_else(|| format!("{:032x}", rand::random::<u128>()));
+    let plist = render_plist(
+        &executable,
+        &config_path,
+        working_directory,
+        &stdout,
+        &stderr,
+        &service_nonce,
+    );
+    if previous.as_deref() == Some(plist.as_bytes()) {
+        start()?;
+        return Ok(plist_path);
+    }
+    // A changed definition gets a new identity: an old listener must not
+    // satisfy readiness for its replacement.
     let service_nonce = format!("{:032x}", rand::random::<u128>());
     let plist = render_plist(
         &executable,
@@ -66,11 +92,6 @@ pub fn install(config_path: &Path, state_dir: &Path) -> Result<PathBuf> {
     candidate.as_file().sync_all()?;
     validate_plist(candidate.path())?;
 
-    let previous = match fs::read(&plist_path) {
-        Ok(bytes) => Some(bytes),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error).with_context(|| format!("read {}", plist_path.display())),
-    };
     let domain = launchctl_domain();
     let was_loaded = is_loaded(&domain)?;
     if was_loaded && previous.is_none() {
@@ -187,6 +208,12 @@ where
     let Err(start_error) = start_new(plist_path) else {
         return Ok(());
     };
+    if start_error.is::<ReadinessTimeout>() {
+        // A deadline is an observation, not a failed bootstrap. In particular,
+        // xpcproxy may still be waiting for macOS to launch the executable.
+        // Leave KeepAlive and the installed job intact so it can finish.
+        return Err(start_error);
+    }
 
     let rollback_result = stop()
         .and_then(|()| match previous {
@@ -388,9 +415,9 @@ pub fn restart() -> Result<()> {
     let previous_pid = state.pid();
     match state {
         LaunchAgentState::Unloaded => bootstrap(&domain, &service.plist_path)?,
-        LaunchAgentState::LoadedStopped { .. } | LaunchAgentState::Running { .. } => {
-            kickstart(&domain)?
-        }
+        LaunchAgentState::Starting
+        | LaunchAgentState::LoadedStopped { .. }
+        | LaunchAgentState::Running { .. } => kickstart(&domain)?,
     }
     service.wait_until_ready(&domain, previous_pid)
 }
@@ -483,6 +510,7 @@ fn installed_service() -> Result<InstalledService> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LaunchAgentState {
     Unloaded,
+    Starting,
     LoadedStopped { previous_pid: Option<u32> },
     Running { pid: u32 },
 }
@@ -490,7 +518,7 @@ enum LaunchAgentState {
 impl LaunchAgentState {
     fn pid(self) -> Option<u32> {
         match self {
-            Self::Unloaded => None,
+            Self::Unloaded | Self::Starting => None,
             Self::LoadedStopped { previous_pid } => previous_pid,
             Self::Running { pid } => Some(pid),
         }
@@ -503,6 +531,17 @@ fn launchctl_output_state(output: &str) -> LaunchAgentState {
         && let Some(pid) = pid
     {
         LaunchAgentState::Running { pid }
+    } else if output.lines().any(|line| {
+        matches!(
+            line.trim(),
+            "state = spawn scheduled"
+                | "state = spawning"
+                | "state = xpcproxy"
+                | "state = pre-exec"
+                | "state = spawn pending"
+        )
+    }) {
+        LaunchAgentState::Starting
     } else {
         LaunchAgentState::LoadedStopped { previous_pid: pid }
     }
@@ -523,7 +562,7 @@ fn execute_start(
             kickstart_job()?;
             previous_pid
         }
-        LaunchAgentState::Running { .. } => None,
+        LaunchAgentState::Running { .. } | LaunchAgentState::Starting => None,
     };
     wait(previous_pid)
 }
@@ -677,13 +716,155 @@ fn wait_until_ready(
                 .map(ToString::to_string)
                 .collect::<Vec<_>>()
                 .join(", ");
-            if targets.is_empty() {
-                bail!("LaunchAgent did not reach a running state within {timeout:?}")
-            }
-            bail!("LaunchAgent did not become ready on {targets} within {timeout:?}")
+            return Err(readiness_deadline_error(
+                launchctl.as_deref(),
+                targets,
+                timeout,
+            ));
         }
         thread::sleep(READY_POLL_INTERVAL);
     }
+}
+
+fn readiness_deadline_error(
+    output: Option<&str>,
+    targets: String,
+    timeout: Duration,
+) -> anyhow::Error {
+    let Some(output) = output else {
+        return anyhow::anyhow!(
+            "LaunchAgent disappeared while waiting for readiness; run `comradex service logs`"
+        );
+    };
+    let state = launchctl_state_summary(output);
+    if matches!(
+        launchctl_output_state(output),
+        LaunchAgentState::LoadedStopped { .. }
+    ) && (launchctl_last_exit(output).is_some_and(|code| code != 0)
+        || output
+            .lines()
+            .any(|line| line.trim().starts_with("last terminating signal = ")))
+    {
+        return anyhow::anyhow!(
+            "LaunchAgent failed to start ({state}); run `comradex service logs`"
+        );
+    }
+    ReadinessTimeout {
+        targets,
+        timeout,
+        state,
+    }
+    .into()
+}
+
+#[derive(Debug)]
+struct ReadinessTimeout {
+    targets: String,
+    timeout: Duration,
+    state: String,
+}
+
+impl std::fmt::Display for ReadinessTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "service is not ready after {:?} ({}; listeners: {}). The LaunchAgent is still installed and loaded; startup has not been cancelled. Run `comradex service status` or `comradex service logs`; reinstalling is unnecessary",
+            self.timeout, self.state, self.targets
+        )
+    }
+}
+
+impl std::error::Error for ReadinessTimeout {}
+
+fn launchctl_last_exit(output: &str) -> Option<i32> {
+    output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("last exit code = ")?.parse().ok())
+}
+
+fn launchctl_state_summary(output: &str) -> String {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            line.starts_with("state = ")
+                || line.starts_with("pid = ")
+                || line.starts_with("last exit code = ")
+                || line.starts_with("last terminating signal = ")
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+pub fn status_description() -> Result<String> {
+    platform_check()?;
+    if !installed()? {
+        return Ok("service is not installed (run `comradex service install`)".into());
+    }
+    let Some(output) = launchctl_print(&launchctl_domain())? else {
+        return Ok("service is installed but not loaded; run `comradex service start`\nLogs: `comradex service logs` (includes historical output)".into());
+    };
+    let state = launchctl_output_state(&output);
+    let description = match state {
+        LaunchAgentState::Starting => "service is starting; macOS has not finished launching it",
+        LaunchAgentState::Running { .. } => {
+            let service = installed_service()?;
+            let (listeners, nonce) = readiness_probe(
+                &service.listener_addresses,
+                service.service_nonce.as_deref(),
+            );
+            if listeners_ready(listeners, nonce) {
+                "service is running and ready"
+            } else {
+                "service process is running but its listeners are not ready"
+            }
+        }
+        _ => "service is loaded but stopped; run `comradex service start`",
+    };
+    Ok(format!(
+        "{description}\n{}\nLogs: `comradex service logs` (includes historical output)",
+        launchctl_state_summary(&output)
+    ))
+}
+
+pub fn logs() -> Result<String> {
+    platform_check()?;
+    let plist = fs::read_to_string(plist_path()?)
+        .context("read installed LaunchAgent; service logs require an installed service")?;
+    let mut result = String::new();
+    for key in ["StandardOutPath", "StandardErrorPath"] {
+        if let Some(path) = plist_string_after(&plist, &format!("<key>{key}</key><string>")) {
+            result.push_str(&log_excerpt(Path::new(&path))?);
+        }
+    }
+    Ok(result)
+}
+
+fn log_excerpt(path: &Path) -> Result<String> {
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(format!("{}: no log yet\n", path.display()));
+        }
+        Err(error) => return Err(error).with_context(|| format!("read {}", path.display())),
+    };
+    let metadata = file.metadata()?;
+    let modified = metadata
+        .modified()
+        .map(|time| chrono::DateTime::<chrono::Local>::from(time).to_rfc3339())
+        .unwrap_or_else(|_| "unknown".into());
+    let start = metadata.len().saturating_sub(64 * 1024);
+    file.seek(SeekFrom::Start(start))?;
+    let mut bytes = Vec::new();
+    file.take(64 * 1024).read_to_end(&mut bytes)?;
+    let text = String::from_utf8_lossy(&bytes);
+    let lines: Vec<_> = text.lines().rev().take(40).collect();
+    Ok(format!(
+        "{} (last modified {modified}; historical output, last {} lines):\n{}\n",
+        path.display(),
+        lines.len(),
+        lines.into_iter().rev().collect::<Vec<_>>().join("\n")
+    ))
 }
 
 fn listeners_ready(listeners: &[SocketAddr], service_nonce: Option<&str>) -> bool {
@@ -923,6 +1104,106 @@ mod tests {
         assert_eq!(stops.get(), 2);
         assert_eq!(new_starts.get(), 1);
         assert_eq!(previous_starts.get(), 1);
+    }
+
+    #[test]
+    fn slow_replacement_stays_installed_and_is_not_killed_or_rolled_back() {
+        for previous in [None, Some(b"old".as_slice())] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("service.plist");
+            if let Some(bytes) = previous {
+                fs::write(&path, bytes).unwrap();
+            }
+            let mut candidate = tempfile::NamedTempFile::new_in(dir.path()).unwrap();
+            candidate.write_all(b"new").unwrap();
+            let stops = Cell::new(0);
+            let result = replace_plist_transaction(
+                &path,
+                candidate,
+                previous,
+                previous.is_some(),
+                || {
+                    stops.set(stops.get() + 1);
+                    Ok(())
+                },
+                |_| {
+                    Err(ReadinessTimeout {
+                        targets: "127.0.0.1:10100".into(),
+                        timeout: READY_TIMEOUT,
+                        state: "state = xpcproxy".into(),
+                    }
+                    .into())
+                },
+                |_| panic!("a slow launch must not restore the old job"),
+            );
+            assert!(result.unwrap_err().is::<ReadinessTimeout>());
+            assert_eq!(fs::read(&path).unwrap(), b"new");
+            assert_eq!(stops.get(), usize::from(previous.is_some()));
+        }
+    }
+
+    #[test]
+    fn readiness_deadline_distinguishes_current_failure_from_historical_exit() {
+        for state in ["xpcproxy", "spawning", "running"] {
+            let output = format!("state = {state}\npid = 42\nlast exit code = 1\n");
+            assert!(
+                readiness_deadline_error(Some(&output), String::new(), READY_TIMEOUT)
+                    .is::<ReadinessTimeout>()
+            );
+        }
+        let failed = "state = waiting\nlast exit code = 1\n";
+        let error = readiness_deadline_error(Some(failed), String::new(), READY_TIMEOUT);
+        assert!(!error.is::<ReadinessTimeout>());
+        assert!(error.to_string().contains("last exit code = 1"));
+        let crashed = "state = waiting\nlast terminating signal = Segmentation fault: 11\n";
+        let error = readiness_deadline_error(Some(crashed), String::new(), READY_TIMEOUT);
+        assert!(!error.is::<ReadinessTimeout>());
+        assert!(error.to_string().contains("Segmentation fault"));
+        assert!(
+            !readiness_deadline_error(None, String::new(), READY_TIMEOUT).is::<ReadinessTimeout>()
+        );
+    }
+
+    #[test]
+    fn start_does_not_kill_a_process_still_being_launched() {
+        for state in [
+            "spawn scheduled",
+            "spawning",
+            "xpcproxy",
+            "pre-exec",
+            "spawn pending",
+        ] {
+            let state = launchctl_output_state(&format!("state = {state}\npid = 42\n"));
+            assert_eq!(state, LaunchAgentState::Starting);
+            execute_start(
+                state,
+                || panic!("already loaded"),
+                || panic!("must not kill an in-progress launch"),
+                |previous| {
+                    assert_eq!(previous, None);
+                    Ok(())
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn logs_show_bounded_history_with_path_and_readable_modification_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stdout.log");
+        fs::write(
+            &path,
+            (0..100)
+                .map(|n| format!("record {n}\n"))
+                .collect::<String>(),
+        )
+        .unwrap();
+        let result = log_excerpt(&path).unwrap();
+        assert!(result.contains("last modified "));
+        assert!(result.contains("historical output, last 40 lines"));
+        assert!(!result.contains("record 59\n"));
+        assert!(result.ends_with("record 99\n"));
     }
 
     #[test]


### PR DESCRIPTION
During login, macOS can leave Comradex in xpcproxy for longer than the service readiness deadline. Reinstalling stopped that pending launch, then the 20-second timeout killed its replacement and restored the previous job.

Preserve an unchanged installation and in-progress launches, and leave a slow replacement loaded when readiness times out. Actual startup failures still roll back. Add distinct startup/readiness status, bounded `service logs` output with readable timestamps, and startup-stage timing so old stderr errors do not masquerade as current failures.

383 tests passed, including delayed-launch preservation and genuine-failure rollback.
