### PR TITLE
Add account preserve for last-resort pool routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,16 @@ comradex account list
 comradex account login personal_2
 comradex account prefer personal_2
 comradex account prefer --clear
+comradex account preserve personal
+comradex account preserve --clear
 comradex account remove personal_2
 ```
 
 `account list` shows each account's login state. `account remove` removes it from the configuration and every pool but keeps its credential directory. `--purge` can delete only the isolated home created for that account; it refuses external or linked Codex homes.
 
 `account prefer <name>` immediately makes that account the first choice for new, unbound work in the default pool. Use `--pool <name>` for another pool and `--clear` to restore automatic selection. The daemon applies the change through an authenticated, user-only Unix socket and persists it in `comradex.toml`; it does not restart, interrupt active turns, or move sticky conversations. An unavailable, quota-limited, or over-threshold preferred account is skipped by the normal quota-aware fallback. If the daemon is not running, the preference is saved and takes effect on its next start.
+
+`account preserve <name>` reserves that account for last use in the pool. New, unbound work uses other eligible accounts first, even when their usage is above the rotation threshold. The preserved account remains available when all others are unavailable or excluded from a retry. Existing conversations keep their account bindings. Use `--pool <name>` to select a pool or `--clear` to remove preservation. Changes apply live without restarting the daemon and persist as `preserved` in the pool's configuration. A pool can prefer one account and preserve another; it cannot prefer and preserve the same account.
 
 The equivalent manual configuration is:
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -158,10 +158,12 @@ pub fn remove_account(text: &str, name: &str) -> Result<(String, Option<String>)
                 members.retain(|member| member.as_str() != Some(name));
                 members.fmt();
             }
-            if pool.get("preferred").and_then(Item::as_str) == Some(name) {
-                pool.as_table_like_mut()
-                    .expect("pool was already accessed as a table")
-                    .remove("preferred");
+            for field in ["preferred", "preserved"] {
+                if pool.get(field).and_then(Item::as_str) == Some(name) {
+                    pool.as_table_like_mut()
+                        .expect("pool was already accessed as a table")
+                        .remove(field);
+                }
             }
         }
     }
@@ -170,6 +172,21 @@ pub fn remove_account(text: &str, name: &str) -> Result<(String, Option<String>)
 
 /// Set or clear the preferred account for a pool while preserving surrounding formatting.
 pub fn set_preferred_account(text: &str, pool_name: &str, account: Option<&str>) -> Result<String> {
+    set_account_order(text, pool_name, account, "preferred", "preserved")
+}
+
+/// Set or clear the account reserved for last use in a pool.
+pub fn set_preserved_account(text: &str, pool_name: &str, account: Option<&str>) -> Result<String> {
+    set_account_order(text, pool_name, account, "preserved", "preferred")
+}
+
+fn set_account_order(
+    text: &str,
+    pool_name: &str,
+    account: Option<&str>,
+    field: &str,
+    opposite: &str,
+) -> Result<String> {
     if let Some(account) = account {
         validate_name(account)?;
     }
@@ -194,10 +211,15 @@ pub fn set_preferred_account(text: &str, pool_name: &str, account: Option<&str>)
             if !is_member {
                 bail!("account {account} is not a member of pool {pool_name}")
             }
-            pool.insert("preferred", value(account));
+            if pool.get(opposite).and_then(Item::as_str) == Some(account) {
+                bail!(
+                    "pool {pool_name} cannot prefer and preserve the same account; clear {opposite} first"
+                )
+            }
+            pool.insert(field, value(account));
         }
         None => {
-            pool.remove("preferred");
+            pool.remove(field);
         }
     }
     Ok(doc.to_string())
@@ -391,6 +413,30 @@ kind = "inbound"
 
         let (removed, _) = remove_account(&preferred, "work2").unwrap();
         assert!(!removed.contains("preferred"));
+    }
+
+    #[test]
+    fn preserved_account_is_validated_cleared_and_removed() {
+        let added = add_account(TEMPLATE, "work2", "default").unwrap();
+        let saved = set_preserved_account(&added, "default", Some("work2")).unwrap();
+        assert!(saved.contains("preserved = \"work2\""));
+        assert!(
+            !set_preserved_account(&saved, "default", None)
+                .unwrap()
+                .contains("preserved")
+        );
+        assert!(
+            !remove_account(&saved, "work2")
+                .unwrap()
+                .0
+                .contains("preserved")
+        );
+        assert!(set_preserved_account(&added, "default", Some("missing")).is_err());
+        assert!(set_preserved_account(&added, "missing", Some("work2")).is_err());
+        assert!(set_preferred_account(&saved, "default", Some("work2")).is_err());
+        let preferred = set_preferred_account(&added, "default", Some("work2")).unwrap();
+        assert!(set_preserved_account(&preferred, "default", Some("work2")).is_err());
+        assert!(set_preferred_account(&saved, "default", Some("caller")).is_ok());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,9 @@ pub struct PoolConfig {
     /// always take precedence, and an unhealthy or quota-limited account is skipped.
     #[serde(default)]
     pub preferred: Option<String>,
+    /// Account used last for fresh work; existing bindings keep their owner.
+    #[serde(default)]
+    pub preserved: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -300,6 +303,16 @@ impl Config {
             bail!("at least one listener is required")
         }
         for (pool_name, pool) in &self.pools {
+            if let Some(preserved) = &pool.preserved {
+                if !pool.members.contains(preserved) {
+                    bail!(
+                        "pool {pool_name} preserves account {preserved}, which is not one of its members"
+                    )
+                }
+                if pool.preferred.as_ref() == Some(preserved) {
+                    bail!("pool {pool_name} cannot prefer and preserve the same account")
+                }
+            }
             if let Some(preferred) = &pool.preferred
                 && !pool.members.contains(preferred)
             {
@@ -464,6 +477,23 @@ kind = "inbound"
         fs::write(&path, text).unwrap();
         let error = Config::load(&path).unwrap_err();
         assert!(error.to_string().contains("not one of its members"));
+    }
+
+    #[test]
+    fn preserved_account_must_be_a_member_and_cannot_be_preferred() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("comradex.toml");
+        for settings in [
+            "preserved = \"missing\"",
+            "preserved = \"caller\"\npreferred = \"caller\"",
+        ] {
+            let text = config_text(None).replace(
+                "members = [\"caller\"]",
+                &format!("members = [\"caller\"]\n{settings}"),
+            );
+            fs::write(&path, text).unwrap();
+            assert!(Config::load(&path).is_err());
+        }
     }
 
     #[test]

--- a/src/control.rs
+++ b/src/control.rs
@@ -51,6 +51,11 @@ enum Request {
         pool: String,
         account: Option<String>,
     },
+    SetPreserved {
+        secret: String,
+        pool: String,
+        account: Option<String>,
+    },
     RoutingStatus {
         secret: String,
     },
@@ -75,7 +80,9 @@ enum Request {
 impl Request {
     fn secret(&self) -> Option<&str> {
         match self {
-            Self::SetPreferred { secret, .. } | Self::RoutingStatus { secret } => Some(secret),
+            Self::SetPreferred { secret, .. }
+            | Self::SetPreserved { secret, .. }
+            | Self::RoutingStatus { secret } => Some(secret),
             Self::UiStatus
             | Self::UiSetPreferred { .. }
             | Self::UiStartLogin { .. }
@@ -736,6 +743,10 @@ async fn process(
                 update_preferred(config_path, config, router, edit_lock, &pool, account).await?;
                 Response::routing(router.routing_snapshot().await)
             }
+            Request::SetPreserved { pool, account, .. } => {
+                update_preserved(config_path, config, router, edit_lock, &pool, account).await?;
+                Response::routing(router.routing_snapshot().await)
+            }
             Request::UiStatus => {
                 Response::status(build_ui_status(config, router, stats, login_manager).await)
             }
@@ -831,6 +842,32 @@ async fn update_preferred(
     let updated = accounts::set_preferred_account(&text, pool, account.as_deref())?;
     config::write_validated(config_path, &updated)?;
     router.set_preferred(pool, account).await;
+    Ok(())
+}
+
+async fn update_preserved(
+    config_path: &Path,
+    config: &Config,
+    router: &Router,
+    edit_lock: &Mutex<()>,
+    pool: &str,
+    account: Option<String>,
+) -> Result<()> {
+    let pool_config = config
+        .pools
+        .get(pool)
+        .with_context(|| format!("unknown pool {pool}"))?;
+    if let Some(account) = &account
+        && !pool_config.members.contains(account)
+    {
+        bail!("account {account} is not a member of pool {pool}")
+    }
+    let _guard = edit_lock.lock().await;
+    let text = fs::read_to_string(config_path)
+        .with_context(|| format!("read {}", config_path.display()))?;
+    let updated = accounts::set_preserved_account(&text, pool, account.as_deref())?;
+    config::write_validated(config_path, &updated)?;
+    router.set_preserved(pool, account).await;
     Ok(())
 }
 
@@ -1013,6 +1050,22 @@ pub fn set_preferred(
     send(
         state_dir,
         &Request::SetPreferred {
+            secret: secret.to_owned(),
+            pool: pool.to_owned(),
+            account: account.map(str::to_owned),
+        },
+    )
+}
+
+pub fn set_preserved(
+    state_dir: &Path,
+    secret: &str,
+    pool: &str,
+    account: Option<&str>,
+) -> Result<RoutingSnapshot> {
+    send(
+        state_dir,
+        &Request::SetPreserved {
             secret: secret.to_owned(),
             pool: pool.to_owned(),
             account: account.map(str::to_owned),
@@ -1234,6 +1287,59 @@ kind = "inbound"
                 .unwrap()
                 .unwrap();
         assert_eq!(routing.active_accounts["default"], "b");
+
+        let state = state_dir.clone();
+        assert!(
+            tokio::task::spawn_blocking(move || {
+                set_preserved(&state, "wrong-secret", "default", Some("a"))
+            })
+            .await
+            .unwrap()
+            .is_err()
+        );
+        for account in [Some("a"), None] {
+            let state = state_dir.clone();
+            let routing = tokio::task::spawn_blocking(move || {
+                set_preserved(&state, "0123456789abcdef", "default", account)
+            })
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(
+                routing
+                    .preserved_accounts
+                    .get("default")
+                    .map(String::as_str),
+                account
+            );
+            let saved = Config::load(&config_path).unwrap();
+            assert_eq!(saved.pools["default"].preserved.as_deref(), account);
+            let restarted = Router::new(&saved, router.affinity.clone());
+            assert_eq!(
+                restarted.routing_snapshot().await.preserved_accounts,
+                routing.preserved_accounts
+            );
+        }
+        for account in ["b", "missing"] {
+            let before = fs::read_to_string(&config_path).unwrap();
+            let state = state_dir.clone();
+            assert!(
+                tokio::task::spawn_blocking(move || {
+                    set_preserved(&state, "0123456789abcdef", "default", Some(account))
+                })
+                .await
+                .unwrap()
+                .is_err()
+            );
+            assert_eq!(fs::read_to_string(&config_path).unwrap(), before);
+            assert!(
+                router
+                    .routing_snapshot()
+                    .await
+                    .preserved_accounts
+                    .is_empty()
+            );
+        }
 
         task.abort();
         let _ = task.await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,16 @@ enum AccountCommand {
         #[arg(long, conflicts_with = "name", required_unless_present = "name")]
         clear: bool,
     },
+    /// Use an account last for new work without interrupting active turns
+    Preserve {
+        /// Account to preserve; omit when using --clear
+        name: Option<String>,
+        #[arg(long, default_value = "default")]
+        pool: String,
+        /// Clear the preserved account for this pool
+        #[arg(long, conflicts_with = "name", required_unless_present = "name")]
+        clear: bool,
+    },
     /// Sign an account in through the official Codex device flow
     Login { name: String },
     /// Connect an inbound account to your existing Codex login
@@ -616,6 +626,11 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
             .and_then(|routing| routing.preferred_accounts.get(name))
             .or(pool.preferred.as_ref())
             .map_or("automatic", String::as_str);
+        let preserved = match routing {
+            Some(routing) => routing.preserved_accounts.get(name),
+            None => pool.preserved.as_ref(),
+        }
+        .map_or("none", String::as_str);
         let active = routing
             .and_then(|routing| routing.active_accounts.get(name))
             .map_or("no fresh work yet", String::as_str);
@@ -624,7 +639,9 @@ fn status(config_path: &Path, json: bool) -> Result<()> {
         let wired = routing
             .and_then(|routing| routing.wired_accounts.get(name))
             .map_or("nothing wired yet", String::as_str);
-        println!("  {name:width$}  preferred {preferred}, active {active}, wired {wired}");
+        println!(
+            "  {name:width$}  preferred {preferred}, preserved {preserved}, active {active}, wired {wired}"
+        );
     }
 
     println!("\ntraffic");
@@ -913,6 +930,59 @@ fn account_command(config_path: &Path, command: AccountCommand) -> Result<()> {
                         ),
                         None => println!(
                             "saved automatic selection for pool {pool}; it will apply when the daemon starts"
+                        ),
+                    }
+                    Ok(())
+                }
+                Err(control_error) => Err(control_error).context(
+                    "live routing request did not complete; check `comradex status` before retrying",
+                ),
+            }
+        }
+        AccountCommand::Preserve { name, pool, clear } => {
+            debug_assert!(name.is_some() || clear);
+            let config = load_config(config_path)?;
+            let pool_config = config
+                .pools
+                .get(&pool)
+                .with_context(|| format!("unknown pool {pool}"))?;
+            if let Some(name) = &name
+                && !pool_config.members.contains(name)
+            {
+                bail!("account {name} is not a member of pool {pool}")
+            }
+            match control::set_preserved(
+                &state_dir(&config),
+                &config.proxy.installation_secret,
+                &pool,
+                name.as_deref(),
+            ) {
+                Ok(routing) => {
+                    match name {
+                        Some(name) => println!(
+                            "pool {pool} now uses {name} last for new work; active turns were not interrupted"
+                        ),
+                        None => println!(
+                            "pool {pool} no longer preserves an account; active turns were not interrupted"
+                        ),
+                    }
+                    if let Some(active) = routing.active_accounts.get(&pool) {
+                        println!("active account for fresh work: {active}");
+                    }
+                    Ok(())
+                }
+                Err(_control_error) if !control::socket_path(&state_dir(&config)).exists() => {
+                    let text = fs::read_to_string(config_path)
+                        .with_context(|| format!("read {}", config_path.display()))?;
+                    let updated =
+                        comradex::accounts::set_preserved_account(&text, &pool, name.as_deref())?;
+                    write_config_validated(config_path, &updated)?;
+                    match name {
+                        Some(name) => println!(
+                            "saved {name} as the preserved account for pool {pool}; it will apply when the daemon starts"
+                        ),
+                        None => println!(
+                            "cleared the preserved account for pool {pool}; it will apply when the daemon starts"
                         ),
                     }
                     Ok(())
@@ -1338,6 +1408,39 @@ mod tests {
 
         assert!(Cli::try_parse_from(["comradex", "account", "prefer", "work", "--clear"]).is_err());
         assert!(Cli::try_parse_from(["comradex", "account", "prefer"]).is_err());
+    }
+
+    #[test]
+    fn account_preserve_cli_accepts_an_account_or_clear_but_not_both() {
+        let cli = Cli::try_parse_from(["comradex", "account", "preserve", "work", "--pool", "p"])
+            .unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Account {
+                command: AccountCommand::Preserve {
+                    name: Some(name),
+                    pool,
+                    clear: false,
+                },
+            } if name == "work" && pool == "p"
+        ));
+
+        let cli = Cli::try_parse_from(["comradex", "account", "preserve", "--clear"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            CommandName::Account {
+                command: AccountCommand::Preserve {
+                    name: None,
+                    pool,
+                    clear: true,
+                },
+            } if pool == "default"
+        ));
+
+        assert!(
+            Cli::try_parse_from(["comradex", "account", "preserve", "work", "--clear"]).is_err()
+        );
+        assert!(Cli::try_parse_from(["comradex", "account", "preserve"]).is_err());
     }
 
     #[test]

--- a/src/proxy/accepted_retry_tests.rs
+++ b/src/proxy/accepted_retry_tests.rs
@@ -248,6 +248,7 @@ impl Fixture {
                 PoolConfig {
                     members: members.iter().map(|name| (*name).to_owned()).collect(),
                     preferred: Some("a".into()),
+                    preserved: None,
                 },
             )]),
             accounts,

--- a/src/proxy/compression_tests.rs
+++ b/src/proxy/compression_tests.rs
@@ -104,6 +104,7 @@ async fn fixture_with_spool_limit(
             PoolConfig {
                 members: vec!["caller".into()],
                 preferred: None,
+                preserved: None,
             },
         )]),
         accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),

--- a/src/proxy/context_tests.rs
+++ b/src/proxy/context_tests.rs
@@ -186,6 +186,7 @@ fn context_test_app_with_preference(
             PoolConfig {
                 members: vec!["a".into(), "b".into()],
                 preferred: preferred.map(str::to_owned),
+                preserved: None,
             },
         )]),
         accounts: BTreeMap::from([

--- a/src/proxy/context_ws_tests.rs
+++ b/src/proxy/context_ws_tests.rs
@@ -310,6 +310,7 @@ async fn start_context_proxy(
             PoolConfig {
                 members: vec!["a".into(), "b".into()],
                 preferred: None,
+                preserved: None,
             },
         )]),
         accounts: BTreeMap::from([

--- a/src/proxy/http_continuity_tests.rs
+++ b/src/proxy/http_continuity_tests.rs
@@ -111,6 +111,7 @@ async fn fixture(dir: &Path, first_event: Bytes, keep_open: bool) -> ContinuityF
             PoolConfig {
                 members: vec!["a".into(), "b".into()],
                 preferred: Some("a".into()),
+                preserved: None,
             },
         )]),
         accounts,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -6694,6 +6694,7 @@ mod tests {
         let pool = PoolConfig {
             members: vec!["a".into(), "b".into()],
             preferred: None,
+            preserved: None,
         };
         let selection = router
             .select_exact(&pool, "a")
@@ -6788,6 +6789,7 @@ mod tests {
         let pool = PoolConfig {
             members: vec!["a".into(), "b".into()],
             preferred: None,
+            preserved: None,
         };
         let selection = router
             .select_exact(&pool, "a")
@@ -6895,6 +6897,7 @@ mod tests {
         let pool = PoolConfig {
             members: vec!["a".into(), "b".into()],
             preferred: None,
+            preserved: None,
         };
         let selection = router
             .select_exact(&pool, "a")
@@ -6997,6 +7000,7 @@ mod tests {
         let pool = PoolConfig {
             members: vec!["a".into(), "b".into()],
             preferred: None,
+            preserved: None,
         };
         let selection = router
             .select_exact(&pool, "a")
@@ -7173,6 +7177,7 @@ mod tests {
                     PoolConfig {
                         members: vec!["managed".into()],
                         preferred: None,
+                        preserved: None,
                     },
                 )]),
                 accounts: BTreeMap::from([(
@@ -7237,6 +7242,7 @@ mod tests {
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -7282,6 +7288,7 @@ mod tests {
                 PoolConfig {
                     members: vec!["caller".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),
@@ -8717,6 +8724,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -8888,6 +8896,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                     &PoolConfig {
                         members: vec!["caller".into()],
                         preferred: None,
+                        preserved: None,
                     },
                     None,
                     None,
@@ -8984,6 +8993,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -9277,6 +9287,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 PoolConfig {
                     members: vec!["caller".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([("caller".into(), AccountConfig::Inbound)]),
@@ -9339,6 +9350,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -9393,6 +9405,7 @@ data: {"type":"response.completed","response":{"id":"resp_compact","status":"com
                 PoolConfig {
                     members: vec!["managed".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([(

--- a/src/routing/router.rs
+++ b/src/routing/router.rs
@@ -49,6 +49,7 @@ pub enum SelectionStaleReason {
     EpochChanged,
     BindingChanged,
     PreferredSuperseded,
+    PreservedSuperseded,
 }
 
 impl std::fmt::Display for SelectionStaleReason {
@@ -63,6 +64,7 @@ impl std::fmt::Display for SelectionStaleReason {
             Self::EpochChanged => "epoch_changed",
             Self::BindingChanged => "binding_changed",
             Self::PreferredSuperseded => "preferred_superseded",
+            Self::PreservedSuperseded => "preserved_superseded",
         };
         write!(f, "{reason}")
     }
@@ -72,6 +74,8 @@ impl std::fmt::Display for SelectionStaleReason {
 pub struct RoutingSnapshot {
     #[serde(default)]
     pub preferred_accounts: BTreeMap<String, String>,
+    #[serde(default)]
+    pub preserved_accounts: BTreeMap<String, String>,
     // NOTE (fix1 display honesty): `active_accounts` is the last *fresh pick* per pool. It is
     // only updated on fresh (unbound) selections and never on bound/select_exact traffic, so it
     // must not be read as "the account carrying traffic". Use `wired_accounts` for last-wired.
@@ -208,6 +212,7 @@ pub struct Router {
     pub affinity: Arc<AffinityStore>,
     accounts: Mutex<HashMap<String, AccountRuntime>>,
     preferred: Mutex<HashMap<String, String>>,
+    preserved: Mutex<HashMap<String, String>>,
     active: Mutex<HashMap<String, String>>,
     wired: Mutex<HashMap<String, String>>,
     sequence: AtomicU64,
@@ -332,6 +337,18 @@ impl Router {
                     })
                     .collect(),
             ),
+            preserved: Mutex::new(
+                config
+                    .pools
+                    .iter()
+                    .filter_map(|(pool, config)| {
+                        config
+                            .preserved
+                            .as_ref()
+                            .map(|account| (pool.clone(), account.clone()))
+                    })
+                    .collect(),
+            ),
             active: Mutex::new(HashMap::new()),
             wired: Mutex::new(HashMap::new()),
             sequence: AtomicU64::new(1),
@@ -424,6 +441,13 @@ impl Router {
                         && a.avoid_until.is_none_or(|v| v <= now)
                 })
         };
+        let preserved = self.preserved.lock().await.get(pool_name).cloned();
+        let has_unpreserved = pool
+            .members
+            .iter()
+            .any(|id| preserved.as_ref() != Some(id) && eligible(id));
+        let eligible =
+            |id: &str| eligible(id) && (!has_unpreserved || preserved.as_deref() != Some(id));
         // Apply the soft capacity preference only after normal eligibility. An
         // unavailable sibling must never turn this preference into an empty pool.
         let has_capacity_alternative = pool
@@ -522,6 +546,20 @@ impl Router {
         self.preferred.lock().await.get(pool).cloned()
     }
 
+    /// Change the preserved account used for new work without disturbing bindings or in-flight
+    /// requests. The caller validates pool membership before invoking this method.
+    pub async fn set_preserved(&self, pool: &str, account: Option<String>) {
+        let mut preserved = self.preserved.lock().await;
+        match account {
+            Some(account) => {
+                preserved.insert(pool.to_owned(), account);
+            }
+            None => {
+                preserved.remove(pool);
+            }
+        }
+    }
+
     pub async fn routing_snapshot(&self) -> RoutingSnapshot {
         let now = Instant::now();
         let wall_now = Utc::now();
@@ -537,6 +575,13 @@ impl Router {
         RoutingSnapshot {
             preferred_accounts: self
                 .preferred
+                .lock()
+                .await
+                .iter()
+                .map(|(pool, account)| (pool.clone(), account.clone()))
+                .collect(),
+            preserved_accounts: self
+                .preserved
                 .lock()
                 .await
                 .iter()
@@ -678,6 +723,23 @@ impl Router {
         // Fresh work: a configured-preferred flip to another eligible account mid-resolve
         // supersedes this selection. Bound work ignores preference by design.
         if !selection.bound {
+            let preserved = self.preserved.lock().await.get(pool_name).cloned();
+            if preserved.as_deref() == Some(selection.account_id.as_str()) {
+                let accounts = self.account_runtimes().await;
+                let has_alternative = pool.members.iter().any(|id| {
+                    id != &selection.account_id
+                        && selection.excluded_account.as_ref() != Some(id)
+                        && accounts.get(id).is_some_and(|runtime| {
+                            !runtime.auth_unavailable()
+                                && !runtime.login_in_progress
+                                && runtime.quota_until.is_none_or(|until| until <= now)
+                                && runtime.avoid_until.is_none_or(|until| until <= now)
+                        })
+                });
+                if has_alternative {
+                    return Err(SelectionStaleReason::PreservedSuperseded);
+                }
+            }
             let configured = self.preferred.lock().await.get(pool_name).cloned();
             if let Some(preferred_id) = configured
                 && preferred_id != selection.account_id
@@ -1372,6 +1434,7 @@ mod tests {
                 PoolConfig {
                     members: vec!["a".into(), "b".into()],
                     preferred: None,
+                    preserved: None,
                 },
             )]),
             accounts: BTreeMap::from([
@@ -1379,6 +1442,139 @@ mod tests {
                 ("b".into(), AccountConfig::Inbound),
             ]),
         }
+    }
+
+    #[tokio::test]
+    async fn preserve_applies_to_fresh_work_and_pre_wire_changes_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, affinity, router, pool) = stale_test_router(dir.path());
+        let key = affinity.key("existing");
+        router
+            .select("default", &pool, Some(key.clone()), None)
+            .await
+            .unwrap();
+        let selected = router.select("default", &pool, None, None).await.unwrap();
+        router.set_preserved("default", Some("a".into())).await;
+        assert_eq!(
+            router.validate_selection(&selected, "default", &pool).await,
+            Err(SelectionStaleReason::PreservedSuperseded)
+        );
+        let bound = router
+            .select("default", &pool, Some(key), None)
+            .await
+            .unwrap();
+        assert_eq!(bound.account_id, "a");
+        assert!(bound.bound);
+        assert!(
+            router
+                .validate_selection(&bound, "default", &pool)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            router
+                .select_preferred("default", &pool, "a")
+                .await
+                .unwrap()
+                .account_id,
+            "b"
+        );
+        router.set_preserved("default", None).await;
+        assert_eq!(
+            router
+                .select_preferred("default", &pool, "a")
+                .await
+                .unwrap()
+                .account_id,
+            "a"
+        );
+        assert!(
+            router
+                .routing_snapshot()
+                .await
+                .preserved_accounts
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn preserved_account_is_last_even_when_other_accounts_have_higher_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut cfg, affinity, _, _) = stale_test_router(dir.path());
+        cfg.pools.get_mut("default").unwrap().preserved = Some("a".into());
+        cfg.pools
+            .get_mut("default")
+            .unwrap()
+            .members
+            .push("c".into());
+        cfg.accounts.insert("c".into(), AccountConfig::Inbound);
+        let router = Router::new(&cfg, affinity);
+        let pool = &cfg.pools["default"];
+        router.accounts.lock().await.get_mut("b").unwrap().usage = Some(99);
+        router.accounts.lock().await.get_mut("c").unwrap().usage = Some(98);
+        assert_eq!(
+            router
+                .select("default", pool, None, None)
+                .await
+                .unwrap()
+                .account_id,
+            "c"
+        );
+        router.reauth_required("c").await;
+        assert_eq!(
+            router
+                .select("default", pool, None, None)
+                .await
+                .unwrap()
+                .account_id,
+            "b"
+        );
+        router.quota_failure("b", &HeaderMap::new()).await;
+        let last = router.select("default", pool, None, None).await.unwrap();
+        assert_eq!(last.account_id, "a");
+        assert!(
+            router
+                .validate_selection(&last, "default", pool)
+                .await
+                .is_ok()
+        );
+        router.reauth_required("a").await;
+        assert!(router.select("default", pool, None, None).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn preserve_respects_retry_exclusions_single_account_pools_and_pool_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, _, router, mut pool) = stale_test_router(dir.path());
+        router.set_preserved("default", Some("a".into())).await;
+        let retry = router
+            .select("default", &pool, None, Some("b"))
+            .await
+            .unwrap();
+        assert_eq!(retry.account_id, "a");
+        assert!(
+            router
+                .validate_selection(&retry, "default", &pool)
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            router
+                .select_preferred("other", &pool, "a")
+                .await
+                .unwrap()
+                .account_id,
+            "a"
+        );
+        pool.members = vec!["a".into()];
+        assert_eq!(
+            router
+                .select("default", &pool, None, None)
+                .await
+                .unwrap()
+                .account_id,
+            "a"
+        );
     }
 
     #[tokio::test]
@@ -1459,6 +1655,7 @@ mod tests {
             router.routing_snapshot().await,
             RoutingSnapshot {
                 preferred_accounts: BTreeMap::from([("default".into(), "b".into())]),
+                preserved_accounts: BTreeMap::new(),
                 active_accounts: BTreeMap::from([("default".into(), "b".into())]),
                 // `wired` tracks last actually-sent traffic, not fresh picks; no wire happened here.
                 wired_accounts: BTreeMap::new(),

--- a/tests/account_preserve.rs
+++ b/tests/account_preserve.rs
@@ -1,0 +1,159 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use comradex::{config::Config, control};
+
+const SECRET: &str = "0123456789abcdef";
+
+fn cli(config: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_comradex"))
+        .arg("--config")
+        .arg(config)
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn preserve(config: &Path, args: &[&str]) {
+    let output = cli(config, &[&["account", "preserve"], args].concat());
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+struct Daemon(Child);
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn start(config: &Path, state: &Path) -> Daemon {
+    let mut daemon = Daemon(
+        Command::new(env!("CARGO_BIN_EXE_comradex"))
+            .arg("--config")
+            .arg(config)
+            .arg("serve")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap(),
+    );
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        assert!(daemon.0.try_wait().unwrap().is_none(), "test daemon exited");
+        if control::routing_status(state, SECRET).is_ok() {
+            return daemon;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "test daemon did not become ready"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn preserve_cli_persists_updates_live_and_keeps_pools_independent() {
+    // A short path also fits macOS's Unix socket path limit.
+    let dir = tempfile::tempdir_in("/tmp").unwrap();
+    let path = dir.path().join("comradex.toml");
+    let state = dir.path().join("state");
+    fs::write(
+        &path,
+        format!(
+            r#"[proxy]
+installation_secret = "{SECRET}"
+affinity_key = "0123456789abcdef0123456789abcdef"
+state_dir = "state"
+
+[listeners.default]
+address = "127.0.0.1:0"
+pool = "default"
+
+[pools.default]
+members = ["grace", "ada"]
+preferred = "ada"
+
+[pools.research]
+members = ["grace", "ada"]
+
+[accounts.grace]
+kind = "inbound"
+[accounts.ada]
+kind = "inbound"
+"#
+        ),
+    )
+    .unwrap();
+
+    preserve(&path, &["grace"]);
+    preserve(&path, &["ada", "--pool", "research"]);
+    let saved = Config::load(&path).unwrap();
+    assert_eq!(saved.pools["default"].preserved.as_deref(), Some("grace"));
+    assert_eq!(saved.pools["research"].preserved.as_deref(), Some("ada"));
+    preserve(&path, &["--clear"]);
+    assert!(
+        Config::load(&path).unwrap().pools["default"]
+            .preserved
+            .is_none()
+    );
+    assert!(cli(&path, &["check"]).status.success());
+
+    let mut daemon = start(&path, &state);
+    preserve(&path, &["grace"]);
+    let routing = control::routing_status(&state, SECRET).unwrap();
+    assert_eq!(routing.preserved_accounts["default"], "grace");
+    assert_eq!(routing.preserved_accounts["research"], "ada");
+    for args in [
+        vec!["account", "preserve", "ada"],
+        vec!["account", "preserve", "missing"],
+        vec!["account", "preserve", "grace", "--pool", "missing"],
+        vec!["account", "prefer", "grace"],
+    ] {
+        let before = fs::read(&path).unwrap();
+        assert!(!cli(&path, &args).status.success());
+        assert_eq!(fs::read(&path).unwrap(), before);
+        assert_eq!(
+            control::routing_status(&state, SECRET)
+                .unwrap()
+                .preserved_accounts,
+            routing.preserved_accounts
+        );
+    }
+    preserve(&path, &["--clear", "--pool", "research"]);
+    let routing = control::routing_status(&state, SECRET).unwrap();
+    assert_eq!(routing.preserved_accounts.len(), 1);
+    assert_eq!(routing.preserved_accounts["default"], "grace");
+    assert!(daemon.0.try_wait().unwrap().is_none());
+    drop(daemon);
+
+    let _restarted = start(&path, &state);
+    assert_eq!(
+        control::routing_status(&state, SECRET)
+            .unwrap()
+            .preserved_accounts,
+        routing.preserved_accounts
+    );
+    preserve(&path, &["--clear"]);
+    assert!(
+        control::routing_status(&state, SECRET)
+            .unwrap()
+            .preserved_accounts
+            .is_empty()
+    );
+    assert!(
+        Config::load(&path).unwrap().pools["default"]
+            .preserved
+            .is_none()
+    );
+}


### PR DESCRIPTION
Hey @nicosuave, extremely cool project!

In my usage, I have a "primary" account that I want to preserve to be used last (because I tend to use the actual ChatGPT web and cloud work features a fair amount so want to make sure they run down last).

To that effect, I've put this together!

---

Add `comradex account preserve` so an account can remain available as a last resort while other eligible pool members handle new work.

```sh
comradex account preserve <name>
comradex account preserve <name> --pool <pool>
comradex account preserve --clear
```

Preservation applies to fresh, unbound work, including when alternatives are above the normal rotation threshold. The preserved account remains eligible when alternatives are unavailable or excluded from a retry. Existing sticky conversations retain their account bindings.

The command persists `preserved` in the pool configuration and updates a running daemon through the authenticated control socket without restarting it. With the daemon stopped, the setting applies at its next start. Status and routing snapshots expose preservation. Validation rejects non-member accounts and using the same account as both preferred and preserved; removing an account clears its preservation reference.

## Automated verification

Validated against upstream 0.11.4 (`9f2387d`):

- `cargo test --locked`: 384 library tests and 17 CLI unit tests passed.
- `cargo test --locked --test account_preserve`: the newly added process-level CLI regression passed, bringing the total to 402 passing tests.
- `cargo clippy --all-targets --locked -- -D warnings`: passed, including the new integration test.
- `cargo fmt --all -- --check`, `git diff --check`, and `git diff --cached --check`: passed.

Routing tests cover last-resort selection despite higher usage on other accounts, unavailable alternatives, retry exclusions, single-account pools, pool scope, sticky bindings, and preservation changes between selection and dispatch. Control tests cover authentication, persistence, and rejected changes. The process-level regression exercises the real CLI against stopped and running daemons, independent pools, invalid changes, and restart persistence.

## Manual verification

1. Copied an existing four-account configuration into a temporary directory, retaining its pool membership and preference.
2. Assigned a separate state directory, fresh secrets, and ephemeral loopback listeners; replaced managed accounts with inbound test accounts and disabled weekly activation to avoid credential access or backend calls.
3. Ran all three command forms with `target/debug/comradex --config <isolated-config>`, inspected persisted settings, and ran `check`.
4. Started a separate daemon and verified live set/clear through its control socket and `status`, including clearing a second pool without changing the default pool.
5. Verified unknown-account and preferred/preserved-conflict requests failed without changing the copied configuration.
6. Restarted only the test daemon, verified preservation survived, and cleared it live.
7. Removed the temporary environment and confirmed the original config bytes and production daemon PID/start time were unchanged.

All manual checks passed. The explicitly opt-in live-backend reasoning test remained ignored; no real inference traffic was used. The installed service was not upgraded or restarted. Fork CI had no runs at submission preparation; the results above are local verification.
